### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+pnpm monorepo with four packages: `dbt-artifacts-parser` (core parser library), `@dbt-tools/core`, `@dbt-tools/cli`, and `@dbt-tools/web` (React/Vite). No external services or databases required.
+
+### Node.js
+
+Node.js version is pinned in `.node-version` (currently 22.10.0). The environment uses nvm; the update script activates the correct version automatically.
+
+### Key commands
+
+All commands run from the repo root. See `package.json` `scripts` for full list.
+
+| Task | Command |
+|---|---|
+| Install deps | `pnpm install --frozen-lockfile` |
+| Build all | `pnpm build` |
+| Unit tests | `pnpm test` |
+| Test + coverage | `pnpm test:coverage` |
+| Lint (ESLint) | `pnpm lint:eslint` |
+| Lint report | `pnpm lint:report` (must exit 0) |
+| Coverage report | `pnpm coverage:report` (must exit 0) |
+| Web dev server | `pnpm dev:web` (localhost:5173) |
+| E2E tests | `pnpm test:e2e` (needs Playwright + Chromium) |
+| CLI | `node packages/dbt-tools/cli/dist/cli.js` (build first) |
+
+### Non-obvious caveats
+
+- **esbuild build script warning**: `pnpm install` may warn about ignored build scripts for `esbuild`. This is safe to ignore; esbuild still works because it ships prebuilt binaries for the platform.
+- **Web dev server with artifacts**: To pre-load dbt artifacts, start with `DBT_TARGET=/path/to/target pnpm dev:web`. Without `DBT_TARGET`, the app shows an upload UI. Sample artifacts live under `packages/dbt-artifacts-parser/resources/`.
+- **Trunk CLI**: `pnpm lint` and `pnpm format` require the Trunk CLI. For CI/agent lint checks, use `pnpm lint:eslint` and `pnpm lint:report` instead.
+- **Build before CLI**: The CLI requires `pnpm build` first since it runs from `dist/`.
+- **Coverage thresholds**: lines 60%, branches 50%, functions 60%, statements 60%. See `vitest.config.mjs`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents, covering:

- Project overview (pnpm monorepo with 4 packages, no external services)
- Node.js version management (nvm, `.node-version`)
- Key commands table (build, test, lint, dev server, CLI)
- Non-obvious caveats (esbuild warnings, `DBT_TARGET` for web dev, Trunk CLI vs ESLint, build-before-CLI, coverage thresholds)

## Environment Setup Verified

| Check | Command | Result |
|---|---|---|
| Build | `pnpm build` | All 4 packages built successfully |
| Lint | `pnpm lint:eslint` | Clean (0 errors, 0 warnings) |
| Lint report | `pnpm lint:report` | Score 100, exit 0 |
| Tests | `pnpm test` | 193 test files, 1562 tests passed |
| Coverage report | `pnpm coverage:report` | Score 73, belowThreshold=false, exit 0 |
| Web dev server | `pnpm dev:web` | Running on localhost:5173 |
| CLI | `dbt-tools summary` | Successfully analyzed jaffle_shop manifest |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac5cbb94-2db3-4c6c-a6d3-44ef9be8ca2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac5cbb94-2db3-4c6c-a6d3-44ef9be8ca2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

