### PR TITLE
feat(timeline): default-hide tests and add time-range brush for scalable navigation

### DIFF
--- a/docs/adr/0026-default-hidden-tests-and-time-range-brush-for-timeline.md
+++ b/docs/adr/0026-default-hidden-tests-and-time-range-brush-for-timeline.md
@@ -1,0 +1,108 @@
+# 26. Default-hidden tests and time-range brush for scalable timeline performance
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+The execution timeline view renders dbt models, seeds, snapshots, and — optionally — their attached test chips, all on a shared canvas with TanStack Virtual for vertical scrolling.
+
+Two compounding scalability problems emerged as adoption of the tool grew to real-world projects:
+
+### 1. Test-chip overhead on large projects
+
+The lane-assignment algorithm (`assignLanes()`) runs for every bundle row at render time. With tens of thousands of tests — common in mature analytics projects that use schema tests on every column — the initial layout and canvas-draw pass is measurably slow, even with virtualisation. The marginal value of showing tests by default is low: most users open the timeline to inspect model parallelism and bottlenecks, not individual test timing.
+
+### 2. Compressed horizontal space in long runs
+
+When a dbt run spans hours (e.g. a full overnight refresh of a large warehouse), the entire timeline must fit within the canvas width (≈ 800–1400 px). Every bar becomes sub-pixel wide, which makes it impossible to distinguish models that ran in the same minute, let alone to correlate timing across related nodes.
+
+There was no mechanism to zoom into a specific time window.
+
+## Decision
+
+### Part A — Default `showTests: false`
+
+Change the initial value of `showTests` in `TimelineFilterState` from `true` to `false`. The "Tests" toggle in the legend remains available; users who want to inspect test timing can opt in with one click.
+
+The change touches four locations:
+
+| File | Change |
+|------|--------|
+| `src/App.tsx` | `showTests: false` in initial state |
+| `src/lib/analysis-workspace/types.ts` | JSDoc updated to "Default false for performance" |
+| `gantt/GanttChart.tsx` | Default prop `showTests = false` |
+| `gantt/canvasDraw.ts` | Default destructure `showTests = false` |
+
+### Part B — Time-range brush for horizontal zoom
+
+Introduce a `timeWindow: TimeWindow | null` field to `TimelineFilterState`:
+
+```typescript
+export interface TimeWindow {
+  start: number; // ms relative to time-origin 0 (same as GanttItem.start)
+  end: number;
+}
+```
+
+When `timeWindow` is set, the main chart:
+
+1. **Filters bundles** to those whose items overlap `[start, end]`.
+2. **Rescales the X-axis** using `minTime = timeWindow.start` and `maxEnd = timeWindow.end - timeWindow.start`.
+
+The rescaling formula in `canvasDraw.ts`, `hitTest.ts`, `edgeGeometry.ts`, and `GanttEdgeLayer.tsx` changes from:
+
+```
+x = labelW + (item.start / maxEnd) * chartW
+```
+
+to:
+
+```
+x = labelW + ((item.start - minTime) / maxEnd) * chartW
+```
+
+where `maxEnd` is now the *visible span* rather than the absolute run duration. A `minTime = 0` default preserves existing behaviour for all callers that don't pass the parameter.
+
+#### New component: `TimeRangeBrush`
+
+A 48 px canvas strip rendered above the main `GanttChartFrame`. It shows a compressed minimap of all bundle items (coloured by resource type) and implements a drag-to-select interaction:
+
+- **New drag** (outside existing selection): draws a selection rectangle; on `mouseup`, commits `onChange({ start, end })` if the span exceeds `MIN_SPAN_RATIO * maxEnd`.
+- **Resize handles**: 6 px wide handles on each edge allow adjusting an existing selection via `ew-resize` cursor.
+- **Click inside** (no movement): clears the selection via `onChange(null)`.
+- **Escape key**: clears the selection.
+
+Window-level `mousemove` / `mouseup` listeners ensure drags that leave the canvas area complete correctly.
+
+The brush receives `allBundles` (computed from `allData`, the unfiltered parent items) so the minimap always shows the full picture even when type/status filters are active in the main chart.
+
+#### Clear-zoom badge
+
+When `timeWindow != null`, a `<p class="timeline-zoom-active">` element appears above the chart showing the zoomed span and a "Clear zoom ×" button.
+
+## Consequences
+
+**Positive:**
+
+- Initial timeline render on large projects is significantly faster — no lane-assignment or chip-draw for hidden tests.
+- Users can zoom into any sub-second window of a multi-hour run without losing context (minimap always shows the full execution).
+- The `minTime` offset is additive and defaults to `0`, so no existing tests or callers break.
+
+**Negative:**
+
+- Users who relied on tests being visible by default must now click the legend toggle once. This is a deliberate UX trade-off: the legend button is prominently placed and self-describing.
+- The `minTime` parameter was added to several internal interfaces (`DrawGanttParams`, `DrawRowBarParams`, `DrawTestChipParams`, `DrawGanttAxisTicksParams`, `DrawGanttVisibleRowParams`, `FocusEdgePathParams`, `GanttPointerContext`, `UseGanttCanvasDrawParams`, `GanttChartFrame` props, `GanttEdgeLayer` props). While the default keeps existing callers working, it increases the surface area of these internal APIs.
+- The `TimeRangeBrush` component introduces a second `ResizeObserver` and canvas per timeline view. For typical viewport sizes this is negligible.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| Keep `showTests: true`, only optimise the algorithm | The lane-assignment is already greedy O(n·k); reducing per-test draw calls requires significant refactoring with uncertain payoff. A default toggle is simpler and reversible. |
+| Mouse-wheel horizontal zoom (no brush) | Requires scroll-event capture on the chart, conflicting with vertical scroll. The brush's explicit drag UX is more predictable. |
+| Preset time-range buttons (first 10%, last 25%, …) | Inflexible; doesn't let users zoom to a specific failure cluster. |
+| Progressive/virtual time buckets | Overkill for a client-side only tool; adds build-time complexity without clear benefit given existing virtualisation. |

--- a/docs/adr/0026-default-hidden-tests-and-time-range-brush-for-timeline.md
+++ b/docs/adr/0026-default-hidden-tests-and-time-range-brush-for-timeline.md
@@ -55,13 +55,13 @@ When `timeWindow` is set, the main chart:
 
 The rescaling formula in `canvasDraw.ts`, `hitTest.ts`, `edgeGeometry.ts`, and `GanttEdgeLayer.tsx` changes from:
 
-```
+```text
 x = labelW + (item.start / maxEnd) * chartW
 ```
 
 to:
 
-```
+```text
 x = labelW + ((item.start - minTime) / maxEnd) * chartW
 ```
 

--- a/docs/adr/0026-default-hidden-tests-and-time-range-brush-for-timeline.md
+++ b/docs/adr/0026-default-hidden-tests-and-time-range-brush-for-timeline.md
@@ -30,12 +30,12 @@ Change the initial value of `showTests` in `TimelineFilterState` from `true` to 
 
 The change touches four locations:
 
-| File | Change |
-|------|--------|
-| `src/App.tsx` | `showTests: false` in initial state |
+| File                                  | Change                                           |
+| ------------------------------------- | ------------------------------------------------ |
+| `src/App.tsx`                         | `showTests: false` in initial state              |
 | `src/lib/analysis-workspace/types.ts` | JSDoc updated to "Default false for performance" |
-| `gantt/GanttChart.tsx` | Default prop `showTests = false` |
-| `gantt/canvasDraw.ts` | Default destructure `showTests = false` |
+| `gantt/GanttChart.tsx`                | Default prop `showTests = false`                 |
+| `gantt/canvasDraw.ts`                 | Default destructure `showTests = false`          |
 
 ### Part B — Time-range brush for horizontal zoom
 
@@ -65,7 +65,7 @@ to:
 x = labelW + ((item.start - minTime) / maxEnd) * chartW
 ```
 
-where `maxEnd` is now the *visible span* rather than the absolute run duration. A `minTime = 0` default preserves existing behaviour for all callers that don't pass the parameter.
+where `maxEnd` is now the _visible span_ rather than the absolute run duration. A `minTime = 0` default preserves existing behaviour for all callers that don't pass the parameter.
 
 #### New component: `TimeRangeBrush`
 
@@ -100,9 +100,9 @@ When `timeWindow != null`, a `<p class="timeline-zoom-active">` element appears 
 
 ## Alternatives considered
 
-| Alternative | Why rejected |
-|---|---|
+| Alternative                                         | Why rejected                                                                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Keep `showTests: true`, only optimise the algorithm | The lane-assignment is already greedy O(n·k); reducing per-test draw calls requires significant refactoring with uncertain payoff. A default toggle is simpler and reversible. |
-| Mouse-wheel horizontal zoom (no brush) | Requires scroll-event capture on the chart, conflicting with vertical scroll. The brush's explicit drag UX is more predictable. |
-| Preset time-range buttons (first 10%, last 25%, …) | Inflexible; doesn't let users zoom to a specific failure cluster. |
-| Progressive/virtual time buckets | Overkill for a client-side only tool; adds build-time complexity without clear benefit given existing virtualisation. |
+| Mouse-wheel horizontal zoom (no brush)              | Requires scroll-event capture on the chart, conflicting with vertical scroll. The brush's explicit drag UX is more predictable.                                                |
+| Preset time-range buttons (first 10%, last 25%, …)  | Inflexible; doesn't let users zoom to a specific failure cluster.                                                                                                              |
+| Progressive/virtual time buckets                    | Overkill for a client-side only tool; adds build-time complexity without clear benefit given existing virtualisation.                                                          |

--- a/packages/dbt-tools/web/src/App.tsx
+++ b/packages/dbt-tools/web/src/App.tsx
@@ -72,10 +72,11 @@ function AppContent() {
         activeStatuses: new Set(),
         activeTypes: new Set(),
         selectedExecutionId: selected,
-        showTests: true,
+        showTests: false,
         failuresOnly: false,
         dependencyDirection: "both",
         dependencyDepthHops: 2,
+        timeWindow: null,
       };
     },
   );

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
@@ -8,7 +8,7 @@ import { GanttChart } from "./GanttChart";
 import { GanttLegend } from "./GanttLegend";
 import { TimelineDependencyControls } from "./TimelineDependencyControls";
 import { TIMELINE_BUNDLE_COUNT_WARNING } from "./gantt/constants";
-import { isPositiveStatus } from "./gantt/formatting";
+import { formatMs, isPositiveStatus } from "./gantt/formatting";
 import type { AnalysisState, GanttItem } from "@web/types";
 import type {
   InvestigationSelectionState,
@@ -49,6 +49,7 @@ function TimelineSurface({
   filters,
   effectiveActiveTypes,
   filteredData,
+  allGanttData,
   bundleRowCount,
   statusCounts,
   typeCounts,
@@ -64,6 +65,8 @@ function TimelineSurface({
   filters: TimelineFilterState;
   effectiveActiveTypes: Set<string>;
   filteredData: GanttItem[];
+  /** All gantt items (pre-filter) for the time-range brush minimap. */
+  allGanttData: GanttItem[];
   bundleRowCount: number;
   statusCounts: Record<string, number>;
   typeCounts: Record<string, number>;
@@ -94,6 +97,8 @@ function TimelineSurface({
     [analysis.ganttData],
   );
 
+  const { timeWindow } = filters;
+
   return (
     <SectionCard
       title="Execution timeline"
@@ -123,6 +128,19 @@ function TimelineSurface({
         typeFilterHint={typeFilterHint}
         setFilters={setFilters}
       />
+      {timeWindow != null && (
+        <p className="timeline-zoom-active" role="status">
+          Zoomed to {formatMs(timeWindow.end - timeWindow.start)} window
+          {" — "}
+          <button
+            type="button"
+            className="timeline-zoom-clear"
+            onClick={() => setFilters((c) => ({ ...c, timeWindow: null }))}
+          >
+            Clear zoom ×
+          </button>
+        </p>
+      )}
       {bundleRowCount >= TIMELINE_BUNDLE_COUNT_WARNING ? (
         <p className="timeline-large-dataset-hint" role="status">
           Showing {bundleRowCount.toLocaleString()} timeline rows. Use search or
@@ -131,6 +149,7 @@ function TimelineSurface({
       ) : null}
       <GanttChart
         data={filteredData}
+        allData={allGanttData}
         runStartedAt={analysis.runStartedAt}
         timelineAdjacency={analysis.timelineAdjacency}
         testStatsById={testStatsById}
@@ -138,6 +157,10 @@ function TimelineSurface({
         dependencyDirection={filters.dependencyDirection}
         dependencyDepthHops={filters.dependencyDepthHops}
         selectedId={filters.selectedExecutionId}
+        timeWindow={timeWindow}
+        onTimeWindowChange={(tw) =>
+          setFilters((c) => ({ ...c, timeWindow: tw }))
+        }
         onSelect={(id) => {
           setFilters((current) => ({ ...current, selectedExecutionId: id }));
           onInvestigationSelectionChange((current) => ({
@@ -370,6 +393,7 @@ export function TimelineView({
         filters={filters}
         effectiveActiveTypes={effectiveActiveTypes}
         filteredData={filteredData}
+        allGanttData={analysis.ganttData}
         bundleRowCount={filteredParents.length}
         statusCounts={statusCounts}
         typeCounts={typeCounts}

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/GanttChart.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/GanttChart.tsx
@@ -1,7 +1,10 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useSyncedDocumentTheme } from "@web/hooks/useTheme";
-import type { TimelineDependencyDirection } from "@web/lib/analysis-workspace/types";
+import type {
+  TimelineDependencyDirection,
+  TimeWindow,
+} from "@web/lib/analysis-workspace/types";
 import type {
   GanttItem,
   ResourceTestStats,
@@ -21,6 +24,7 @@ import {
 import { getAvailableTimeZones, getInitialTimeZone } from "./formatting";
 import { GanttChartFrame } from "./GanttChartFrame";
 import { GanttModeToggle } from "./GanttModeToggle";
+import { TimeRangeBrush } from "./TimeRangeBrush";
 import { bundleRowHeight, computeRowLayout } from "./ganttChartHelpers";
 import { applyGanttPointerInteraction } from "./ganttPointerInteraction";
 import type { BundleLayout, HoverState } from "./hitTest";
@@ -31,29 +35,37 @@ export { getFailureBundleIds } from "./ganttChartHelpers";
 
 export interface GanttChartProps {
   data: GanttItem[];
+  /** All items before time-window filtering — used by the minimap brush. */
+  allData?: GanttItem[];
   /** Absolute epoch-ms of the earliest executed node — enables wall-clock timestamps. */
   runStartedAt?: number | null;
   /** Immediate manifest neighbors for executed timeline nodes (from analyze). */
   timelineAdjacency?: Record<string, TimelineAdjacencyEntry>;
   testStatsById?: Map<string, ResourceTestStats>;
-  /** Whether to show test chips inside bundle rows. Default: true. */
+  /** Whether to show test chips inside bundle rows. Default: false. */
   showTests?: boolean;
   dependencyDirection?: TimelineDependencyDirection;
   dependencyDepthHops?: number;
   selectedId?: string | null;
   onSelect?: (id: string | null) => void;
+  /** Active time-range zoom window. null = full timeline. */
+  timeWindow?: TimeWindow | null;
+  onTimeWindowChange?: (tw: TimeWindow | null) => void;
 }
 
 export function GanttChart({
   data,
+  allData,
   runStartedAt,
   timelineAdjacency,
   testStatsById,
-  showTests = true,
+  showTests = false,
   dependencyDirection = "both",
   dependencyDepthHops = 2,
   selectedId = null,
   onSelect,
+  timeWindow = null,
+  onTimeWindowChange,
 }: GanttChartProps) {
   const theme = useSyncedDocumentTheme();
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -83,7 +95,37 @@ export function GanttChart({
       ? Math.max(80, Math.min(LABEL_W, Math.round(containerWidth * 0.35)))
       : LABEL_W;
 
-  const bundles = useMemo(() => groupIntoBundles(data), [data]);
+  // All bundles (unfiltered by time window) — used by the minimap brush.
+  const allBundles = useMemo(
+    () => groupIntoBundles(allData ?? data),
+    [allData, data],
+  );
+
+  // Absolute max end across all data (used as the brush's total span).
+  const absoluteMaxEnd = useMemo(() => {
+    let m = 1;
+    for (const b of allBundles) {
+      m = Math.max(m, b.item.end);
+      for (const t of b.tests) m = Math.max(m, t.end);
+    }
+    return m;
+  }, [allBundles]);
+
+  // When a time window is active, show only bundles that overlap it.
+  const bundles = useMemo(() => {
+    if (!timeWindow) return groupIntoBundles(data);
+    const { start, end } = timeWindow;
+    return groupIntoBundles(
+      data.filter((item) => item.end > start && item.start < end),
+    );
+  }, [data, timeWindow]);
+
+  // Derived zoom parameters for canvas rendering and hit-testing.
+  const minTime = timeWindow?.start ?? 0;
+  const maxEnd = timeWindow
+    ? timeWindow.end - timeWindow.start
+    : absoluteMaxEnd;
+
   const { rowOffsets, rowHeights } = useMemo(
     () => computeRowLayout(bundles, showTests),
     [bundles, showTests],
@@ -126,15 +168,6 @@ export function GanttChart({
       for (const test of bundle.tests) map.set(test.unique_id, i);
     }
     return map;
-  }, [bundles]);
-
-  const maxEnd = useMemo(() => {
-    let m = 1;
-    for (const b of bundles) {
-      m = Math.max(m, b.item.end);
-      for (const t of b.tests) m = Math.max(m, t.end);
-    }
-    return m;
   }, [bundles]);
 
   /** Selection wins over hover for which dependency edges are shown. */
@@ -186,6 +219,7 @@ export function GanttChart({
     rowOffsets,
     rowHeights,
     scrollTop,
+    minTime,
     maxEnd,
     activeMode,
     runStartedAt,
@@ -199,7 +233,7 @@ export function GanttChart({
     setContainerWidth,
   });
 
-  if (bundles.length === 0) {
+  if (allBundles.length === 0) {
     return (
       <div className="empty-state empty-state--chart">
         No Gantt data (run_results may lack timing info)
@@ -215,6 +249,7 @@ export function GanttChart({
       bundles,
       layout,
       scrollTop,
+      minTime,
       maxEnd,
       effectiveLabelW,
       canvas: canvasRef.current,
@@ -235,6 +270,17 @@ export function GanttChart({
         />
       )}
 
+      {absoluteMaxEnd > 1 && onTimeWindowChange != null && (
+        <TimeRangeBrush
+          bundles={allBundles}
+          maxEnd={absoluteMaxEnd}
+          labelW={effectiveLabelW}
+          timeWindow={timeWindow}
+          onChange={onTimeWindowChange}
+          theme={theme}
+        />
+      )}
+
       <GanttChartFrame
         canvasRef={canvasRef}
         scrollRef={scrollRef}
@@ -246,6 +292,7 @@ export function GanttChart({
         rowOffsets={rowOffsets}
         containerWidth={containerWidth}
         effectiveLabelW={effectiveLabelW}
+        minTime={minTime}
         maxEnd={maxEnd}
         scrollTop={scrollTop}
         viewportH={viewportH}

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/GanttChartFrame.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/GanttChartFrame.tsx
@@ -18,6 +18,7 @@ export function GanttChartFrame({
   rowOffsets,
   containerWidth,
   effectiveLabelW,
+  minTime,
   maxEnd,
   scrollTop,
   viewportH,
@@ -46,6 +47,7 @@ export function GanttChartFrame({
   rowOffsets: number[];
   containerWidth: number;
   effectiveLabelW: number;
+  minTime: number;
   maxEnd: number;
   scrollTop: number;
   viewportH: number;
@@ -91,6 +93,7 @@ export function GanttChartFrame({
         rowOffsets={rowOffsets}
         canvasWidth={containerWidth > 0 ? containerWidth : 600}
         effectiveLabelW={effectiveLabelW}
+        minTime={minTime}
         maxEnd={maxEnd}
         scrollTop={scrollTop}
         viewportH={viewportH}

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/GanttEdgeLayer.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/GanttEdgeLayer.tsx
@@ -93,6 +93,7 @@ export function GanttEdgeLayer({
   rowOffsets,
   canvasWidth,
   effectiveLabelW,
+  minTime = 0,
   maxEnd,
   scrollTop,
   viewportH,
@@ -107,6 +108,7 @@ export function GanttEdgeLayer({
   rowOffsets: number[];
   canvasWidth: number;
   effectiveLabelW: number;
+  minTime?: number;
   maxEnd: number;
   scrollTop: number;
   viewportH: number;
@@ -151,6 +153,7 @@ export function GanttEdgeLayer({
           scrollTop,
           showTests,
           effectiveLabelW,
+          minTime,
           maxEnd,
           chartW: approxChartW,
         });

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
@@ -1,0 +1,444 @@
+/**
+ * TimeRangeBrush — compact minimap + drag-to-zoom strip above the main Gantt.
+ *
+ * Renders a thin canvas overview of all timeline bundles. The user can:
+ *   • Drag to draw a selection rectangle → zooms the main chart to that window.
+ *   • Drag the left or right resize handle to adjust an existing selection.
+ *   • Click inside the selection (without moving) → clears the selection.
+ *   • Press Escape → clears the selection.
+ *
+ * The component is intentionally self-contained: all pointer tracking is done
+ * on the window so drags that escape the canvas border are handled correctly.
+ */
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+} from "react";
+import type { BundleRow } from "@web/lib/analysis-workspace/bundleLayout";
+import type { ThemeMode } from "@web/constants/themeColors";
+import {
+  getCanvasColors,
+  getResourceTypeSoftFill,
+} from "@web/constants/themeColors";
+import type { TimeWindow } from "@web/lib/analysis-workspace/types";
+import { X_PAD } from "./constants";
+
+// ---------------------------------------------------------------------------
+// Layout constants
+// ---------------------------------------------------------------------------
+
+/** Total height of the brush strip in CSS pixels. */
+const BRUSH_H = 48;
+/** Vertical margin above/below the minimap bars inside the strip. */
+const BAR_MARGIN = 10;
+/** Height of each minimap bar. */
+const BAR_H = BRUSH_H - BAR_MARGIN * 2;
+/** Width of the drag handles on each edge of the selection. */
+const HANDLE_W = 6;
+/** Minimum visible selection span as a fraction of maxEnd. */
+const MIN_SPAN_RATIO = 0.002;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** Convert a pixel X offset (relative to the canvas) to a time value in ms. */
+function xToTime(
+  x: number,
+  labelW: number,
+  chartW: number,
+  maxEnd: number,
+): number {
+  const frac = (x - labelW) / chartW;
+  return clamp(frac * maxEnd, 0, maxEnd);
+}
+
+/** Convert a time value in ms to a pixel X offset within the canvas. */
+function timeToX(
+  time: number,
+  labelW: number,
+  chartW: number,
+  maxEnd: number,
+): number {
+  return labelW + (time / maxEnd) * chartW;
+}
+
+// ---------------------------------------------------------------------------
+// Canvas draw
+// ---------------------------------------------------------------------------
+
+function drawBrush(
+  canvas: HTMLCanvasElement,
+  bundles: BundleRow[],
+  maxEnd: number,
+  labelW: number,
+  timeWindow: TimeWindow | null,
+  theme: ThemeMode,
+  dragState: DragState | null,
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  const w = rect.width;
+  const h = rect.height;
+  if (w === 0 || h === 0) return;
+  canvas.width = w * dpr;
+  canvas.height = h * dpr;
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, w, h);
+
+  const palette = getCanvasColors(theme);
+  const chartW = w - labelW - X_PAD;
+
+  // Background
+  ctx.fillStyle = palette.rowStripe;
+  ctx.globalAlpha = 0.4;
+  ctx.fillRect(labelW, 0, chartW + X_PAD, h);
+  ctx.globalAlpha = 1;
+
+  // Label zone text
+  ctx.font = '10px "IBM Plex Sans", "Avenir Next", sans-serif';
+  ctx.fillStyle = palette.axisTick;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("Zoom", labelW / 2, h / 2);
+
+  // Minimap bars (all bundles, very compact)
+  for (const bundle of bundles) {
+    const item = bundle.item;
+    if (item.end <= 0 || maxEnd <= 0) continue;
+    const bx = timeToX(item.start, labelW, chartW, maxEnd);
+    const bw = Math.max(1, (item.duration / maxEnd) * chartW);
+    ctx.fillStyle = getResourceTypeSoftFill(item.resourceType, theme);
+    ctx.globalAlpha = 0.7;
+    ctx.fillRect(bx, BAR_MARGIN, bw, BAR_H);
+    ctx.globalAlpha = 1;
+  }
+
+  // Determine the active selection (committed window or live drag)
+  let selStart: number | null = null;
+  let selEnd: number | null = null;
+
+  if (dragState && dragState.kind !== "idle") {
+    if (
+      dragState.kind === "new" ||
+      dragState.kind === "resize-left" ||
+      dragState.kind === "resize-right"
+    ) {
+      selStart = dragState.selStart;
+      selEnd = dragState.selEnd;
+    }
+  } else if (timeWindow) {
+    selStart = timeWindow.start;
+    selEnd = timeWindow.end;
+  }
+
+  if (selStart != null && selEnd != null && selEnd > selStart) {
+    const sx = timeToX(selStart, labelW, chartW, maxEnd);
+    const ex = timeToX(selEnd, labelW, chartW, maxEnd);
+    const sw = ex - sx;
+
+    // Dim the unselected regions
+    ctx.fillStyle =
+      theme === "dark" ? "rgba(0,0,0,0.55)" : "rgba(255,255,255,0.55)";
+    ctx.fillRect(labelW, 0, sx - labelW, h);
+    ctx.fillRect(ex, 0, w - ex, h);
+
+    // Selection outline
+    ctx.strokeStyle = palette.barHoverStroke;
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(sx, 1, sw, h - 2);
+
+    // Resize handles
+    const handleColor =
+      theme === "dark" ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.5)";
+    ctx.fillStyle = handleColor;
+    ctx.fillRect(sx, (h - 16) / 2, HANDLE_W, 16);
+    ctx.fillRect(ex - HANDLE_W, (h - 16) / 2, HANDLE_W, 16);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Drag state machine
+// ---------------------------------------------------------------------------
+
+type DragState =
+  | { kind: "idle" }
+  | {
+      kind: "new";
+      originX: number; // canvas px where drag started
+      selStart: number; // ms
+      selEnd: number; // ms
+    }
+  | {
+      kind: "resize-left";
+      selStart: number;
+      selEnd: number;
+    }
+  | {
+      kind: "resize-right";
+      selStart: number;
+      selEnd: number;
+    };
+
+function hitHandle(
+  mouseX: number,
+  timeWindow: TimeWindow | null,
+  labelW: number,
+  chartW: number,
+  maxEnd: number,
+): "left" | "right" | "inside" | "outside" {
+  if (!timeWindow) return "outside";
+  const sx = timeToX(timeWindow.start, labelW, chartW, maxEnd);
+  const ex = timeToX(timeWindow.end, labelW, chartW, maxEnd);
+
+  if (mouseX >= sx && mouseX <= sx + HANDLE_W) return "left";
+  if (mouseX >= ex - HANDLE_W && mouseX <= ex) return "right";
+  if (mouseX > sx && mouseX < ex) return "inside";
+  return "outside";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface TimeRangeBrushProps {
+  bundles: BundleRow[];
+  maxEnd: number;
+  labelW: number;
+  timeWindow: TimeWindow | null;
+  onChange: (tw: TimeWindow | null) => void;
+  theme?: ThemeMode;
+}
+
+export function TimeRangeBrush({
+  bundles,
+  maxEnd,
+  labelW,
+  timeWindow,
+  onChange,
+  theme = "light",
+}: TimeRangeBrushProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dragRef = useRef<DragState>({ kind: "idle" });
+
+  // Redraw whenever relevant props change.
+  const redraw = useCallback(
+    (drag: DragState) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const chartW =
+        canvas.getBoundingClientRect().width - labelW - X_PAD;
+      if (chartW <= 0) return;
+      drawBrush(canvas, bundles, maxEnd, labelW, timeWindow, theme, drag);
+    },
+    [bundles, labelW, maxEnd, theme, timeWindow],
+  );
+
+  useEffect(() => {
+    redraw(dragRef.current);
+  }, [redraw]);
+
+  // ResizeObserver to handle container width changes.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ro = new ResizeObserver(() => redraw(dragRef.current));
+    ro.observe(canvas);
+    return () => ro.disconnect();
+  }, [redraw]);
+
+  // -------------------------------------------------------------------------
+  // Pointer interaction
+  // -------------------------------------------------------------------------
+
+  const getChartW = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return 0;
+    return canvas.getBoundingClientRect().width - labelW - X_PAD;
+  };
+
+  const getCanvasX = (clientX: number) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return 0;
+    return clientX - canvas.getBoundingClientRect().left;
+  };
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (e.button !== 0) return;
+    const chartW = getChartW();
+    if (chartW <= 0) return;
+    const x = getCanvasX(e.clientX);
+    const zone = hitHandle(x, timeWindow, labelW, chartW, maxEnd);
+
+    if (zone === "inside") {
+      // Click-to-clear starts here; confirmed on mouseup without movement.
+      dragRef.current = {
+        kind: "new",
+        originX: x,
+        selStart: timeWindow!.start,
+        selEnd: timeWindow!.end,
+      };
+    } else if (zone === "left") {
+      dragRef.current = {
+        kind: "resize-left",
+        selStart: timeWindow!.start,
+        selEnd: timeWindow!.end,
+      };
+    } else if (zone === "right") {
+      dragRef.current = {
+        kind: "resize-right",
+        selStart: timeWindow!.start,
+        selEnd: timeWindow!.end,
+      };
+    } else {
+      // New drag outside any selection.
+      const t = xToTime(x, labelW, chartW, maxEnd);
+      dragRef.current = {
+        kind: "new",
+        originX: x,
+        selStart: t,
+        selEnd: t,
+      };
+    }
+    redraw(dragRef.current);
+  };
+
+  // Window-level mousemove so drags outside the canvas work.
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      const drag = dragRef.current;
+      if (drag.kind === "idle") return;
+      const chartW = getChartW();
+      if (chartW <= 0) return;
+      const x = getCanvasX(e.clientX);
+      const minSpan = maxEnd * MIN_SPAN_RATIO;
+
+      if (drag.kind === "new") {
+        const origin = drag.originX;
+        const t = xToTime(x, labelW, chartW, maxEnd);
+        const originT = xToTime(origin, labelW, chartW, maxEnd);
+        dragRef.current = {
+          ...drag,
+          selStart: Math.min(t, originT),
+          selEnd: Math.max(t, originT),
+        };
+      } else if (drag.kind === "resize-left") {
+        const t = xToTime(x, labelW, chartW, maxEnd);
+        dragRef.current = {
+          ...drag,
+          selStart: clamp(t, 0, drag.selEnd - minSpan),
+        };
+      } else if (drag.kind === "resize-right") {
+        const t = xToTime(x, labelW, chartW, maxEnd);
+        dragRef.current = {
+          ...drag,
+          selEnd: clamp(t, drag.selStart + minSpan, maxEnd),
+        };
+      }
+      redraw(dragRef.current);
+    };
+
+    const onUp = (e: MouseEvent) => {
+      const drag = dragRef.current;
+      if (drag.kind === "idle") return;
+      const chartW = getChartW();
+      if (chartW <= 0) return;
+      const x = getCanvasX(e.clientX);
+      const minSpan = maxEnd * MIN_SPAN_RATIO;
+
+      if (drag.kind === "new") {
+        const span = drag.selEnd - drag.selStart;
+        const moved = Math.abs(x - drag.originX) > 3;
+        if (!moved && timeWindow) {
+          // Stationary click inside existing selection → clear.
+          const zone = hitHandle(x, timeWindow, labelW, chartW, maxEnd);
+          if (zone === "inside") {
+            onChange(null);
+          }
+        } else if (moved && span >= minSpan) {
+          onChange({ start: drag.selStart, end: drag.selEnd });
+        }
+      } else if (drag.kind === "resize-left" || drag.kind === "resize-right") {
+        const span = drag.selEnd - drag.selStart;
+        if (span >= minSpan) {
+          onChange({ start: drag.selStart, end: drag.selEnd });
+        }
+      }
+
+      dragRef.current = { kind: "idle" };
+      redraw({ kind: "idle" });
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable refs / maxEnd/labelW don't change during a drag
+  }, [labelW, maxEnd, onChange, redraw, timeWindow]);
+
+  // Keyboard: Escape clears the selection.
+  const handleKeyDown = (e: KeyboardEvent<HTMLCanvasElement>) => {
+    if (e.key === "Escape" && timeWindow) {
+      onChange(null);
+    }
+  };
+
+  // Dynamic cursor based on hover zone.
+  const getCursor = useCallback(
+    (clientX: number): CSSProperties["cursor"] => {
+      const chartW = getChartW();
+      if (chartW <= 0) return "crosshair";
+      const x = getCanvasX(clientX);
+      const zone = hitHandle(x, timeWindow, labelW, chartW, maxEnd);
+      if (zone === "left" || zone === "right") return "ew-resize";
+      if (zone === "inside") return "pointer";
+      return "crosshair";
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- labelW/maxEnd/timeWindow are stable per render
+    [labelW, maxEnd, timeWindow],
+  );
+
+  const [cursor, setCursor] = useState<CSSProperties["cursor"]>("crosshair");
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (dragRef.current.kind !== "idle") return;
+    setCursor(getCursor(e.clientX));
+  };
+
+  const handleMouseLeave = () => {
+    if (dragRef.current.kind === "idle") setCursor("crosshair");
+  };
+
+  return (
+    <div className="time-range-brush" aria-label="Timeline zoom brush">
+      <canvas
+        ref={canvasRef}
+        style={{
+          display: "block",
+          width: "100%",
+          height: BRUSH_H,
+          cursor,
+        }}
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- brush is keyboard-accessible for Escape to clear
+        tabIndex={0}
+        aria-label="Drag to select a time range to zoom into"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  );
+}

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
@@ -25,6 +25,7 @@ import {
   getResourceTypeSoftFill,
 } from "@web/constants/themeColors";
 import type { TimeWindow } from "@web/lib/analysis-workspace/types";
+import { isPositiveStatus } from "./formatting";
 import { X_PAD } from "./constants";
 
 // ---------------------------------------------------------------------------
@@ -116,13 +117,21 @@ function drawBrush(
   ctx.textBaseline = "middle";
   ctx.fillText("Zoom", labelW / 2, h / 2);
 
+  // Returns true if the bundle or any of its tests has a non-positive status.
+  function isFailed(bundle: BundleRow): boolean {
+    if (!isPositiveStatus(bundle.item.status)) return true;
+    return bundle.tests.some((t) => !isPositiveStatus(t.status));
+  }
+
   // Minimap bars (all bundles, very compact)
   for (const bundle of bundles) {
     const item = bundle.item;
     if (item.end <= 0 || maxEnd <= 0) continue;
     const bx = timeToX(item.start, labelW, chartW, maxEnd);
     const bw = Math.max(1, (item.duration / maxEnd) * chartW);
-    ctx.fillStyle = getResourceTypeSoftFill(item.resourceType, theme);
+    ctx.fillStyle = isFailed(bundle)
+      ? palette.testFailStripe
+      : getResourceTypeSoftFill(item.resourceType, theme);
     ctx.globalAlpha = 0.7;
     ctx.fillRect(bx, BAR_MARGIN, bw, BAR_H);
     ctx.globalAlpha = 1;

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
@@ -25,7 +25,7 @@ import {
   getResourceTypeSoftFill,
 } from "@web/constants/themeColors";
 import type { TimeWindow } from "@web/lib/analysis-workspace/types";
-import { isPositiveStatus } from "./formatting";
+import { formatMs, isPositiveStatus, isSkippedStatus } from "./formatting";
 import { X_PAD } from "./constants";
 
 // ---------------------------------------------------------------------------
@@ -76,6 +76,101 @@ function timeToX(
   return labelW + (time / maxEnd) * chartW;
 }
 
+/** Returns the first bundle whose minimap bar contains the given X pixel. */
+function hitBundle(
+  mouseX: number,
+  bundles: BundleRow[],
+  labelW: number,
+  chartW: number,
+  maxEnd: number,
+): BundleRow | null {
+  for (const bundle of bundles) {
+    const item = bundle.item;
+    if (item.end <= 0 || maxEnd <= 0) continue;
+    const bx = timeToX(item.start, labelW, chartW, maxEnd);
+    const bw = Math.max(1, (item.duration / maxEnd) * chartW);
+    if (mouseX >= bx && mouseX <= bx + bw) return bundle;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Bundle status helpers
+// ---------------------------------------------------------------------------
+
+/** True if the bundle or any test has a non-positive, non-skipped status. */
+function isBundleFailed(bundle: BundleRow): boolean {
+  const isNotable = (s: string) => !isPositiveStatus(s) && !isSkippedStatus(s);
+  if (isNotable(bundle.item.status)) return true;
+  return bundle.tests.some((t) => isNotable(t.status));
+}
+
+/** True if the bundle or any test is skipped/no-op (failure takes priority). */
+function isBundleSkipped(bundle: BundleRow): boolean {
+  if (isSkippedStatus(bundle.item.status)) return true;
+  return bundle.tests.some((t) => isSkippedStatus(t.status));
+}
+
+// ---------------------------------------------------------------------------
+// Canvas draw helpers
+// ---------------------------------------------------------------------------
+
+/** Resolves the active time-range selection from drag state or committed window. */
+function resolveSelection(
+  dragState: DragState | null,
+  timeWindow: TimeWindow | null,
+): { start: number; end: number } | null {
+  if (dragState && dragState.kind !== "idle") {
+    if (
+      dragState.kind === "new" ||
+      dragState.kind === DRAG_KIND_RESIZE_LEFT ||
+      dragState.kind === DRAG_KIND_RESIZE_RIGHT
+    ) {
+      return { start: dragState.selStart, end: dragState.selEnd };
+    }
+    return null;
+  }
+  return timeWindow ? { start: timeWindow.start, end: timeWindow.end } : null;
+}
+
+interface DrawSelectionGeo {
+  labelW: number;
+  chartW: number;
+  maxEnd: number;
+  w: number;
+  h: number;
+}
+
+/** Draws the dimmed overlay, selection outline, and resize handles for a selection. */
+function drawSelection(
+  ctx: CanvasRenderingContext2D,
+  selStart: number,
+  selEnd: number,
+  geo: DrawSelectionGeo,
+  theme: ThemeMode,
+  strokeColor: string,
+): void {
+  if (selEnd <= selStart) return;
+  const { labelW, chartW, maxEnd, w, h } = geo;
+  const sx = timeToX(selStart, labelW, chartW, maxEnd);
+  const ex = timeToX(selEnd, labelW, chartW, maxEnd);
+
+  ctx.fillStyle =
+    theme === "dark" ? "rgba(0,0,0,0.55)" : "rgba(255,255,255,0.55)";
+  ctx.fillRect(labelW, 0, sx - labelW, h);
+  ctx.fillRect(ex, 0, w - ex, h);
+
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = 1.5;
+  ctx.strokeRect(sx, 1, ex - sx, h - 2);
+
+  const handleColor =
+    theme === "dark" ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.5)";
+  ctx.fillStyle = handleColor;
+  ctx.fillRect(sx, (h - 16) / 2, HANDLE_W, 16);
+  ctx.fillRect(ex - HANDLE_W, (h - 16) / 2, HANDLE_W, 16);
+}
+
 // ---------------------------------------------------------------------------
 // Canvas draw
 // ---------------------------------------------------------------------------
@@ -117,67 +212,32 @@ function drawBrush(
   ctx.textBaseline = "middle";
   ctx.fillText("Zoom", labelW / 2, h / 2);
 
-  // Returns true if the bundle or any of its tests has a non-positive status.
-  function isFailed(bundle: BundleRow): boolean {
-    if (!isPositiveStatus(bundle.item.status)) return true;
-    return bundle.tests.some((t) => !isPositiveStatus(t.status));
-  }
-
   // Minimap bars (all bundles, very compact)
   for (const bundle of bundles) {
     const item = bundle.item;
     if (item.end <= 0 || maxEnd <= 0) continue;
     const bx = timeToX(item.start, labelW, chartW, maxEnd);
     const bw = Math.max(1, (item.duration / maxEnd) * chartW);
-    ctx.fillStyle = isFailed(bundle)
+    ctx.fillStyle = isBundleFailed(bundle)
       ? palette.testFailStripe
-      : getResourceTypeSoftFill(item.resourceType, theme);
+      : isBundleSkipped(bundle)
+        ? palette.testSkipStripe
+        : getResourceTypeSoftFill(item.resourceType, theme);
     ctx.globalAlpha = 0.7;
     ctx.fillRect(bx, BAR_MARGIN, bw, BAR_H);
     ctx.globalAlpha = 1;
   }
 
-  // Determine the active selection (committed window or live drag)
-  let selStart: number | null = null;
-  let selEnd: number | null = null;
-
-  if (dragState && dragState.kind !== "idle") {
-    if (
-      dragState.kind === "new" ||
-      dragState.kind === DRAG_KIND_RESIZE_LEFT ||
-      dragState.kind === DRAG_KIND_RESIZE_RIGHT
-    ) {
-      selStart = dragState.selStart;
-      selEnd = dragState.selEnd;
-    }
-  } else if (timeWindow) {
-    selStart = timeWindow.start;
-    selEnd = timeWindow.end;
-  }
-
-  if (selStart != null && selEnd != null && selEnd > selStart) {
-    const sx = timeToX(selStart, labelW, chartW, maxEnd);
-    const ex = timeToX(selEnd, labelW, chartW, maxEnd);
-    const sw = ex - sx;
-
-    // Dim the unselected regions
-    ctx.fillStyle =
-      theme === "dark" ? "rgba(0,0,0,0.55)" : "rgba(255,255,255,0.55)";
-    ctx.fillRect(labelW, 0, sx - labelW, h);
-    ctx.fillRect(ex, 0, w - ex, h);
-
-    // Selection outline
-    ctx.strokeStyle = palette.barHoverStroke;
-    ctx.lineWidth = 1.5;
-    ctx.strokeRect(sx, 1, sw, h - 2);
-
-    // Resize handles
-    const handleColor =
-      theme === "dark" ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.5)";
-    ctx.fillStyle = handleColor;
-    ctx.fillRect(sx, (h - 16) / 2, HANDLE_W, 16);
-    ctx.fillRect(ex - HANDLE_W, (h - 16) / 2, HANDLE_W, 16);
-  }
+  const sel = resolveSelection(dragState, timeWindow);
+  if (sel)
+    drawSelection(
+      ctx,
+      sel.start,
+      sel.end,
+      { labelW, chartW, maxEnd, w, h },
+      theme,
+      palette.barHoverStroke,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +281,80 @@ function hitHandle(
 }
 
 // ---------------------------------------------------------------------------
+// Tooltip
+// ---------------------------------------------------------------------------
+
+interface BrushTooltipProps {
+  bundle: BundleRow;
+  clientX: number;
+  canvasWidth: number;
+  theme: ThemeMode;
+}
+
+function BrushTooltip({
+  bundle,
+  clientX,
+  canvasWidth,
+  theme,
+}: BrushTooltipProps) {
+  const item = bundle.item;
+  const failedTests = bundle.tests.filter(
+    (t) => !isPositiveStatus(t.status) && !isSkippedStatus(t.status),
+  ).length;
+  const isItemSkipped = isSkippedStatus(item.status);
+  const statusColor = isItemSkipped
+    ? theme === "dark"
+      ? "#F5B95C"
+      : "#A56315"
+    : theme === "dark"
+      ? "#FF8D86"
+      : "#C0352B";
+  const left = Math.max(0, Math.min(clientX - 80, canvasWidth - 200));
+  return (
+    <div
+      role="tooltip"
+      style={{
+        position: "absolute",
+        left,
+        bottom: BRUSH_H + 4,
+        background: theme === "dark" ? "#1B2035" : "#fff",
+        border: `1px solid ${statusColor}`,
+        borderRadius: 6,
+        padding: "6px 10px",
+        pointerEvents: "none",
+        zIndex: 100,
+        minWidth: 160,
+        maxWidth: 280,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.18)",
+        fontSize: 12,
+        lineHeight: 1.5,
+        color: theme === "dark" ? "#F3F6FC" : "#171C28",
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 2, wordBreak: "break-all" }}>
+        {item.name}
+      </div>
+      <div style={{ color: statusColor, textTransform: "capitalize" }}>
+        {item.status}
+      </div>
+      <div style={{ color: theme === "dark" ? "#98A3BC" : "#6B7385" }}>
+        {item.resourceType} · {formatMs(item.duration)}
+      </div>
+      {failedTests > 0 && (
+        <div
+          style={{
+            color: theme === "dark" ? "#FF8D86" : "#C0352B",
+            marginTop: 2,
+          }}
+        >
+          {failedTests} test{failedTests > 1 ? "s" : ""} failed
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -243,6 +377,10 @@ export function TimeRangeBrush({
 }: TimeRangeBrushProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const dragRef = useRef<DragState>({ kind: "idle" });
+  const [tooltip, setTooltip] = useState<{
+    bundle: BundleRow;
+    clientX: number;
+  } | null>(null);
 
   // Redraw whenever relevant props change.
   const redraw = useCallback(
@@ -322,6 +460,7 @@ export function TimeRangeBrush({
         selEnd: t,
       };
     }
+    setTooltip(null);
     redraw(dragRef.current);
   };
 
@@ -430,14 +569,40 @@ export function TimeRangeBrush({
   const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
     if (dragRef.current.kind !== "idle") return;
     setCursor(getCursor(e.clientX));
+    // Tooltip: show for failed / skipped bundles only.
+    const chartW = getChartW();
+    const x = getCanvasX(e.clientX);
+    const hit =
+      chartW > 0 ? hitBundle(x, bundles, labelW, chartW, maxEnd) : null;
+    const noteworthy =
+      hit != null && (isBundleFailed(hit) || isBundleSkipped(hit));
+    setTooltip(noteworthy ? { bundle: hit, clientX: e.clientX } : null);
   };
 
   const handleMouseLeave = () => {
     if (dragRef.current.kind === "idle") setCursor("crosshair");
+    setTooltip(null);
   };
 
+  const canvasWidth = canvasRef.current?.getBoundingClientRect().width ?? 400;
+  const tooltipClientX = tooltip
+    ? tooltip.clientX - (canvasRef.current?.getBoundingClientRect().left ?? 0)
+    : 0;
+
   return (
-    <div className="time-range-brush" aria-label="Timeline zoom brush">
+    <div
+      className="time-range-brush"
+      aria-label="Timeline zoom brush"
+      style={{ position: "relative" }}
+    >
+      {tooltip && (
+        <BrushTooltip
+          bundle={tooltip.bundle}
+          clientX={tooltipClientX}
+          canvasWidth={canvasWidth}
+          theme={theme}
+        />
+      )}
       <canvas
         ref={canvasRef}
         style={{

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
@@ -135,8 +135,8 @@ function drawBrush(
   if (dragState && dragState.kind !== "idle") {
     if (
       dragState.kind === "new" ||
-      dragState.kind === "resize-left" ||
-      dragState.kind === "resize-right"
+      dragState.kind === DRAG_KIND_RESIZE_LEFT ||
+      dragState.kind === DRAG_KIND_RESIZE_RIGHT
     ) {
       selStart = dragState.selStart;
       selEnd = dragState.selEnd;
@@ -184,12 +184,12 @@ type DragState =
       selEnd: number; // ms
     }
   | {
-      kind: "resize-left";
+      kind: typeof DRAG_KIND_RESIZE_LEFT;
       selStart: number;
       selEnd: number;
     }
   | {
-      kind: "resize-right";
+      kind: typeof DRAG_KIND_RESIZE_RIGHT;
       selStart: number;
       selEnd: number;
     };
@@ -294,13 +294,13 @@ export function TimeRangeBrush({
       };
     } else if (zone === "left") {
       dragRef.current = {
-        kind: "resize-left",
+        kind: DRAG_KIND_RESIZE_LEFT,
         selStart: timeWindow!.start,
         selEnd: timeWindow!.end,
       };
     } else if (zone === "right") {
       dragRef.current = {
-        kind: "resize-right",
+        kind: DRAG_KIND_RESIZE_RIGHT,
         selStart: timeWindow!.start,
         selEnd: timeWindow!.end,
       };
@@ -336,13 +336,13 @@ export function TimeRangeBrush({
           selStart: Math.min(t, originT),
           selEnd: Math.max(t, originT),
         };
-      } else if (drag.kind === "resize-left") {
+      } else if (drag.kind === DRAG_KIND_RESIZE_LEFT) {
         const t = xToTime(x, labelW, chartW, maxEnd);
         dragRef.current = {
           ...drag,
           selStart: clamp(t, 0, drag.selEnd - minSpan),
         };
-      } else if (drag.kind === "resize-right") {
+      } else if (drag.kind === DRAG_KIND_RESIZE_RIGHT) {
         const t = xToTime(x, labelW, chartW, maxEnd);
         dragRef.current = {
           ...drag,
@@ -372,7 +372,7 @@ export function TimeRangeBrush({
         } else if (moved && span >= minSpan) {
           onChange({ start: drag.selStart, end: drag.selEnd });
         }
-      } else if (drag.kind === "resize-left" || drag.kind === "resize-right") {
+      } else if (drag.kind === DRAG_KIND_RESIZE_LEFT || drag.kind === DRAG_KIND_RESIZE_RIGHT) {
         const span = drag.selEnd - drag.selStart;
         if (span >= minSpan) {
           onChange({ start: drag.selStart, end: drag.selEnd });
@@ -435,7 +435,6 @@ export function TimeRangeBrush({
           height: BRUSH_H,
           cursor,
         }}
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- brush is keyboard-accessible for Escape to clear
         tabIndex={0}
         aria-label="Drag to select a time range to zoom into"
         onMouseDown={handleMouseDown}

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
@@ -41,6 +41,10 @@ const BAR_H = BRUSH_H - BAR_MARGIN * 2;
 const HANDLE_W = 6;
 /** Minimum visible selection span as a fraction of maxEnd. */
 const MIN_SPAN_RATIO = 0.002;
+/** Drag state kind for resizing the left edge of the selection. */
+const DRAG_KIND_RESIZE_LEFT = "resize-left" as const;
+/** Drag state kind for resizing the right edge of the selection. */
+const DRAG_KIND_RESIZE_RIGHT = "resize-right" as const;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/TimeRangeBrush.tsx
@@ -240,8 +240,7 @@ export function TimeRangeBrush({
     (drag: DragState) => {
       const canvas = canvasRef.current;
       if (!canvas) return;
-      const chartW =
-        canvas.getBoundingClientRect().width - labelW - X_PAD;
+      const chartW = canvas.getBoundingClientRect().width - labelW - X_PAD;
       if (chartW <= 0) return;
       drawBrush(canvas, bundles, maxEnd, labelW, timeWindow, theme, drag);
     },
@@ -372,7 +371,10 @@ export function TimeRangeBrush({
         } else if (moved && span >= minSpan) {
           onChange({ start: drag.selStart, end: drag.selEnd });
         }
-      } else if (drag.kind === DRAG_KIND_RESIZE_LEFT || drag.kind === DRAG_KIND_RESIZE_RIGHT) {
+      } else if (
+        drag.kind === DRAG_KIND_RESIZE_LEFT ||
+        drag.kind === DRAG_KIND_RESIZE_RIGHT
+      ) {
         const span = drag.selEnd - drag.selStart;
         if (span >= minSpan) {
           onChange({ start: drag.selStart, end: drag.selEnd });

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/canvasDraw.ts
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/canvasDraw.ts
@@ -161,6 +161,7 @@ interface DrawRowBarParams {
   ctx: CanvasRenderingContext2D;
   item: GanttItem;
   rowY: number;
+  minTime: number;
   maxEnd: number;
   chartW: number;
   labelW: number;
@@ -175,6 +176,7 @@ function drawRowBar({
   ctx,
   item,
   rowY,
+  minTime,
   maxEnd,
   chartW,
   labelW,
@@ -185,7 +187,7 @@ function drawRowBar({
   theme,
 }: DrawRowBarParams) {
   const barY = rowY + BAR_PAD;
-  const barX = labelW + (item.start / maxEnd) * chartW;
+  const barX = labelW + ((item.start - minTime) / maxEnd) * chartW;
   const barW = Math.max(2, (item.duration / maxEnd) * chartW);
   const radius = 3;
 
@@ -198,8 +200,8 @@ function drawRowBar({
   const ce = item.compileEnd;
   const hasCompile = cs != null && ce != null && ce > cs && maxEnd > 0;
   if (hasCompile) {
-    const compileX = labelW + (cs / maxEnd) * chartW;
-    const compileEndX = labelW + (ce / maxEnd) * chartW;
+    const compileX = labelW + ((cs - minTime) / maxEnd) * chartW;
+    const compileEndX = labelW + ((ce - minTime) / maxEnd) * chartW;
     const segLeft = Math.max(barX, compileX);
     const segRight = Math.min(barX + barW, compileEndX);
     const segW = segRight - segLeft;
@@ -246,6 +248,7 @@ interface DrawTestChipParams {
   ctx: CanvasRenderingContext2D;
   test: GanttItem;
   chipY: number;
+  minTime: number;
   maxEnd: number;
   chartW: number;
   labelW: number;
@@ -259,6 +262,7 @@ function drawTestChip({
   ctx,
   test,
   chipY,
+  minTime,
   maxEnd,
   chartW,
   labelW,
@@ -267,7 +271,7 @@ function drawTestChip({
   emphasis,
   isHovered,
 }: DrawTestChipParams) {
-  const chipX = labelW + (test.start / maxEnd) * chartW;
+  const chipX = labelW + ((test.start - minTime) / maxEnd) * chartW;
   const chipW = Math.max(MIN_CHIP_W, (test.duration / maxEnd) * chartW);
   const chipH = TEST_BAR_H;
   const radius = 2;
@@ -281,8 +285,8 @@ function drawTestChip({
   const ce = test.compileEnd;
   const hasCompile = cs != null && ce != null && ce > cs && maxEnd > 0;
   if (hasCompile) {
-    const compileX = labelW + (cs / maxEnd) * chartW;
-    const compileEndX = labelW + (ce / maxEnd) * chartW;
+    const compileX = labelW + ((cs - minTime) / maxEnd) * chartW;
+    const compileEndX = labelW + ((ce - minTime) / maxEnd) * chartW;
     const segLeft = Math.max(chipX, compileX);
     const segRight = Math.min(chipX + chipW, compileEndX);
     const segW = segRight - segLeft;
@@ -362,6 +366,7 @@ interface DrawGanttAxisTicksParams {
   labelW: number;
   chartW: number;
   h: number;
+  minTime: number;
   maxEnd: number;
   displayMode: DisplayMode;
   runStartedAt: number | null | undefined;
@@ -374,6 +379,7 @@ function drawGanttAxisTicks({
   labelW,
   chartW,
   h,
+  minTime,
   maxEnd,
   displayMode,
   runStartedAt,
@@ -396,7 +402,7 @@ function drawGanttAxisTicks({
     ctx.stroke();
     const label =
       displayMode === "timestamps" && runStartedAt != null
-        ? formatTimestamp(runStartedAt + tick.ms, timeZone)
+        ? formatTimestamp(runStartedAt + minTime + tick.ms, timeZone)
         : tick.label;
     ctx.fillText(label, x, AXIS_TOP / 2);
   }
@@ -410,6 +416,7 @@ interface DrawGanttVisibleRowParams {
   w: number;
   labelW: number;
   chartW: number;
+  minTime: number;
   maxEnd: number;
   focusIds: Set<string> | null;
   hoveredId: string | null;
@@ -431,6 +438,7 @@ function drawGanttVisibleRow(p: DrawGanttVisibleRowParams): void {
     w,
     labelW,
     chartW,
+    minTime,
     maxEnd,
     focusIds,
     hoveredId,
@@ -470,6 +478,7 @@ function drawGanttVisibleRow(p: DrawGanttVisibleRowParams): void {
     ctx,
     item: bundle.item,
     rowY,
+    minTime,
     maxEnd,
     chartW,
     labelW,
@@ -490,6 +499,7 @@ function drawGanttVisibleRow(p: DrawGanttVisibleRowParams): void {
       ctx,
       test,
       chipY,
+      minTime,
       maxEnd,
       chartW,
       labelW,
@@ -507,6 +517,16 @@ function drawGanttVisibleRow(p: DrawGanttVisibleRowParams): void {
 
 export interface DrawGanttParams {
   scrollTop: number;
+  /**
+   * The start of the visible time window in ms (same coordinate space as
+   * `GanttItem.start`). Defaults to `0` (full timeline from the beginning).
+   * When a time-range brush is active this is `timeWindow.start`.
+   */
+  minTime?: number;
+  /**
+   * The visible time span in ms. When a time-range brush is active this is
+   * `timeWindow.end - timeWindow.start`; otherwise it is the full run duration.
+   */
   maxEnd: number;
   displayMode: DisplayMode;
   runStartedAt: number | null | undefined;
@@ -528,6 +548,7 @@ export function drawGantt(
   rowHeights: number[],
   {
     scrollTop,
+    minTime = 0,
     maxEnd,
     displayMode,
     runStartedAt,
@@ -537,7 +558,7 @@ export function drawGantt(
     timeZone,
     testStatsById,
     theme = "light",
-    showTests = true,
+    showTests = false,
   }: DrawGanttParams,
 ) {
   const prepared = initGanttCanvas(canvas, labelW);
@@ -551,6 +572,7 @@ export function drawGantt(
     labelW,
     chartW,
     h,
+    minTime,
     maxEnd,
     displayMode,
     runStartedAt,
@@ -578,6 +600,7 @@ export function drawGantt(
       w,
       labelW,
       chartW,
+      minTime,
       maxEnd,
       focusIds,
       hoveredId,

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/edgeGeometry.ts
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/edgeGeometry.ts
@@ -734,6 +734,8 @@ export interface FocusEdgePathParams {
   scrollTop: number;
   showTests: boolean;
   effectiveLabelW: number;
+  /** Start of the visible time window in ms (0 when no zoom). */
+  minTime?: number;
   maxEnd: number;
   chartW: number;
 }
@@ -751,6 +753,7 @@ export function focusEdgePath(p: FocusEdgePathParams): string {
     scrollTop,
     showTests,
     effectiveLabelW,
+    minTime = 0,
     maxEnd,
     chartW,
   } = p;
@@ -786,8 +789,9 @@ export function focusEdgePath(p: FocusEdgePathParams): string {
   if (sy == null || ty == null) return "";
 
   const sx =
-    effectiveLabelW + ((fromItem.start + fromItem.duration) / maxEnd) * chartW;
-  const tx = effectiveLabelW + (toItem.start / maxEnd) * chartW;
+    effectiveLabelW +
+    ((fromItem.start + fromItem.duration - minTime) / maxEnd) * chartW;
+  const tx = effectiveLabelW + ((toItem.start - minTime) / maxEnd) * chartW;
   const cx = Math.abs(tx - sx) * 0.4;
 
   return `M${sx},${sy} C${sx + cx},${sy} ${tx - cx},${ty} ${tx},${ty}`;

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/formatting.ts
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/formatting.ts
@@ -46,6 +46,10 @@ export function isPositiveStatus(status: string): boolean {
   return ["success", "pass", "passed"].includes(status.trim().toLowerCase());
 }
 
+export function isSkippedStatus(status: string): boolean {
+  return ["skipped", "no op"].includes(status.trim().toLowerCase());
+}
+
 export function computeTicks(
   maxEnd: number,
 ): Array<{ ms: number; label: string }> {

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/ganttPointerInteraction.ts
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/ganttPointerInteraction.ts
@@ -6,6 +6,7 @@ export interface GanttPointerContext {
   bundles: BundleRow[];
   layout: BundleLayout;
   scrollTop: number;
+  minTime: number;
   maxEnd: number;
   effectiveLabelW: number;
   canvas: HTMLCanvasElement | null;
@@ -23,6 +24,7 @@ export function applyGanttPointerInteraction(
     bundles,
     layout,
     scrollTop,
+    minTime,
     maxEnd,
     effectiveLabelW,
     canvas,
@@ -37,6 +39,7 @@ export function applyGanttPointerInteraction(
     maxEnd,
     effectiveLabelW,
     canvas,
+    minTime,
   );
   if (!hit) {
     if (mode === "move") setHover(null);

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/hitTest.ts
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/hitTest.ts
@@ -63,6 +63,7 @@ export function hitTestBundle(
   maxEnd: number,
   effectiveLabelW: number,
   canvas: HTMLCanvasElement | null,
+  minTime = 0,
 ): { item: GanttItem; x: number; y: number } | null {
   const { rowOffsets, rowHeights, showTests } = layout;
   if (!canvas) return null;
@@ -88,7 +89,7 @@ export function hitTestBundle(
   }
 
   // Check parent bar
-  const barX = effectiveLabelW + (bundle.item.start / maxEnd) * chartW;
+  const barX = effectiveLabelW + ((bundle.item.start - minTime) / maxEnd) * chartW;
   const barW = Math.max(2, (bundle.item.duration / maxEnd) * chartW);
   if (mouseX >= barX && mouseX <= barX + barW) {
     return { item: bundle.item, x: mouseX, y: mouseY };
@@ -96,7 +97,7 @@ export function hitTestBundle(
 
   if (showTests && bundle.lanes.length > 0) {
     for (const { item: test, lane } of bundle.lanes) {
-      const chipX = effectiveLabelW + (test.start / maxEnd) * chartW;
+      const chipX = effectiveLabelW + ((test.start - minTime) / maxEnd) * chartW;
       const chipW = Math.max(2, (test.duration / maxEnd) * chartW);
       const chipY = bundleRowY + ROW_H + BUNDLE_HULL_PAD + lane * TEST_LANE_H;
       const chipH = 10; // TEST_BAR_H
@@ -126,6 +127,7 @@ export function hitTestBar(
   maxEnd: number,
   effectiveLabelW: number,
   canvas: HTMLCanvasElement | null,
+  minTime = 0,
 ): HoverState | null {
   if (!canvas) return null;
   const rect = event.currentTarget.getBoundingClientRect();
@@ -140,7 +142,7 @@ export function hitTestBar(
   const chartW = canvas.getBoundingClientRect().width - effectiveLabelW - X_PAD;
   const item = data[rowIdx];
   if (!item) return null;
-  const barX = effectiveLabelW + (item.start / maxEnd) * chartW;
+  const barX = effectiveLabelW + ((item.start - minTime) / maxEnd) * chartW;
   const barW = Math.max(2, (item.duration / maxEnd) * chartW);
 
   return mouseX >= barX && mouseX <= barX + barW

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/hitTest.ts
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/hitTest.ts
@@ -89,7 +89,8 @@ export function hitTestBundle(
   }
 
   // Check parent bar
-  const barX = effectiveLabelW + ((bundle.item.start - minTime) / maxEnd) * chartW;
+  const barX =
+    effectiveLabelW + ((bundle.item.start - minTime) / maxEnd) * chartW;
   const barW = Math.max(2, (bundle.item.duration / maxEnd) * chartW);
   if (mouseX >= barX && mouseX <= barX + barW) {
     return { item: bundle.item, x: mouseX, y: mouseY };
@@ -97,7 +98,8 @@ export function hitTestBundle(
 
   if (showTests && bundle.lanes.length > 0) {
     for (const { item: test, lane } of bundle.lanes) {
-      const chipX = effectiveLabelW + ((test.start - minTime) / maxEnd) * chartW;
+      const chipX =
+        effectiveLabelW + ((test.start - minTime) / maxEnd) * chartW;
       const chipW = Math.max(2, (test.duration / maxEnd) * chartW);
       const chipY = bundleRowY + ROW_H + BUNDLE_HULL_PAD + lane * TEST_LANE_H;
       const chipH = 10; // TEST_BAR_H

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/useGanttCanvasDraw.ts
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/gantt/useGanttCanvasDraw.ts
@@ -11,6 +11,7 @@ export interface UseGanttCanvasDrawParams {
   rowOffsets: number[];
   rowHeights: number[];
   scrollTop: number;
+  minTime: number;
   maxEnd: number;
   activeMode: DisplayMode;
   runStartedAt?: number | null;
@@ -30,6 +31,7 @@ export function useGanttCanvasDraw({
   rowOffsets,
   rowHeights,
   scrollTop,
+  minTime,
   maxEnd,
   activeMode,
   runStartedAt,
@@ -50,6 +52,7 @@ export function useGanttCanvasDraw({
       if (!c) return;
       drawGantt(c, bundles, rowOffsets, rowHeights, {
         scrollTop,
+        minTime,
         maxEnd,
         displayMode: activeMode,
         runStartedAt,
@@ -79,6 +82,7 @@ export function useGanttCanvasDraw({
     rowOffsets,
     rowHeights,
     scrollTop,
+    minTime,
     maxEnd,
     activeMode,
     runStartedAt,

--- a/packages/dbt-tools/web/src/constants/themeColors.ts
+++ b/packages/dbt-tools/web/src/constants/themeColors.ts
@@ -163,6 +163,8 @@ export const CANVAS_LIGHT = {
   gridLine: "#E6E9F0",
   barHoverStroke: THEME_HEX_LIGHT.accent,
   testFailStripe: "rgba(192, 53, 43, 0.9)",
+  /** Skipped/no-op bundle fill in the minimap — amber. */
+  testSkipStripe: "rgba(165, 99, 21, 0.88)",
   /** Bundle hull stroke — light neutral border. */
   hullStroke: "#C8CEDB",
   /** Bundle hull fill — near-transparent background. */
@@ -178,6 +180,8 @@ export const CANVAS_DARK = {
   gridLine: "#262E47",
   barHoverStroke: THEME_HEX_DARK.accent,
   testFailStripe: "rgba(255, 141, 134, 0.88)",
+  /** Skipped/no-op bundle fill in the minimap — amber. */
+  testSkipStripe: "rgba(245, 185, 92, 0.88)",
   /** Bundle hull stroke — dark neutral border. */
   hullStroke: "#2E3759",
   /** Bundle hull fill — near-transparent background. */

--- a/packages/dbt-tools/web/src/lib/analysis-workspace/types.ts
+++ b/packages/dbt-tools/web/src/lib/analysis-workspace/types.ts
@@ -46,12 +46,23 @@ export interface ResultsFilterState {
   query: string;
 }
 
+/**
+ * A selected time window used to zoom the timeline X-axis.
+ * Both `start` and `end` are milliseconds relative to the run's earliest node
+ * (i.e. relative to the implicit time-origin 0, same coordinate space as
+ * `GanttItem.start` / `GanttItem.end`).
+ */
+export interface TimeWindow {
+  start: number;
+  end: number;
+}
+
 export interface TimelineFilterState {
   query: string;
   activeStatuses: Set<string>;
   activeTypes: Set<string>;
   selectedExecutionId: string | null;
-  /** Show test chips inside bundle rows. Default true. */
+  /** Show test chips inside bundle rows. Default false for performance on large projects. */
   showTests: boolean;
   /**
    * When true: auto-expand all bundles with failures and visually collapse
@@ -65,6 +76,12 @@ export interface TimelineFilterState {
    * values > 1 enable capped extended BFS up to the given hop.
    */
   dependencyDepthHops: number;
+  /**
+   * When set, the timeline X-axis is zoomed to show only [start, end] ms.
+   * Bundles whose items do not overlap the window are hidden from the
+   * virtualizer. null means the full timeline is shown.
+   */
+  timeWindow: TimeWindow | null;
 }
 
 export interface AssetViewState {


### PR DESCRIPTION
- Change showTests default from true to false for improved initial render
  performance on large dbt projects with thousands of test chips.

- Add TimeWindow type and timeWindow: TimeWindow | null to
  TimelineFilterState. When active, the timeline X-axis is zoomed to the
  selected [start, end] window and bundles outside it are hidden from the
  virtualizer.

- Extend the canvas draw pipeline (canvasDraw.ts, hitTest.ts,
  ganttPointerInteraction.ts, edgeGeometry.ts, GanttEdgeLayer.tsx,
  GanttChartFrame.tsx, useGanttCanvasDraw.ts) with a minTime offset
  parameter so all X-position calculations correctly reflect the active
  zoom window. Defaults to 0 — no behaviour change for existing callers.

- Add TimeRangeBrush component: a 48px canvas minimap strip above the
  main chart. Drag to draw a zoom selection; resize via edge handles;
  click inside or press Escape to clear. Uses window-level pointer events
  so out-of-canvas drags complete correctly.

- Show "Zoomed to N window — Clear zoom ×" badge in TimelineView when a
  time window is active.

- Add ADR 0026 documenting the decisions and trade-offs.

https://claude.ai/code/session_01AFiiUszwPHmmLwwtkRYRks