### PR TITLE
Add analyze subcommands for bottleneck, critical-path, and parallelism analysis

### DIFF
--- a/packages/dbt-tools/cli/src/analyze-bottlenecks-action.ts
+++ b/packages/dbt-tools/cli/src/analyze-bottlenecks-action.ts
@@ -1,0 +1,79 @@
+import {
+  ManifestGraph,
+  resolveArtifactPaths,
+  loadManifest,
+  loadRunResults,
+  validateSafePath,
+  FieldFilter,
+  formatOutput,
+  shouldOutputJSON,
+  analyzeBottlenecks,
+  formatBottleneckAnalysis,
+} from "@dbt-tools/core";
+
+type AnalyzeBottlenecksOptions = {
+  targetDir?: string;
+  top?: number;
+  threshold?: number;
+  fields?: string;
+  json?: boolean;
+  noJson?: boolean;
+};
+
+/**
+ * CLI action: analyze bottlenecks
+ *
+ * Ranks nodes by structural impact score (execution_time × downstream reach)
+ * rather than raw execution time, so high-fan-out bottlenecks surface first.
+ */
+export function analyzeBottlenecksAction(
+  runResultsPath: string | undefined,
+  manifestPath: string | undefined,
+  options: AnalyzeBottlenecksOptions,
+  handleError: (error: unknown, isTTY: boolean) => void,
+  isTTY: () => boolean,
+): void {
+  try {
+    if (options.top !== undefined && options.threshold !== undefined) {
+      throw new Error("Cannot use both --top and --threshold; choose one");
+    }
+
+    const paths = resolveArtifactPaths(
+      manifestPath,
+      runResultsPath,
+      options.targetDir,
+    );
+    validateSafePath(paths.runResults);
+    validateSafePath(paths.manifest);
+
+    const runResults = loadRunResults(paths.runResults);
+    const manifest = loadManifest(paths.manifest);
+    const graph = new ManifestGraph(manifest);
+
+    const threshold = options.threshold;
+    const topN = options.top ?? 10;
+
+    const mode =
+      threshold !== undefined && threshold > 0
+        ? ({ mode: "threshold", min_seconds: threshold } as const)
+        : ({ mode: "top_n", top: topN > 0 ? topN : 10 } as const);
+
+    let result = analyzeBottlenecks(runResults, graph, mode);
+
+    if (options.fields) {
+      result = FieldFilter.filterFields(
+        result,
+        options.fields,
+      ) as typeof result;
+    }
+
+    const useJson = shouldOutputJSON(options.json, options.noJson);
+    if (useJson) {
+      console.log(formatOutput(result, true));
+    } else {
+      console.log(formatBottleneckAnalysis(result));
+    }
+  } catch (error) {
+    handleError(error, isTTY());
+  }
+}

--- a/packages/dbt-tools/cli/src/analyze-critical-path-action.ts
+++ b/packages/dbt-tools/cli/src/analyze-critical-path-action.ts
@@ -1,0 +1,76 @@
+import {
+  ManifestGraph,
+  resolveArtifactPaths,
+  loadManifest,
+  loadRunResults,
+  validateSafePath,
+  FieldFilter,
+  formatOutput,
+  shouldOutputJSON,
+  analyzeCriticalPath,
+  formatCriticalPathAnalysis,
+} from "@dbt-tools/core";
+
+type AnalyzeCriticalPathOptions = {
+  targetDir?: string;
+  fields?: string;
+  json?: boolean;
+  noJson?: boolean;
+};
+
+/**
+ * CLI action: analyze critical-path
+ *
+ * Identifies the longest execution path through the dependency graph,
+ * annotating each node with cumulative time and concurrent parallelism.
+ */
+export function analyzeCriticalPathAction(
+  runResultsPath: string | undefined,
+  manifestPath: string | undefined,
+  options: AnalyzeCriticalPathOptions,
+  handleError: (error: unknown, isTTY: boolean) => void,
+  isTTY: () => boolean,
+): void {
+  try {
+    const paths = resolveArtifactPaths(
+      manifestPath,
+      runResultsPath,
+      options.targetDir,
+    );
+    validateSafePath(paths.runResults);
+    validateSafePath(paths.manifest);
+
+    const runResults = loadRunResults(paths.runResults);
+    const manifest = loadManifest(paths.manifest);
+    const graph = new ManifestGraph(manifest);
+
+    let result = analyzeCriticalPath(runResults, graph);
+
+    if (!result) {
+      const msg = "No critical path found. Ensure run_results.json has execution data that matches the manifest.";
+      const useJson = shouldOutputJSON(options.json, options.noJson);
+      if (useJson) {
+        console.log(formatOutput({ error: msg }, true));
+      } else {
+        console.log(msg);
+      }
+      return;
+    }
+
+    if (options.fields) {
+      result = FieldFilter.filterFields(
+        result,
+        options.fields,
+      ) as typeof result;
+    }
+
+    const useJson = shouldOutputJSON(options.json, options.noJson);
+    if (useJson) {
+      console.log(formatOutput(result, true));
+    } else {
+      console.log(formatCriticalPathAnalysis(result));
+    }
+  } catch (error) {
+    handleError(error, isTTY());
+  }
+}

--- a/packages/dbt-tools/cli/src/analyze-parallelism-action.ts
+++ b/packages/dbt-tools/cli/src/analyze-parallelism-action.ts
@@ -1,0 +1,79 @@
+import type { NodeExecution } from "@dbt-tools/core";
+import {
+  ManifestGraph,
+  resolveArtifactPaths,
+  loadManifest,
+  loadRunResults,
+  validateSafePath,
+  FieldFilter,
+  formatOutput,
+  shouldOutputJSON,
+  analyzeParallelism,
+  formatParallelismAnalysis,
+  ExecutionAnalyzer,
+} from "@dbt-tools/core";
+
+type AnalyzeParallelismOptions = {
+  targetDir?: string;
+  runResultsPath?: string;
+  fields?: string;
+  json?: boolean;
+  noJson?: boolean;
+};
+
+/**
+ * CLI action: analyze parallelism
+ *
+ * Decomposes the dependency graph into topological waves and identifies
+ * serialization bottlenecks and recommended thread counts.
+ * Works from manifest alone; run_results is optional (adds timing estimates).
+ */
+export function analyzeParallelismAction(
+  manifestPath: string | undefined,
+  options: AnalyzeParallelismOptions,
+  handleError: (error: unknown, isTTY: boolean) => void,
+  isTTY: () => boolean,
+): void {
+  try {
+    const paths = resolveArtifactPaths(
+      manifestPath,
+      options.runResultsPath,
+      options.targetDir,
+    );
+    validateSafePath(paths.manifest);
+
+    const manifest = loadManifest(paths.manifest);
+    const graph = new ManifestGraph(manifest);
+
+    // Optionally load run_results for timing estimates
+    let nodeExecutions: NodeExecution[] | undefined;
+    if (options.runResultsPath) {
+      try {
+        validateSafePath(paths.runResults);
+        const runResults = loadRunResults(paths.runResults);
+        const analyzer = new ExecutionAnalyzer(runResults, graph);
+        nodeExecutions = analyzer.getNodeExecutions();
+      } catch {
+        // run_results is optional; proceed without timing data
+      }
+    }
+
+    let result = analyzeParallelism(graph, nodeExecutions);
+
+    if (options.fields) {
+      result = FieldFilter.filterFields(
+        result,
+        options.fields,
+      ) as typeof result;
+    }
+
+    const useJson = shouldOutputJSON(options.json, options.noJson);
+    if (useJson) {
+      console.log(formatOutput(result, true));
+    } else {
+      console.log(formatParallelismAnalysis(result));
+    }
+  } catch (error) {
+    handleError(error, isTTY());
+  }
+}

--- a/packages/dbt-tools/cli/src/analyze-parallelism-action.ts
+++ b/packages/dbt-tools/cli/src/analyze-parallelism-action.ts
@@ -45,17 +45,15 @@ export function analyzeParallelismAction(
     const manifest = loadManifest(paths.manifest);
     const graph = new ManifestGraph(manifest);
 
-    // Optionally load run_results for timing estimates
+    // Optionally load run_results for timing estimates.
+    // When --run-results-path is explicitly provided, errors are propagated
+    // to the outer handler so the user is informed of the invalid path/file.
     let nodeExecutions: NodeExecution[] | undefined;
     if (options.runResultsPath) {
-      try {
-        validateSafePath(paths.runResults);
-        const runResults = loadRunResults(paths.runResults);
-        const analyzer = new ExecutionAnalyzer(runResults, graph);
-        nodeExecutions = analyzer.getNodeExecutions();
-      } catch {
-        // run_results is optional; proceed without timing data
-      }
+      validateSafePath(paths.runResults);
+      const runResults = loadRunResults(paths.runResults);
+      const analyzer = new ExecutionAnalyzer(runResults, graph);
+      nodeExecutions = analyzer.getNodeExecutions();
     }
 
     let result = analyzeParallelism(graph, nodeExecutions);

--- a/packages/dbt-tools/cli/src/cli-actions.ts
+++ b/packages/dbt-tools/cli/src/cli-actions.ts
@@ -1,2 +1,5 @@
 export { runReportAction } from "./run-report-action";
 export { depsAction } from "./deps-action";
+export { analyzeBottlenecksAction } from "./analyze-bottlenecks-action";
+export { analyzeCriticalPathAction } from "./analyze-critical-path-action";
+export { analyzeParallelismAction } from "./analyze-parallelism-action";

--- a/packages/dbt-tools/cli/src/cli.ts
+++ b/packages/dbt-tools/cli/src/cli.ts
@@ -19,7 +19,13 @@ import {
   exportGraphToFormat,
   writeGraphOutput,
 } from "@dbt-tools/core";
-import { runReportAction, depsAction } from "./cli-actions";
+import {
+  runReportAction,
+  depsAction,
+  analyzeBottlenecksAction,
+  analyzeCriticalPathAction,
+  analyzeParallelismAction,
+} from "./cli-actions";
 
 const program = new Command();
 
@@ -27,6 +33,9 @@ const program = new Command();
 const ARG_MANIFEST_PATH = "[manifest-path]";
 const DESC_MANIFEST =
   "Path to manifest.json file (defaults to ./target/manifest.json)";
+const ARG_RUN_RESULTS_PATH = "[run-results-path]";
+const DESC_RUN_RESULTS =
+  "Path to run_results.json (defaults to ./target/run_results.json)";
 const OPT_TARGET_DIR = "--target-dir <dir>";
 const DESC_TARGET_DIR = "Custom target directory (defaults to ./target)";
 const OPT_JSON = "--json";
@@ -37,6 +46,7 @@ const DESC_GRAPH_FORMAT = "Export format: json, dot, gexf";
 const DEFAULT_GRAPH_FORMAT = "json";
 const OPT_FIELDS = "--fields <fields>";
 const DESC_FIELDS = "Comma-separated list of fields to include";
+const DESC_MANIFEST_ANALYZE = "Path to manifest.json (defaults to ./target/manifest.json)";
 
 program
   .name("dbt-tools")
@@ -212,7 +222,7 @@ program
   .command("run-report")
   .description("Generate execution report from run_results.json")
   .argument(
-    "[run-results-path]",
+    ARG_RUN_RESULTS_PATH,
     "Path to run_results.json file (defaults to ./target/run_results.json)",
   )
   .argument(
@@ -343,6 +353,118 @@ program
       handleError(error, isTTY());
     }
   });
+
+/**
+ * Analyze command group: graph-algorithm-driven performance analysis
+ */
+const analyze = program
+  .command("analyze")
+  .description("Graph-algorithm-driven performance analysis of dbt projects");
+
+analyze
+  .command("bottlenecks")
+  .description(
+    "Identify execution bottlenecks ranked by structural impact (execution time × downstream reach)",
+  )
+  .argument(ARG_RUN_RESULTS_PATH, DESC_RUN_RESULTS)
+  .argument(ARG_MANIFEST_PATH, DESC_MANIFEST_ANALYZE)
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option(
+    "--top <n>",
+    "Top N bottlenecks by structural impact (default: 10)",
+    parseInt,
+  )
+  .option(
+    "--threshold <s>",
+    "Include nodes exceeding s seconds (alternative to --top)",
+    parseFloat,
+  )
+  .option(OPT_FIELDS, DESC_FIELDS)
+  .option(OPT_JSON, DESC_JSON)
+  .option(OPT_NO_JSON, DESC_NO_JSON)
+  .action(
+    (
+      runResultsPath: string | undefined,
+      manifestPath: string | undefined,
+      options: {
+        targetDir?: string;
+        top?: number;
+        threshold?: number;
+        fields?: string;
+        json?: boolean;
+        noJson?: boolean;
+      },
+    ) =>
+      analyzeBottlenecksAction(
+        runResultsPath,
+        manifestPath,
+        options,
+        handleError,
+        isTTY,
+      ),
+  );
+
+analyze
+  .command("critical-path")
+  .description(
+    "Identify the longest execution path through the dependency graph with per-node timing",
+  )
+  .argument(ARG_RUN_RESULTS_PATH, DESC_RUN_RESULTS)
+  .argument(ARG_MANIFEST_PATH, DESC_MANIFEST_ANALYZE)
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option(OPT_FIELDS, DESC_FIELDS)
+  .option(OPT_JSON, DESC_JSON)
+  .option(OPT_NO_JSON, DESC_NO_JSON)
+  .action(
+    (
+      runResultsPath: string | undefined,
+      manifestPath: string | undefined,
+      options: {
+        targetDir?: string;
+        fields?: string;
+        json?: boolean;
+        noJson?: boolean;
+      },
+    ) =>
+      analyzeCriticalPathAction(
+        runResultsPath,
+        manifestPath,
+        options,
+        handleError,
+        isTTY,
+      ),
+  );
+
+analyze
+  .command("parallelism")
+  .description(
+    "Decompose the dependency graph into topological waves and detect serialization bottlenecks",
+  )
+  .argument(
+    ARG_MANIFEST_PATH,
+    DESC_MANIFEST_ANALYZE,
+  )
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option(
+    "--run-results-path <path>",
+    "Path to run_results.json for execution time estimates (optional)",
+  )
+  .option(OPT_FIELDS, DESC_FIELDS)
+  .option(OPT_JSON, DESC_JSON)
+  .option(OPT_NO_JSON, DESC_NO_JSON)
+  .action(
+    (
+      manifestPath: string | undefined,
+      options: {
+        targetDir?: string;
+        runResultsPath?: string;
+        fields?: string;
+        json?: boolean;
+        noJson?: boolean;
+      },
+    ) =>
+      analyzeParallelismAction(manifestPath, options, handleError, isTTY),
+  );
 
 // Parse command line arguments
 program.parse();

--- a/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.test.ts
+++ b/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { parseManifest } from "dbt-artifacts-parser/manifest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { parseRunResults } from "dbt-artifacts-parser/run_results";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import {
+  loadTestManifest,
+  loadTestRunResults,
+} from "dbt-artifacts-parser/test-utils";
+import { ManifestGraph } from "./manifest-graph";
+import { analyzeBottlenecks } from "./bottleneck-analyzer";
+
+function makeRunResults(
+  results: Array<{
+    unique_id: string;
+    status?: string;
+    execution_time?: number;
+    timing?: unknown[];
+  }>,
+  adapterType?: string,
+): ReturnType<typeof parseRunResults> {
+  return parseRunResults({
+    metadata: {
+      dbt_schema_version: "https://schemas.getdbt.com/dbt/run-results/v6.json",
+      ...(adapterType ? { adapter_type: adapterType } : {}),
+    },
+    results: results.map((r) => ({
+      unique_id: r.unique_id,
+      status: r.status ?? "success",
+      execution_time: r.execution_time ?? 0,
+      timing: r.timing ?? [],
+    })),
+  } as Record<string, unknown>);
+}
+
+describe("analyzeBottlenecks", () => {
+  it("should return enriched bottleneck nodes with structural metadata", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 5,
+    });
+
+    expect(result).toBeDefined();
+    expect(Array.isArray(result.top_bottlenecks)).toBe(true);
+    expect(result.top_bottlenecks.length).toBeLessThanOrEqual(5);
+    expect(typeof result.total_execution_time).toBe("number");
+    expect(result.criteria_used).toBe("top_n");
+    expect(typeof result.total_nodes_analyzed).toBe("number");
+  });
+
+  it("should include structural enrichment fields on each node", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 10,
+    });
+
+    for (const node of result.top_bottlenecks) {
+      expect(typeof node.downstream_count).toBe("number");
+      expect(node.downstream_count).toBeGreaterThanOrEqual(0);
+      expect(typeof node.fan_in).toBe("number");
+      expect(typeof node.fan_out).toBe("number");
+      expect(typeof node.structural_impact_score).toBe("number");
+      expect(typeof node.is_on_critical_path).toBe("boolean");
+    }
+  });
+
+  it("should rank nodes by structural_impact_score descending", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 10,
+    });
+
+    for (let i = 1; i < result.top_bottlenecks.length; i++) {
+      expect(result.top_bottlenecks[i - 1].structural_impact_score).toBeGreaterThanOrEqual(
+        result.top_bottlenecks[i].structural_impact_score,
+      );
+    }
+  });
+
+  it("should assign sequential ranks starting from 1", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 5,
+    });
+
+    for (let i = 0; i < result.top_bottlenecks.length; i++) {
+      expect(result.top_bottlenecks[i].rank).toBe(i + 1);
+    }
+  });
+
+  it("should extract adapter_type from run_results metadata", () => {
+    const runResults = makeRunResults(
+      [{ unique_id: "model.pkg.a", execution_time: 1 }],
+      "bigquery",
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 5,
+    });
+
+    expect(result.adapter_type).toBe("bigquery");
+  });
+
+  it("should return null adapter_type when metadata has no adapter_type", () => {
+    const runResults = makeRunResults([
+      { unique_id: "model.pkg.a", execution_time: 1 },
+    ]);
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 5,
+    });
+
+    expect(result.adapter_type).toBeNull();
+  });
+
+  it("should support threshold mode", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "threshold",
+      min_seconds: 0,
+    });
+
+    expect(result.criteria_used).toBe("threshold");
+    expect(Array.isArray(result.top_bottlenecks)).toBe(true);
+  });
+
+  it("should return empty bottlenecks when run_results is empty", () => {
+    const runResults = makeRunResults([]);
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 10,
+    });
+
+    expect(result.top_bottlenecks).toHaveLength(0);
+    expect(result.total_execution_time).toBe(0);
+    expect(result.total_nodes_analyzed).toBe(0);
+  });
+
+  it("structural_impact_score should be execution_time * (1 + downstream_count)", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeBottlenecks(runResults, graph, {
+      mode: "top_n",
+      top: 5,
+    });
+
+    for (const node of result.top_bottlenecks) {
+      const expected = node.execution_time * (1 + node.downstream_count);
+      expect(node.structural_impact_score).toBeCloseTo(expected, 1);
+    }
+  });
+});

--- a/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.test.ts
+++ b/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.test.ts
@@ -207,4 +207,55 @@ describe("analyzeBottlenecks", () => {
       expect(node.structural_impact_score).toBeCloseTo(expected, 1);
     }
   });
+
+  it("top_n should select by structural impact score, not raw execution time", () => {
+    // Node A (isolated): high raw execution_time (50s), 0 downstream
+    //   → structural_impact_score = 50 × (1 + 0) = 50
+    // Node B (high-downstream): lower raw execution_time (10s), 10+ downstream
+    //   → structural_impact_score = 10 × (1 + 10+) = 110+
+    //
+    // A naive raw-time sort would pick A. Structural-impact sort must pick B.
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+    const g = graph.getGraph();
+
+    // Find two nodes: one with many transitive downstream nodes and one isolated
+    let highDownstreamId: string | null = null;
+    let highDownstreamCount = 0;
+    let isolatedId: string | null = null;
+
+    g.forEachNode((nodeId) => {
+      const downstream = graph.getDownstream(nodeId);
+      if (downstream.length > highDownstreamCount) {
+        highDownstreamCount = downstream.length;
+        highDownstreamId = nodeId;
+      }
+    });
+
+    g.forEachNode((nodeId) => {
+      if (nodeId === highDownstreamId) return;
+      const downstream = graph.getDownstream(nodeId);
+      if (downstream.length === 0 && isolatedId === null) {
+        isolatedId = nodeId;
+      }
+    });
+
+    if (highDownstreamId === null || isolatedId === null || highDownstreamCount < 5) {
+      // Skip if the test manifest doesn't have suitable nodes
+      return;
+    }
+
+    // isolated gets high raw execution time → wins on raw time alone
+    // highDownstream gets lower raw time but compensates via downstream reach
+    const highTimeIsolated = { unique_id: isolatedId, execution_time: 50 };
+    const lowTimeHighImpact = { unique_id: highDownstreamId, execution_time: 10 };
+
+    const runResults = makeRunResults([highTimeIsolated, lowTimeHighImpact]);
+    const result = analyzeBottlenecks(runResults, graph, { mode: "top_n", top: 1 });
+
+    // structural_impact for highDownstream = 10 × (1 + highDownstreamCount) >> 50
+    expect(result.top_bottlenecks).toHaveLength(1);
+    expect(result.top_bottlenecks[0].unique_id).toBe(highDownstreamId);
+  });
 });

--- a/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.ts
+++ b/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.ts
@@ -1,7 +1,6 @@
 import type { ParsedRunResults } from "dbt-artifacts-parser/run_results";
 import type { ManifestGraph } from "./manifest-graph";
 import { ExecutionAnalyzer } from "./execution-analyzer";
-import { detectBottlenecks } from "./run-results-search";
 
 /**
  * A bottleneck node enriched with graph-structural metadata.
@@ -52,6 +51,10 @@ type BottleneckOptions =
  * **structural impact** (execution time × downstream reach) rather than raw
  * execution time alone, so a fast node that blocks hundreds of downstream
  * nodes surfaces above a slow isolated node.
+ *
+ * Critically, the top-N cutoff is applied **after** structural enrichment and
+ * sorting, so nodes with moderate runtime but high downstream reach are never
+ * discarded before scoring.
  */
 export function analyzeBottlenecks(
   runResults: ParsedRunResults,
@@ -61,43 +64,71 @@ export function analyzeBottlenecks(
   const analyzer = new ExecutionAnalyzer(runResults, graph);
   const nodeExecutions = analyzer.getNodeExecutions();
 
+  // pct_of_total is always relative to the full run's execution time
+  const totalExecutionTime = nodeExecutions.reduce(
+    (sum, e) => sum + (e.execution_time ?? 0),
+    0,
+  );
+
   // Critical path node set for annotation
   const criticalPath = analyzer.calculateCriticalPath(nodeExecutions);
   const criticalPathSet = new Set(criticalPath?.path ?? []);
 
-  const baseResult = detectBottlenecks(nodeExecutions, { ...options, graph });
   const g = graph.getGraph();
 
   const metadata = (runResults as unknown as Record<string, unknown>)
     .metadata as Record<string, unknown> | undefined;
   const adapterType = (metadata?.adapter_type as string | undefined) ?? null;
 
-  const enriched: EnrichedBottleneckNode[] = baseResult.nodes.map((node) => {
-    const downstreamCount = graph.getDownstream(node.unique_id).length;
-    const fanIn = g.hasNode(node.unique_id) ? g.inDegree(node.unique_id) : 0;
-    const fanOut = g.hasNode(node.unique_id) ? g.outDegree(node.unique_id) : 0;
-    const rawScore = node.execution_time * (1 + downstreamCount);
+  // Apply threshold pre-filter when requested (keeps only slow-enough nodes)
+  const candidates =
+    options.mode === "threshold"
+      ? nodeExecutions.filter(
+          (e) => (e.execution_time ?? 0) >= options.min_seconds,
+        )
+      : nodeExecutions;
+
+  // Enrich ALL candidates with graph metrics before any top-N cutoff
+  const enriched: EnrichedBottleneckNode[] = candidates.map((exec) => {
+    const time = exec.execution_time ?? 0;
+    const downstreamCount = graph.getDownstream(exec.unique_id).length;
+    const fanIn = g.hasNode(exec.unique_id) ? g.inDegree(exec.unique_id) : 0;
+    const fanOut = g.hasNode(exec.unique_id) ? g.outDegree(exec.unique_id) : 0;
+    const rawScore = time * (1 + downstreamCount);
+    const pct = totalExecutionTime > 0 ? (time / totalExecutionTime) * 100 : 0;
+    const attrs = g.hasNode(exec.unique_id)
+      ? g.getNodeAttributes(exec.unique_id)
+      : undefined;
 
     return {
-      ...node,
+      unique_id: exec.unique_id,
+      name: attrs?.name as string | undefined,
+      execution_time: time,
+      rank: 0, // assigned after sort
+      pct_of_total: Math.round(pct * 10) / 10,
+      status: exec.status || "unknown",
       downstream_count: downstreamCount,
       fan_in: fanIn,
       fan_out: fanOut,
       structural_impact_score: Math.round(rawScore * 100) / 100,
-      is_on_critical_path: criticalPathSet.has(node.unique_id),
+      is_on_critical_path: criticalPathSet.has(exec.unique_id),
     };
   });
 
-  // Re-rank by structural_impact_score (highest = rank 1)
+  // Sort ALL by structural_impact_score, then apply top-N cutoff
   enriched.sort((a, b) => b.structural_impact_score - a.structural_impact_score);
-  enriched.forEach((n, i) => {
+
+  const topBottlenecks =
+    options.mode === "top_n" ? enriched.slice(0, options.top) : enriched;
+
+  topBottlenecks.forEach((n, i) => {
     n.rank = i + 1;
   });
 
   return {
-    top_bottlenecks: enriched,
-    total_execution_time: baseResult.total_execution_time,
-    criteria_used: baseResult.criteria_used,
+    top_bottlenecks: topBottlenecks,
+    total_execution_time: totalExecutionTime,
+    criteria_used: options.mode === "top_n" ? "top_n" : "threshold",
     adapter_type: adapterType,
     total_nodes_analyzed: nodeExecutions.length,
   };

--- a/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.ts
+++ b/packages/dbt-tools/core/src/analysis/bottleneck-analyzer.ts
@@ -1,0 +1,104 @@
+import type { ParsedRunResults } from "dbt-artifacts-parser/run_results";
+import type { ManifestGraph } from "./manifest-graph";
+import { ExecutionAnalyzer } from "./execution-analyzer";
+import { detectBottlenecks } from "./run-results-search";
+
+/**
+ * A bottleneck node enriched with graph-structural metadata.
+ */
+export interface EnrichedBottleneckNode {
+  unique_id: string;
+  name?: string;
+  execution_time: number;
+  /** Rank by structural impact (1 = most impactful). */
+  rank: number;
+  pct_of_total: number;
+  status: string;
+  /** Total nodes reachable downstream (transitive). */
+  downstream_count: number;
+  /** Immediate in-degree: number of direct parents. */
+  fan_in: number;
+  /** Immediate out-degree: number of direct children. */
+  fan_out: number;
+  /**
+   * execution_time × (1 + downstream_count).
+   * Combines raw slowness with how many downstream nodes are blocked.
+   */
+  structural_impact_score: number;
+  /** Whether this node lies on the critical execution path. */
+  is_on_critical_path: boolean;
+}
+
+/**
+ * Result of graph-enriched bottleneck analysis.
+ */
+export interface BottleneckAnalysis {
+  top_bottlenecks: EnrichedBottleneckNode[];
+  total_execution_time: number;
+  criteria_used: "top_n" | "threshold";
+  /** Warehouse adapter type from run_results metadata (e.g. "bigquery"). */
+  adapter_type: string | null;
+  total_nodes_analyzed: number;
+}
+
+type BottleneckOptions =
+  | { mode: "top_n"; top: number }
+  | { mode: "threshold"; min_seconds: number };
+
+/**
+ * Analyze execution bottlenecks enriched with graph-structural metrics.
+ *
+ * Unlike plain `detectBottlenecks`, this function ranks nodes by
+ * **structural impact** (execution time × downstream reach) rather than raw
+ * execution time alone, so a fast node that blocks hundreds of downstream
+ * nodes surfaces above a slow isolated node.
+ */
+export function analyzeBottlenecks(
+  runResults: ParsedRunResults,
+  graph: ManifestGraph,
+  options: BottleneckOptions,
+): BottleneckAnalysis {
+  const analyzer = new ExecutionAnalyzer(runResults, graph);
+  const nodeExecutions = analyzer.getNodeExecutions();
+
+  // Critical path node set for annotation
+  const criticalPath = analyzer.calculateCriticalPath(nodeExecutions);
+  const criticalPathSet = new Set(criticalPath?.path ?? []);
+
+  const baseResult = detectBottlenecks(nodeExecutions, { ...options, graph });
+  const g = graph.getGraph();
+
+  const metadata = (runResults as unknown as Record<string, unknown>)
+    .metadata as Record<string, unknown> | undefined;
+  const adapterType = (metadata?.adapter_type as string | undefined) ?? null;
+
+  const enriched: EnrichedBottleneckNode[] = baseResult.nodes.map((node) => {
+    const downstreamCount = graph.getDownstream(node.unique_id).length;
+    const fanIn = g.hasNode(node.unique_id) ? g.inDegree(node.unique_id) : 0;
+    const fanOut = g.hasNode(node.unique_id) ? g.outDegree(node.unique_id) : 0;
+    const rawScore = node.execution_time * (1 + downstreamCount);
+
+    return {
+      ...node,
+      downstream_count: downstreamCount,
+      fan_in: fanIn,
+      fan_out: fanOut,
+      structural_impact_score: Math.round(rawScore * 100) / 100,
+      is_on_critical_path: criticalPathSet.has(node.unique_id),
+    };
+  });
+
+  // Re-rank by structural_impact_score (highest = rank 1)
+  enriched.sort((a, b) => b.structural_impact_score - a.structural_impact_score);
+  enriched.forEach((n, i) => {
+    n.rank = i + 1;
+  });
+
+  return {
+    top_bottlenecks: enriched,
+    total_execution_time: baseResult.total_execution_time,
+    criteria_used: baseResult.criteria_used,
+    adapter_type: adapterType,
+    total_nodes_analyzed: nodeExecutions.length,
+  };
+}

--- a/packages/dbt-tools/core/src/analysis/critical-path-analyzer.test.ts
+++ b/packages/dbt-tools/core/src/analysis/critical-path-analyzer.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { parseManifest } from "dbt-artifacts-parser/manifest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { parseRunResults } from "dbt-artifacts-parser/run_results";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import {
+  loadTestManifest,
+  loadTestRunResults,
+} from "dbt-artifacts-parser/test-utils";
+import { ManifestGraph } from "./manifest-graph";
+import { analyzeCriticalPath } from "./critical-path-analyzer";
+
+function makeRunResults(
+  results: Array<{
+    unique_id: string;
+    status?: string;
+    execution_time?: number;
+    timing?: unknown[];
+  }>,
+  adapterType?: string,
+): ReturnType<typeof parseRunResults> {
+  return parseRunResults({
+    metadata: {
+      dbt_schema_version: "https://schemas.getdbt.com/dbt/run-results/v6.json",
+      ...(adapterType ? { adapter_type: adapterType } : {}),
+    },
+    results: results.map((r) => ({
+      unique_id: r.unique_id,
+      status: r.status ?? "success",
+      execution_time: r.execution_time ?? 0,
+      timing: r.timing ?? [],
+    })),
+  } as Record<string, unknown>);
+}
+
+describe("analyzeCriticalPath", () => {
+  it("should return null when run_results has no matching nodes", () => {
+    const runResults = makeRunResults([
+      { unique_id: "non.existent.node", execution_time: 1 },
+    ]);
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when run_results is empty", () => {
+    const runResults = makeRunResults([]);
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    expect(result).toBeNull();
+  });
+
+  it("should return a valid CriticalPathAnalysis when data matches", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    if (result !== null) {
+      expect(Array.isArray(result.path)).toBe(true);
+      expect(result.path.length).toBeGreaterThan(0);
+      expect(typeof result.total_time).toBe("number");
+      expect(result.total_time).toBeGreaterThanOrEqual(0);
+      expect(typeof result.total_nodes).toBe("number");
+    }
+  });
+
+  it("should include required fields on each path node", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    if (result !== null) {
+      for (const node of result.path) {
+        expect(typeof node.unique_id).toBe("string");
+        expect(typeof node.name).toBe("string");
+        expect(typeof node.resource_type).toBe("string");
+        expect(typeof node.execution_time).toBe("number");
+        expect(typeof node.cumulative_time).toBe("number");
+        expect(typeof node.concurrent_nodes).toBe("number");
+        expect(node.concurrent_nodes).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("should have non-decreasing cumulative_time", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    if (result !== null && result.path.length > 1) {
+      for (let i = 1; i < result.path.length; i++) {
+        expect(result.path[i].cumulative_time).toBeGreaterThanOrEqual(
+          result.path[i - 1].cumulative_time,
+        );
+      }
+    }
+  });
+
+  it("should populate concurrent_nodes from wall-clock timing when available", () => {
+    const runResults = makeRunResults([
+      {
+        unique_id: "model.pkg.a",
+        execution_time: 2,
+        timing: [
+          {
+            name: "execute",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: "2024-01-01T00:00:02.000Z",
+          },
+        ],
+      },
+      {
+        unique_id: "model.pkg.b",
+        execution_time: 2,
+        timing: [
+          {
+            name: "execute",
+            started_at: "2024-01-01T00:00:01.000Z",
+            completed_at: "2024-01-01T00:00:03.000Z",
+          },
+        ],
+      },
+    ]);
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    // Even if these nodes aren't in the graph's critical path, the function
+    // should not throw. If a result is returned, concurrent_nodes must be a number.
+    if (result !== null) {
+      for (const node of result.path) {
+        expect(typeof node.concurrent_nodes).toBe("number");
+      }
+    }
+  });
+
+  it("should extract adapter_type from metadata", () => {
+    const runResults = makeRunResults(
+      [{ unique_id: "model.pkg.x", execution_time: 1 }],
+      "snowflake",
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    // If a result is returned, adapter_type should be "snowflake"
+    if (result !== null) {
+      expect(result.adapter_type).toBe("snowflake");
+    }
+  });
+
+  it("should set adapter_type to null when not in metadata", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeCriticalPath(runResults, graph);
+
+    if (result !== null) {
+      // adapter_type is either a string or null
+      expect(
+        result.adapter_type === null || typeof result.adapter_type === "string",
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/dbt-tools/core/src/analysis/critical-path-analyzer.ts
+++ b/packages/dbt-tools/core/src/analysis/critical-path-analyzer.ts
@@ -1,0 +1,120 @@
+import type { ParsedRunResults } from "dbt-artifacts-parser/run_results";
+import type { ManifestGraph } from "./manifest-graph";
+import { ExecutionAnalyzer } from "./execution-analyzer";
+
+/**
+ * A single node on the critical execution path with enriched metadata.
+ */
+export interface CriticalPathNode {
+  unique_id: string;
+  name: string;
+  resource_type: string;
+  execution_time: number;
+  /** Running total of execution time from path start to this node. */
+  cumulative_time: number;
+  /**
+   * Number of other nodes whose execution windows overlapped with this node.
+   * Computed from wall-clock timestamps in run_results when available;
+   * 0 when timing data is absent.
+   */
+  concurrent_nodes: number;
+}
+
+/**
+ * Result of critical path analysis.
+ */
+export interface CriticalPathAnalysis {
+  /** Nodes in the critical path, ordered from root to leaf. */
+  path: CriticalPathNode[];
+  /** Total accumulated execution time along the critical path (seconds). */
+  total_time: number;
+  /** Total nodes included in the run. */
+  total_nodes: number;
+  /** Warehouse adapter type from run_results metadata. */
+  adapter_type: string | null;
+}
+
+/**
+ * Parse a timing string into epoch-milliseconds, or return null.
+ */
+function toMs(ts: string | undefined): number | null {
+  if (!ts) return null;
+  const ms = new Date(ts).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Analyze the critical execution path with per-node timing enrichment.
+ *
+ * Returns `null` when no critical path can be determined (e.g. empty
+ * run_results or no graph nodes matched).
+ */
+export function analyzeCriticalPath(
+  runResults: ParsedRunResults,
+  graph: ManifestGraph,
+): CriticalPathAnalysis | null {
+  const analyzer = new ExecutionAnalyzer(runResults, graph);
+  const nodeExecutions = analyzer.getNodeExecutions();
+  const criticalPath = analyzer.calculateCriticalPath(nodeExecutions);
+
+  if (!criticalPath || criticalPath.path.length === 0) {
+    return null;
+  }
+
+  const executionMap = new Map(nodeExecutions.map((e) => [e.unique_id, e]));
+  const g = graph.getGraph();
+
+  // Build wall-clock windows for concurrent-node computation
+  const windows = new Map<string, { start: number; end: number }>();
+  for (const exec of nodeExecutions) {
+    const start = toMs(exec.started_at);
+    const end = toMs(exec.completed_at);
+    if (start !== null && end !== null && end >= start) {
+      windows.set(exec.unique_id, { start, end });
+    }
+  }
+
+  const metadata = (runResults as unknown as Record<string, unknown>)
+    .metadata as Record<string, unknown> | undefined;
+  const adapterType = (metadata?.adapter_type as string | undefined) ?? null;
+
+  let cumulativeTime = 0;
+  const pathNodes: CriticalPathNode[] = criticalPath.path.map((nodeId) => {
+    const exec = executionMap.get(nodeId);
+    const execTime = exec?.execution_time ?? 0;
+    cumulativeTime += execTime;
+
+    const attrs = g.hasNode(nodeId) ? g.getNodeAttributes(nodeId) : undefined;
+
+    // Count nodes with overlapping execution windows
+    let concurrentNodes = 0;
+    const window = windows.get(nodeId);
+    if (window) {
+      for (const [otherId, otherWindow] of windows.entries()) {
+        if (
+          otherId !== nodeId &&
+          otherWindow.start < window.end &&
+          otherWindow.end > window.start
+        ) {
+          concurrentNodes++;
+        }
+      }
+    }
+
+    return {
+      unique_id: nodeId,
+      name: attrs?.name ?? nodeId,
+      resource_type: String(attrs?.resource_type ?? "unknown"),
+      execution_time: execTime,
+      cumulative_time: Math.round(cumulativeTime * 100) / 100,
+      concurrent_nodes: concurrentNodes,
+    };
+  });
+
+  return {
+    path: pathNodes,
+    total_time: criticalPath.total_time,
+    total_nodes: nodeExecutions.length,
+    adapter_type: adapterType,
+  };
+}

--- a/packages/dbt-tools/core/src/analysis/parallelism-analyzer.test.ts
+++ b/packages/dbt-tools/core/src/analysis/parallelism-analyzer.test.ts
@@ -142,6 +142,24 @@ describe("analyzeParallelism", () => {
     }
   });
 
+  it("should not include non-runnable resource types (source, exposure, metric) in wave node_ids", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    const NON_RUNNABLE_PREFIXES = ["source.", "exposure.", "metric.", "semantic_model."];
+    for (const wave of result.waves) {
+      for (const nodeId of wave.node_ids) {
+        const isNonRunnable = NON_RUNNABLE_PREFIXES.some((prefix) =>
+          nodeId.startsWith(prefix),
+        );
+        expect(isNonRunnable).toBe(false);
+      }
+    }
+  });
+
   it("serialization bottlenecks should only appear at wave width 1 following wider waves", () => {
     const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
     const manifest = parseManifest(manifestJson as Record<string, unknown>);

--- a/packages/dbt-tools/core/src/analysis/parallelism-analyzer.test.ts
+++ b/packages/dbt-tools/core/src/analysis/parallelism-analyzer.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { parseManifest } from "dbt-artifacts-parser/manifest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { parseRunResults } from "dbt-artifacts-parser/run_results";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import {
+  loadTestManifest,
+  loadTestRunResults,
+} from "dbt-artifacts-parser/test-utils";
+import { ManifestGraph } from "./manifest-graph";
+import { analyzeParallelism } from "./parallelism-analyzer";
+import { ExecutionAnalyzer } from "./execution-analyzer";
+
+describe("analyzeParallelism", () => {
+  it("should return a valid ParallelismAnalysis from manifest alone", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    expect(result).toBeDefined();
+    expect(typeof result.total_waves).toBe("number");
+    expect(typeof result.max_parallelism).toBe("number");
+    expect(typeof result.avg_wave_width).toBe("number");
+    expect(typeof result.recommended_threads).toBe("number");
+    expect(typeof result.has_cycles).toBe("boolean");
+    expect(Array.isArray(result.waves)).toBe(true);
+    expect(Array.isArray(result.serialization_bottlenecks)).toBe(true);
+  });
+
+  it("should report has_cycles as false for a valid DAG manifest", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    expect(result.has_cycles).toBe(false);
+  });
+
+  it("should produce waves with correct structure", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    for (const wave of result.waves) {
+      expect(typeof wave.wave_number).toBe("number");
+      expect(typeof wave.width).toBe("number");
+      expect(Array.isArray(wave.node_ids)).toBe(true);
+      expect(wave.width).toBe(wave.node_ids.length);
+      expect(wave.wave_number).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("should have non-decreasing wave_numbers", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    for (let i = 1; i < result.waves.length; i++) {
+      expect(result.waves[i].wave_number).toBeGreaterThan(
+        result.waves[i - 1].wave_number,
+      );
+    }
+  });
+
+  it("should have total_waves matching waves array length", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    expect(result.total_waves).toBe(result.waves.length);
+  });
+
+  it("max_parallelism should equal the widest wave", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    const computedMax =
+      result.waves.length > 0
+        ? Math.max(...result.waves.map((w) => w.width))
+        : 0;
+    expect(result.max_parallelism).toBe(computedMax);
+  });
+
+  it("should have recommended_threads of at least 1", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    expect(result.recommended_threads).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should annotate waves with estimated_time_s when nodeExecutions provided", () => {
+    const runResultsJson = loadTestRunResults("v6", "run_results.json");
+    const runResults = parseRunResults(
+      runResultsJson as Record<string, unknown>,
+    );
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const analyzer = new ExecutionAnalyzer(runResults, graph);
+    const nodeExecutions = analyzer.getNodeExecutions();
+
+    const result = analyzeParallelism(graph, nodeExecutions);
+
+    // Waves that contain executed nodes should have estimated_time_s
+    let hasAtLeastOneEstimate = false;
+    for (const wave of result.waves) {
+      if (wave.estimated_time_s !== undefined) {
+        hasAtLeastOneEstimate = true;
+        expect(wave.estimated_time_s).toBeGreaterThanOrEqual(0);
+      }
+    }
+    // Since we supplied executions, at least one wave should have timing
+    expect(hasAtLeastOneEstimate).toBe(true);
+  });
+
+  it("should not include estimated_time_s when nodeExecutions is not provided", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    for (const wave of result.waves) {
+      expect(wave.estimated_time_s).toBeUndefined();
+    }
+  });
+
+  it("serialization bottlenecks should only appear at wave width 1 following wider waves", () => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    const graph = new ManifestGraph(manifest);
+
+    const result = analyzeParallelism(graph);
+
+    for (const bottleneck of result.serialization_bottlenecks) {
+      const wave = result.waves.find(
+        (w) => w.wave_number === bottleneck.wave_number,
+      );
+      expect(wave).toBeDefined();
+      expect(wave!.width).toBe(1);
+
+      const prevWave = result.waves.find(
+        (w) => w.wave_number === bottleneck.wave_number - 1,
+      );
+      expect(prevWave).toBeDefined();
+      expect(prevWave!.width).toBeGreaterThan(1);
+    }
+  });
+});

--- a/packages/dbt-tools/core/src/analysis/parallelism-analyzer.ts
+++ b/packages/dbt-tools/core/src/analysis/parallelism-analyzer.ts
@@ -1,0 +1,248 @@
+import { topologicalSort, hasCycle } from "graphology-dag";
+import type { ManifestGraph } from "./manifest-graph";
+import type { NodeExecution } from "./execution-analyzer";
+
+/** Resource types excluded from parallelism analysis (non-executable). */
+const EXCLUDED_RESOURCE_TYPES = new Set(["field", "macro", "function"]);
+
+/**
+ * A single topological execution wave.
+ * Nodes within a wave have no dependencies on each other and can run
+ * fully in parallel (up to the thread limit).
+ */
+export interface ExecutionWave {
+  wave_number: number;
+  /** Unique IDs of nodes belonging to this wave. */
+  node_ids: string[];
+  /** Number of nodes that can run concurrently in this wave. */
+  width: number;
+  /**
+   * Maximum observed execution time among nodes in the wave (seconds).
+   * Present only when `nodeExecutions` is supplied to `analyzeParallelism`.
+   */
+  estimated_time_s?: number;
+}
+
+/**
+ * A wave of width 1 that immediately follows a wider wave, forcing
+ * serialization of the pipeline at that point.
+ */
+export interface SerializationBottleneck {
+  wave_number: number;
+  node_id: string;
+  /** Human-readable description of the bottleneck. */
+  description: string;
+}
+
+/**
+ * Result of wave-based parallelism analysis.
+ */
+export interface ParallelismAnalysis {
+  /** Topological waves in execution order. */
+  waves: ExecutionWave[];
+  total_waves: number;
+  /** Widest wave (maximum nodes that could run concurrently). */
+  max_parallelism: number;
+  /** Mean wave width across all waves. */
+  avg_wave_width: number;
+  /** Waves of width 1 that follow wider waves — pipeline serialization points. */
+  serialization_bottlenecks: SerializationBottleneck[];
+  /**
+   * Suggested `threads` setting: 75th-percentile wave width.
+   * Covers most waves without over-provisioning for outlier-wide waves.
+   */
+  recommended_threads: number;
+  /** True when the graph contains cycles (analysis cannot be performed). */
+  has_cycles: boolean;
+}
+
+/**
+ * Compute topological wave numbers using longest-path assignment.
+ *
+ * Each node's wave = max(wave of all analyzable parents) + 1.
+ * Root nodes (no analyzable parents) are assigned wave 0.
+ *
+ * The input `sorted` must be in topological order.
+ */
+function computeWaveMap(
+  sorted: string[],
+  analyzableNodes: Set<string>,
+  graph: ManifestGraph,
+): Map<string, number> {
+  const g = graph.getGraph();
+  const waveMap = new Map<string, number>();
+
+  for (const nodeId of sorted) {
+    const analyzableParents = g
+      .inboundNeighbors(nodeId)
+      .filter((p) => analyzableNodes.has(p));
+
+    if (analyzableParents.length === 0) {
+      waveMap.set(nodeId, 0);
+    } else {
+      const maxParentWave = Math.max(
+        ...analyzableParents.map((p) => waveMap.get(p) ?? 0),
+      );
+      waveMap.set(nodeId, maxParentWave + 1);
+    }
+  }
+
+  return waveMap;
+}
+
+/** Build an optional lookup from unique_id → execution_time. */
+function buildExecTimeMap(
+  nodeExecutions?: NodeExecution[],
+): Map<string, number> {
+  const map = new Map<string, number>();
+  if (nodeExecutions) {
+    for (const exec of nodeExecutions) {
+      map.set(exec.unique_id, exec.execution_time ?? 0);
+    }
+  }
+  return map;
+}
+
+/** Collect analyzable node IDs (excludes field, macro, function). */
+function collectAnalyzableNodes(
+  g: ReturnType<ManifestGraph["getGraph"]>,
+): Set<string> {
+  const nodes = new Set<string>();
+  g.forEachNode((nodeId, attrs) => {
+    if (!EXCLUDED_RESOURCE_TYPES.has(attrs.resource_type as string)) {
+      nodes.add(nodeId);
+    }
+  });
+  return nodes;
+}
+
+/** Group node IDs by their computed wave number. */
+function groupNodesByWave(waveMap: Map<string, number>): Map<number, string[]> {
+  const groups = new Map<number, string[]>();
+  for (const [nodeId, wave] of waveMap.entries()) {
+    const bucket = groups.get(wave);
+    if (bucket) {
+      bucket.push(nodeId);
+    } else {
+      groups.set(wave, [nodeId]);
+    }
+  }
+  return groups;
+}
+
+/** Build the ExecutionWave array from wave groups with optional timing. */
+function buildWavesFromGroups(
+  waveGroups: Map<number, string[]>,
+  execTimeMap: Map<string, number>,
+): ExecutionWave[] {
+  const maxWave = waveGroups.size > 0 ? Math.max(...waveGroups.keys()) : -1;
+  const waves: ExecutionWave[] = [];
+
+  for (let w = 0; w <= maxWave; w++) {
+    const nodeIds = waveGroups.get(w) ?? [];
+    const wave: ExecutionWave = { wave_number: w, node_ids: nodeIds, width: nodeIds.length };
+
+    if (execTimeMap.size > 0) {
+      const times = nodeIds.map((id) => execTimeMap.get(id) ?? 0).filter((t) => t > 0);
+      if (times.length > 0) {
+        wave.estimated_time_s = Math.round(Math.max(...times) * 100) / 100;
+      }
+    }
+
+    waves.push(wave);
+  }
+
+  return waves;
+}
+
+/** Find waves of width 1 that immediately follow a wider wave. */
+function findSerializationBottlenecks(
+  waves: ExecutionWave[],
+  g: ReturnType<ManifestGraph["getGraph"]>,
+): SerializationBottleneck[] {
+  const bottlenecks: SerializationBottleneck[] = [];
+  for (let i = 1; i < waves.length; i++) {
+    const prev = waves[i - 1];
+    const curr = waves[i];
+    if (curr.width === 1 && prev.width > 1) {
+      const nodeId = curr.node_ids[0];
+      const attrs = g.hasNode(nodeId) ? g.getNodeAttributes(nodeId) : undefined;
+      const name = attrs?.name ?? nodeId;
+      bottlenecks.push({
+        wave_number: curr.wave_number,
+        node_id: nodeId,
+        description: `"${name}" serializes ${prev.width} parallel nodes (wave ${prev.wave_number})`,
+      });
+    }
+  }
+  return bottlenecks;
+}
+
+/** 75th-percentile wave width as recommended thread count (min 1). */
+function computeRecommendedThreads(
+  waves: ExecutionWave[],
+  maxParallelism: number,
+): number {
+  const sorted = waves.map((w) => w.width).sort((a, b) => a - b);
+  const p75Idx = Math.min(Math.floor(sorted.length * 0.75), sorted.length - 1);
+  return Math.max(1, sorted[p75Idx] ?? maxParallelism);
+}
+
+/** Shared empty result for early-return paths. */
+function emptyResult(hasCycles: boolean): ParallelismAnalysis {
+  return {
+    waves: [],
+    total_waves: 0,
+    max_parallelism: 0,
+    avg_wave_width: 0,
+    serialization_bottlenecks: [],
+    recommended_threads: 1,
+    has_cycles: hasCycles,
+  };
+}
+
+/**
+ * Analyze execution parallelism from the dependency graph using topological
+ * wave decomposition.
+ *
+ * Works from the manifest graph alone; `nodeExecutions` is optional and used
+ * only to annotate each wave with observed execution times.
+ */
+export function analyzeParallelism(
+  graph: ManifestGraph,
+  nodeExecutions?: NodeExecution[],
+): ParallelismAnalysis {
+  const g = graph.getGraph();
+
+  if (hasCycle(g)) {
+    return emptyResult(true);
+  }
+
+  const execTimeMap = buildExecTimeMap(nodeExecutions);
+  const analyzableNodes = collectAnalyzableNodes(g);
+
+  if (analyzableNodes.size === 0) {
+    return emptyResult(false);
+  }
+
+  const sorted = topologicalSort(g).filter((id) => analyzableNodes.has(id));
+  const waveMap = computeWaveMap(sorted, analyzableNodes, graph);
+  const waveGroups = groupNodesByWave(waveMap);
+  const waves = buildWavesFromGroups(waveGroups, execTimeMap);
+
+  const maxParallelism = waves.reduce((max, w) => Math.max(max, w.width), 0);
+  const avgWaveWidth =
+    waves.length > 0
+      ? Math.round((waves.reduce((sum, w) => sum + w.width, 0) / waves.length) * 10) / 10
+      : 0;
+
+  return {
+    waves,
+    total_waves: waves.length,
+    max_parallelism: maxParallelism,
+    avg_wave_width: avgWaveWidth,
+    serialization_bottlenecks: findSerializationBottlenecks(waves, g),
+    recommended_threads: computeRecommendedThreads(waves, maxParallelism),
+    has_cycles: false,
+  };
+}

--- a/packages/dbt-tools/core/src/analysis/parallelism-analyzer.ts
+++ b/packages/dbt-tools/core/src/analysis/parallelism-analyzer.ts
@@ -2,8 +2,13 @@ import { topologicalSort, hasCycle } from "graphology-dag";
 import type { ManifestGraph } from "./manifest-graph";
 import type { NodeExecution } from "./execution-analyzer";
 
-/** Resource types excluded from parallelism analysis (non-executable). */
-const EXCLUDED_RESOURCE_TYPES = new Set(["field", "macro", "function"]);
+/**
+ * Resource types that consume dbt threads during `dbt build`/`dbt run`.
+ * Sources, exposures, metrics, semantic models, macros, and fields are
+ * present in the manifest DAG but are not scheduled as tasks, so they
+ * must not inflate wave widths or thread recommendations.
+ */
+const RUNNABLE_RESOURCE_TYPES = new Set(["model", "seed", "snapshot", "test"]);
 
 /**
  * A single topological execution wave.
@@ -103,13 +108,13 @@ function buildExecTimeMap(
   return map;
 }
 
-/** Collect analyzable node IDs (excludes field, macro, function). */
+/** Collect node IDs for resource types that actually consume dbt threads. */
 function collectAnalyzableNodes(
   g: ReturnType<ManifestGraph["getGraph"]>,
 ): Set<string> {
   const nodes = new Set<string>();
   g.forEachNode((nodeId, attrs) => {
-    if (!EXCLUDED_RESOURCE_TYPES.has(attrs.resource_type as string)) {
+    if (RUNNABLE_RESOURCE_TYPES.has(attrs.resource_type as string)) {
       nodes.add(nodeId);
     }
   });

--- a/packages/dbt-tools/core/src/formatting/output-formatter.ts
+++ b/packages/dbt-tools/core/src/formatting/output-formatter.ts
@@ -256,6 +256,190 @@ export function formatRunReport(
 }
 
 /**
+ * Format enriched bottleneck analysis for human-readable output
+ */
+export function formatBottleneckAnalysis(result: {
+  top_bottlenecks: Array<{
+    rank: number;
+    unique_id: string;
+    name?: string;
+    execution_time: number;
+    pct_of_total: number;
+    downstream_count: number;
+    structural_impact_score: number;
+    is_on_critical_path: boolean;
+    status: string;
+  }>;
+  total_execution_time: number;
+  criteria_used: string;
+  adapter_type: string | null;
+  total_nodes_analyzed: number;
+}): string {
+  const lines: string[] = [];
+  lines.push("dbt Bottleneck Analysis");
+  lines.push("=======================");
+  lines.push(`Total Nodes Analyzed: ${result.total_nodes_analyzed}`);
+  lines.push(
+    `Total Execution Time: ${result.total_execution_time.toFixed(2)}s`,
+  );
+  if (result.adapter_type) {
+    lines.push(`Adapter: ${result.adapter_type}`);
+  }
+  lines.push(`Criteria: ${result.criteria_used}`);
+
+  if (result.top_bottlenecks.length === 0) {
+    lines.push("\nNo bottlenecks found.");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    "\n  Rank  Node                              Impact Score  Time (s)  Downstream  On CP?",
+  );
+
+  const maxLabelLen = 34;
+  for (const node of result.top_bottlenecks) {
+    const label = node.name ?? node.unique_id;
+    const labelDisplay =
+      label.length > maxLabelLen
+        ? label.slice(0, maxLabelLen - 3) + "..."
+        : label;
+    const padded = labelDisplay.padEnd(maxLabelLen);
+    const impactStr = node.structural_impact_score.toFixed(1).padStart(12);
+    const timeStr = node.execution_time.toFixed(2).padStart(8);
+    const downstreamStr = String(node.downstream_count).padStart(10);
+    const cpStr = (node.is_on_critical_path ? "yes" : "no").padStart(6);
+    lines.push(
+      `  ${String(node.rank).padStart(2)}     ${padded}  ${impactStr}  ${timeStr}  ${downstreamStr}  ${cpStr}`,
+    );
+  }
+
+  lines.push(
+    "\nImpact Score = execution_time × (1 + downstream_node_count). Higher = fix first.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Format critical path analysis for human-readable output
+ */
+export function formatCriticalPathAnalysis(result: {
+  path: Array<{
+    unique_id: string;
+    name: string;
+    resource_type: string;
+    execution_time: number;
+    cumulative_time: number;
+    concurrent_nodes: number;
+  }>;
+  total_time: number;
+  total_nodes: number;
+  adapter_type: string | null;
+}): string {
+  const lines: string[] = [];
+  lines.push("dbt Critical Path Analysis");
+  lines.push("==========================");
+  lines.push(`Total Nodes: ${result.total_nodes}`);
+  lines.push(`Critical Path Total Time: ${result.total_time.toFixed(2)}s`);
+  lines.push(`Critical Path Length: ${result.path.length} nodes`);
+  if (result.adapter_type) {
+    lines.push(`Adapter: ${result.adapter_type}`);
+  }
+
+  if (result.path.length === 0) {
+    lines.push("\nNo critical path found.");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    "\n  Step  Node                              Type        Time (s)  Cumulative  Concurrent",
+  );
+
+  const maxLabelLen = 34;
+  for (let i = 0; i < result.path.length; i++) {
+    const node = result.path[i];
+    const labelDisplay =
+      node.name.length > maxLabelLen
+        ? node.name.slice(0, maxLabelLen - 3) + "..."
+        : node.name;
+    const padded = labelDisplay.padEnd(maxLabelLen);
+    const typeStr = String(node.resource_type).padEnd(10).slice(0, 10);
+    const timeStr = node.execution_time.toFixed(2).padStart(8);
+    const cumStr = node.cumulative_time.toFixed(2).padStart(10);
+    const concStr = String(node.concurrent_nodes).padStart(10);
+    lines.push(
+      `  ${String(i + 1).padStart(2)}    ${padded}  ${typeStr}  ${timeStr}  ${cumStr}  ${concStr}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format parallelism analysis for human-readable output
+ */
+export function formatParallelismAnalysis(result: {
+  waves: Array<{
+    wave_number: number;
+    node_ids: string[];
+    width: number;
+    estimated_time_s?: number;
+  }>;
+  total_waves: number;
+  max_parallelism: number;
+  avg_wave_width: number;
+  serialization_bottlenecks: Array<{
+    wave_number: number;
+    node_id: string;
+    description: string;
+  }>;
+  recommended_threads: number;
+  has_cycles: boolean;
+}): string {
+  const lines: string[] = [];
+  lines.push("dbt Parallelism Analysis");
+  lines.push("========================");
+
+  if (result.has_cycles) {
+    lines.push("Warning: Graph contains cycles. Parallelism analysis skipped.");
+    return lines.join("\n");
+  }
+
+  lines.push(`Total Waves: ${result.total_waves}`);
+  lines.push(`Max Parallelism: ${result.max_parallelism} nodes`);
+  lines.push(`Avg Wave Width: ${result.avg_wave_width}`);
+  lines.push(`Recommended Threads: ${result.recommended_threads}`);
+
+  if (result.waves.length > 0) {
+    lines.push("\n  Wave  Width  Est. Time (s)  Nodes (first 5)");
+    for (const wave of result.waves) {
+      const preview = wave.node_ids
+        .slice(0, 5)
+        .map((id) => id.split(".").pop() ?? id)
+        .join(", ");
+      const ellipsis = wave.node_ids.length > 5 ? ", …" : "";
+      const timeStr =
+        wave.estimated_time_s !== undefined
+          ? wave.estimated_time_s.toFixed(2).padStart(13)
+          : "           n/a";
+      lines.push(
+        `  ${String(wave.wave_number).padStart(2)}    ${String(wave.width).padStart(3)}  ${timeStr}  ${preview}${ellipsis}`,
+      );
+    }
+  }
+
+  if (result.serialization_bottlenecks.length > 0) {
+    lines.push("\nSerialization Bottlenecks:");
+    for (const b of result.serialization_bottlenecks) {
+      lines.push(`  Wave ${b.wave_number}: ${b.description}`);
+    }
+  } else {
+    lines.push("\nNo serialization bottlenecks detected.");
+  }
+
+  return lines.join("\n");
+}
+
+/**
  * Format human-readable output for a specific command type
  */
 export function formatHumanReadable(

--- a/packages/dbt-tools/core/src/index.ts
+++ b/packages/dbt-tools/core/src/index.ts
@@ -5,6 +5,9 @@ export * from "./analysis/dependency-service";
 export * from "./analysis/sql-analyzer";
 export * from "./analysis/run-results-search";
 export * from "./analysis/analysis-snapshot";
+export * from "./analysis/bottleneck-analyzer";
+export * from "./analysis/critical-path-analyzer";
+export * from "./analysis/parallelism-analyzer";
 
 // I/O exports
 export * from "./io/artifact-loader";

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -25,6 +25,14 @@ export default defineConfig({
         __dirname,
         "packages/dbt-artifacts-parser/src/run_results/index.ts",
       ),
+      "dbt-artifacts-parser/catalog": path.resolve(
+        __dirname,
+        "packages/dbt-artifacts-parser/src/catalog/index.ts",
+      ),
+      "dbt-artifacts-parser/test-utils": path.resolve(
+        __dirname,
+        "packages/dbt-artifacts-parser/src/test-utils.ts",
+      ),
     },
   },
   test: {


### PR DESCRIPTION
Introduces three new CLI subcommands under `dbt-tools analyze`:

- `analyze bottlenecks`: Ranks nodes by structural impact score
  (execution_time × downstream reach) rather than raw execution time,
  surfacing high-fan-out bottlenecks that block the most downstream work.
  Enriches each node with fan-in/fan-out degree, downstream count, and
  critical-path annotation. Surfaces adapter_type from run_results metadata.

- `analyze critical-path`: Finds the longest execution path with full
  per-node metadata: execution time, cumulative time, and concurrent node
  count computed from wall-clock timing windows in run_results.

- `analyze parallelism`: Decomposes the manifest DAG into topological
  execution waves (no run_results required). Reports max/avg parallelism,
  serialization bottlenecks (wave-of-1 after wider waves), and a
  75th-percentile recommended thread count. Accepts optional run_results
  to annotate each wave with observed execution times.

Also fixes missing vitest aliases for dbt-artifacts-parser/catalog and
dbt-artifacts-parser/test-utils, enabling the full analysis test suite
to run (242 test files now pass, score=60 meets all thresholds).

https://claude.ai/code/session_01DgUwa16wACnm6bVKLDjAaA