### PR TITLE
Add security signal workflows, npm provenance publishing, and badges

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,27 +19,48 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "35 3 * * 1"
 
 concurrency:
   group: codeql-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:
-  security-events: write
   actions: read
   contents: read
+  security-events: write
 
 jobs:
   analyze:
-    name: CodeQL Analysis
+    name: CodeQL analysis (JavaScript/TypeScript)
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.1.0
+        with:
+          node-version-file: .node-version
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: javascript-typescript
-      - name: Perform CodeQL Analysis
+
+      - name: Build workspace for CodeQL
+        run: pnpm build
+
+      - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/publish-dbt-artifacts-parser.yml
+++ b/.github/workflows/publish-dbt-artifacts-parser.yml
@@ -52,8 +52,6 @@ jobs:
       - name: Run tests
         run: |
           pnpm --filter ./packages/dbt-artifacts-parser test
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (trusted publishing + provenance)
         run: |
-          pnpm publish --filter ./packages/dbt-artifacts-parser --no-git-checks --access public
+          pnpm publish --filter ./packages/dbt-artifacts-parser --no-git-checks --access public --provenance

--- a/.github/workflows/publish-dbt-tools.yml
+++ b/.github/workflows/publish-dbt-tools.yml
@@ -57,10 +57,8 @@ jobs:
         run: |
           pnpm --filter @dbt-tools/core test
           pnpm --filter @dbt-tools/cli test
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (trusted publishing + provenance)
         run: |
-          pnpm publish --filter @dbt-tools/core --no-git-checks --access public
-          pnpm publish --filter @dbt-tools/cli --no-git-checks --access public
-          pnpm publish --filter @dbt-tools/web --no-git-checks --access public
+          pnpm publish --filter @dbt-tools/core --no-git-checks --access public --provenance
+          pnpm publish --filter @dbt-tools/cli --no-git-checks --access public --provenance
+          pnpm publish --filter @dbt-tools/web --no-git-checks --access public --provenance

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,39 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "15 5 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/supply-chain-checks.yml
+++ b/.github/workflows/supply-chain-checks.yml
@@ -25,13 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
-          comment-summary-in-pr: on-failure
 
   osv-scan:
     name: OSV scan (full dependency graph)

--- a/.github/workflows/supply-chain-checks.yml
+++ b/.github/workflows/supply-chain-checks.yml
@@ -1,0 +1,51 @@
+name: Supply chain checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "20 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supply-chain-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review (PR gate)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
+  osv-scan:
+    name: OSV scan (full dependency graph)
+    if: github.event_name != 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1
+    with:
+      scan-args: |-
+        --lockfile=pnpm-lock.yaml
+        --recursive
+        .
+      fail-on-vuln: true
+      upload-sarif: true
+      results-file-name: osv-results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # dbt-artifacts-parser-ts
 
+[![Test](https://github.com/yu-iskw/dbt-artifacts-parser-ts/actions/workflows/test.yml/badge.svg)](https://github.com/yu-iskw/dbt-artifacts-parser-ts/actions/workflows/test.yml)
+[![CodeQL](https://github.com/yu-iskw/dbt-artifacts-parser-ts/actions/workflows/codeql.yml/badge.svg)](https://github.com/yu-iskw/dbt-artifacts-parser-ts/actions/workflows/codeql.yml)
+[![Supply chain checks](https://github.com/yu-iskw/dbt-artifacts-parser-ts/actions/workflows/supply-chain-checks.yml/badge.svg)](https://github.com/yu-iskw/dbt-artifacts-parser-ts/actions/workflows/supply-chain-checks.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/yu-iskw/dbt-artifacts-parser-ts/badge)](https://scorecard.dev/viewer/?uri=github.com/yu-iskw/dbt-artifacts-parser-ts)
+[![npm dbt-artifacts-parser](https://img.shields.io/npm/v/dbt-artifacts-parser)](https://www.npmjs.com/package/dbt-artifacts-parser)
+[![npm @dbt-tools/cli](https://img.shields.io/npm/v/%40dbt-tools%2Fcli)](https://www.npmjs.com/package/@dbt-tools/cli)
+[![npm @dbt-tools/web](https://img.shields.io/npm/v/%40dbt-tools%2Fweb)](https://www.npmjs.com/package/@dbt-tools/web)
+
+> Security signals shown here are evidence of current release and scanning workflows, not proof of absence of defects or malicious behavior. npm releases are configured for provenance via GitHub Actions OIDC trusted publishing, repository code is continuously analyzed, and dependency changes are checked before merge.
+
 A TypeScript monorepo for parsing and analyzing [dbt](https://www.getdbt.com/) artifacts.
 
 This repo contains two distinct but related ecosystems:
@@ -63,6 +73,14 @@ dbt-tools-web --target ./target   # or: npx @dbt-tools/web --target ./target
 ```
 
 See [`packages/dbt-tools/web/README.md`](./packages/dbt-tools/web/README.md) for configuration (`DBT_TOOLS_REMOTE_SOURCE`, debugging, Docker pointers).
+
+---
+
+## Release provenance (npm)
+
+Public npm packages published from this repository are intended to use npm trusted publishing from GitHub Actions with OIDC and provenance enabled. This helps consumers trace a published package back to this repository and workflow run, but it does not prove that software is defect-free or non-malicious on its own.
+
+See [docs/security-signals.md](./docs/security-signals.md) for the security signal model, workflow coverage, and manual setup steps.
 
 ---
 

--- a/docs/security-signals.md
+++ b/docs/security-signals.md
@@ -1,0 +1,60 @@
+# Security signals for dbt-artifacts-parser-ts
+
+This document describes the repository’s **trust signals** for released npm packages and source code scanning. These signals help consumers evaluate traceability and security process maturity. They are not proof of total safety.
+
+## What was implemented
+
+- **npm trusted publishing + provenance** in release workflows for:
+  - `dbt-artifacts-parser`
+  - `@dbt-tools/core`
+  - `@dbt-tools/cli`
+  - `@dbt-tools/web`
+- **CodeQL** workflow for JavaScript/TypeScript on `main`, pull requests to `main`, and weekly schedule.
+- **Dependency Review** PR gate to block introduction of known vulnerable dependencies above configured severity.
+- **OSV-Scanner** scheduled/full scans over the monorepo dependency graph (`pnpm-lock.yaml`) with SARIF upload.
+- **OpenSSF Scorecard** workflow and public Scorecard badge.
+- Root and package README updates to surface these signals to both GitHub readers and npm package-page readers.
+
+## What each badge/workflow does
+
+- **Test badge (`test.yml`)**
+  - Shows whether CI test/build checks currently pass.
+- **CodeQL badge (`codeql.yml`)**
+  - Indicates status of static security analysis for JavaScript/TypeScript.
+- **Supply chain checks badge (`supply-chain-checks.yml`)**
+  - Aggregates dependency review gating on PRs and scheduled OSV dependency vulnerability scans.
+- **OpenSSF Scorecard badge**
+  - Reflects Scorecard’s repository-level posture checks (for example branch protection and workflow hygiene).
+- **npm version badges**
+  - Show currently published package versions on npm for key end-user packages.
+
+## What these signals do NOT prove
+
+These signals do **not** prove:
+
+- absence of vulnerabilities,
+- absence of malicious code,
+- perfect dependency hygiene,
+- suitability for every environment or threat model.
+
+They provide evidence of process, traceability, and ongoing checks.
+
+## Manual setup still required (GitHub/npm settings)
+
+Trusted publishing cannot be fully enabled from repository files alone. A maintainer must configure npm trusted publishers for each package:
+
+1. In npm package settings, add a trusted publisher for repository `yu-iskw/dbt-artifacts-parser-ts`.
+2. Bind each published package to its corresponding workflow file:
+   - `.github/workflows/publish-dbt-artifacts-parser.yml`
+   - `.github/workflows/publish-dbt-tools.yml`
+3. Ensure package visibility/access settings remain public where intended.
+4. After trusted publishers are active and validated, remove any no-longer-needed long-lived `NPM_TOKEN` secrets from GitHub repository/org settings.
+
+Optional hardening steps:
+
+- Enforce branch protection and required status checks for `main`.
+- Enable GitHub Advanced Security features in repository/org settings if not already enabled.
+
+## Why this is a trust/evidence model (not proof)
+
+Software supply-chain trust is probabilistic and layered. Provenance and CI scans increase accountability and detection coverage, but they do not mathematically prove software is free from defects or malicious behavior. This repo therefore presents these controls as **evidence signals** so users can make informed risk decisions.

--- a/packages/dbt-artifacts-parser/README.md
+++ b/packages/dbt-artifacts-parser/README.md
@@ -17,6 +17,14 @@ graph LR
 
 ---
 
+## Trust & security signals
+
+Published npm releases for **dbt-artifacts-parser** are intended to be produced by GitHub Actions using npm trusted publishing (OIDC) with provenance enabled. Repository code is continuously scanned (CodeQL), pull requests are checked for newly introduced vulnerable dependencies, and scheduled dependency scans run against the monorepo lockfile. These are evidence signals about process and traceability, not proof that defects or malicious behavior are impossible.
+
+Details: [Security signals](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/docs/security-signals.md)
+
+---
+
 ## Installation
 
 ```bash

--- a/packages/dbt-tools/cli/README.md
+++ b/packages/dbt-tools/cli/README.md
@@ -24,6 +24,14 @@ graph TD
 
 ---
 
+## Trust & security signals
+
+Published npm releases for **@dbt-tools/cli** are intended to be produced by GitHub Actions using npm trusted publishing (OIDC) with provenance enabled. Repository code is continuously scanned (CodeQL), pull requests are checked for newly introduced vulnerable dependencies, and scheduled dependency scans run against the monorepo lockfile. These are evidence signals about process and traceability, not proof that defects or malicious behavior are impossible.
+
+Details: [Security signals](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/docs/security-signals.md)
+
+---
+
 ## Installation
 
 ```bash

--- a/packages/dbt-tools/web/README.md
+++ b/packages/dbt-tools/web/README.md
@@ -8,6 +8,14 @@ Full operator topics (Docker, GHCR, remote sources, Vite-only options) live in t
 
 ---
 
+## Trust & security signals
+
+Published npm releases for **@dbt-tools/web** are intended to be produced by GitHub Actions using npm trusted publishing (OIDC) with provenance enabled. Repository code is continuously scanned (CodeQL), pull requests are checked for newly introduced vulnerable dependencies, and scheduled dependency scans run against the monorepo lockfile. These are evidence signals about process and traceability, not proof that defects or malicious behavior are impossible.
+
+Details: [Security signals](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/docs/security-signals.md)
+
+---
+
 ## Prerequisites
 
 - **Node.js** — use the version in [`.node-version`](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/.node-version) when developing; **Node.js 20+** is required to run the published app (Node 18 is EOL — see [Node.js releases](https://nodejs.org/en/about/previous-releases)).


### PR DESCRIPTION
### Motivation

- Provide end-user facing, defensible security signals (provenance for published npm packages, continuous static analysis, dependency vulnerability checks, and repository posture signals) without overstating guarantees. 
- Prefer official/first-party mechanisms (GitHub Actions OIDC provenance, CodeQL, Dependency Review, OSV, OpenSSF Scorecard) and document any remaining manual steps required to enable them.

### Description

- Publish workflows updated so release publishes use npm trusted-publishing-compatible steps with provenance (`--provenance`) and no in-step `NPM_TOKEN` usage, and CodeQL workflow was updated to build the workspace and run on pushes, PRs to `main` and on a weekly schedule. 
- Added a new `Supply chain checks` workflow that gates PRs with `actions/dependency-review-action` and runs a scheduled full OSV scan via the `google/osv-scanner-action` reusable workflow with SARIF upload. 
- Added an OpenSSF Scorecard workflow using `ossf/scorecard-action` and SARIF upload, and added repository-level badges and a concise, non-overstated badge section to the root README and package READMEs. 
- Added `docs/security-signals.md` documenting what was implemented, what each workflow/badge does and does not prove, and the manual npm/GitHub setup steps required to enable trusted publishing for each package; changed files include the updated workflows and the new `scorecard.yml`, `supply-chain-checks.yml`, README updates, and package README notes.

### Testing

- Ran formatting check: `pnpm exec prettier --check` on changed files (OK). 
- Ran lint report: `pnpm lint:report` which wrote `lint-report.json` with score=100 (OK). 
- Ran unit tests and coverage: `pnpm test` / `pnpm coverage:report` (tests passed, coverage report generated; overall coverage reported and written to `coverage-report.json`). 
- Built packages: `pnpm --filter ./packages/dbt-artifacts-parser build` and `pnpm --filter @dbt-tools/core build` (both succeeded) and ran `pnpm knip` after building (succeeded). 
- Verified badge and workflow endpoints with `curl`; most badge endpoints resolved, and the new supply-chain badge may 404 until the new workflow exists on the default branch (expected pre-merge behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27662d7b8832c9a57c0272949c35f)