### PR TITLE
feat(cli): add inventory/timeline/search/status and focused graph export

### DIFF
--- a/packages/dbt-tools/cli/README.md
+++ b/packages/dbt-tools/cli/README.md
@@ -10,14 +10,22 @@ Command-line interface for dbt artifact analysis. Optimized for both human and A
 graph TD
   CLI["dbt-tools"]
   CLI --> summary["summary\nmanifest statistics"]
+  CLI --> inventory["inventory\nresource inventory + filters"]
   CLI --> graphCmd["graph\nexport dependency graph"]
+  CLI --> timeline["timeline\nrow-level execution timeline"]
+  CLI --> search["search\nmanifest resource search"]
   CLI --> rr["run-report\nexecution report"]
+  CLI --> status["status/freshness\nartifact readiness + recency"]
   CLI --> deps["deps\nupstream / downstream deps"]
   CLI --> schema["schema\nruntime introspection"]
 
   summary -->|manifest.json| MG[ManifestGraph]
   graphCmd -->|manifest.json| MG
+  inventory -->|manifest.json| MG
+  search -->|manifest.json| MG
   rr -->|run_results.json\n+ manifest.json| EA[ExecutionAnalyzer]
+  timeline -->|run_results.json| EA
+  status -->|artifact files| FS[Local filesystem]
   deps -->|manifest.json| DS[DependencyService]
   schema -.->|describes| CLI
 ```
@@ -40,6 +48,9 @@ pnpm add -g @dbt-tools/cli
 - **Field filtering**: Reduce context window usage with `--fields` option
 - **Schema introspection**: Runtime command discovery via `schema` command
 - **Dependency analysis**: Find upstream/downstream dependencies with `deps` command
+- **Inventory and search**: Discover/filter dbt resources from manifest metadata
+- **Timeline rows**: Inspect per-node execution entries (`timeline`) beyond aggregated `run-report`
+- **Artifact readiness**: Check local artifact presence/freshness via `status` / `freshness`
 
 ---
 
@@ -93,6 +104,12 @@ dbt-tools graph --format json --fields "name,resource_type"
 
 # Custom target directory
 dbt-tools graph --target-dir ./custom-target
+
+# Focus to a node-centered subgraph
+dbt-tools graph --focus model.my_project.orders --depth 2 --direction upstream
+
+# Focus by selector and keep selected resource types
+dbt-tools graph --focus tag:finance --direction both --resource-types model,test
 ```
 
 **Options:**
@@ -102,6 +119,12 @@ dbt-tools graph --target-dir ./custom-target
 - `--output <path>` - Output file path (default: stdout)
 - `--target-dir <dir>` - Custom target directory
 - `--fields <fields>` - Comma-separated list of fields to include (affects JSON nodes)
+- `--field-level` - Include field-level lineage (requires catalog.json)
+- `--catalog-path <path>` - Path to catalog.json file
+- `--focus <selector>` - Focus graph export on a node or selector (`tag:...`, `type:...`, `package:...`, `path:...`)
+- `--depth <number>` - Max traversal depth for focused export
+- `--direction <direction>` - Focus traversal direction: `upstream`, `downstream`, or `both`
+- `--resource-types <types>` - Comma-separated resource type filter for focused export
 
 ### run-report
 
@@ -129,6 +152,8 @@ dbt-tools run-report ./custom/run_results.json ./custom/manifest.json
 # JSON output
 dbt-tools run-report --json
 ```
+
+`run-report` is aggregate-first (totals/status/bottlenecks). Use `timeline` for row-level per-node execution entries.
 
 **Options:**
 
@@ -199,6 +224,97 @@ dbt-tools deps model.my_project.customers --manifest-path ./custom/manifest.json
   "count": 1
 }
 ```
+
+### inventory
+
+List/filter dbt resources in `manifest.json`.
+
+```bash
+dbt-tools inventory
+dbt-tools inventory --type model
+dbt-tools inventory --type test --status fail
+dbt-tools inventory --tag finance --fields unique_id,name,path
+dbt-tools inventory --package my_project --format table
+```
+
+**Options:**
+
+- `--manifest-path <path>` - Path to manifest.json
+- `--run-results-path <path>` - Path to run_results.json (optional; enables `--status`)
+- `--target-dir <dir>` - Custom target directory
+- `--type <type>` - Filter by resource type
+- `--package <package>` - Filter by package name
+- `--tag <tag>` - Filter by tag
+- `--path <path>` - Filter by path substring
+- `--owner <owner>` - Filter by owner metadata (when available)
+- `--group <group>` - Filter by group metadata (when available)
+- `--status <status>` - Filter by run status (when run_results is available)
+- `--fields <fields>` - Projected fields (comma-separated)
+- `--format <format>` - `json` or `table`
+- `--json` / `--no-json` - Force output style
+
+### timeline
+
+Show row-level execution timeline entries from `run_results.json`.
+
+```bash
+dbt-tools timeline
+dbt-tools timeline --sort duration --top 20
+dbt-tools timeline --failed-only
+dbt-tools timeline --status error,fail --format table
+dbt-tools timeline --format csv
+```
+
+**Options:**
+
+- `--manifest-path <path>` - Optional manifest path for name/type enrichment
+- `--run-results-path <path>` - Path to run_results.json
+- `--target-dir <dir>` - Custom target directory
+- `--sort <sort>` - `duration` (default) or `start`
+- `--top <n>` - Top N rows after sorting
+- `--failed-only` - Keep failed/error/warn rows
+- `--status <status>` - Status filter (comma-separated)
+- `--format <format>` - `json`, `table`, or `csv`
+- `--json` / `--no-json` - Force output style
+
+### search
+
+Search manifest entities by ID/name/package/tag/path.
+
+```bash
+dbt-tools search orders
+dbt-tools search tag:finance
+dbt-tools search type:model orders
+dbt-tools search package:core source:stripe
+```
+
+**Options:**
+
+- `[terms...]` - Free-text and/or scoped terms (`type:`, `package:`, `tag:`, `path:`)
+- `--manifest-path <path>` - Path to manifest.json
+- `--target-dir <dir>` - Custom target directory
+- `--type <type>` / `--package <package>` / `--tag <tag>` / `--path <path>` - Structured filters
+- `--top <n>` - Limit results
+- `--format <format>` - `json` or `table`
+- `--json` / `--no-json` - Force output style
+
+### status / freshness
+
+Report local artifact file presence, readiness, and recency.
+
+```bash
+dbt-tools status
+dbt-tools status --target-dir ./target
+dbt-tools freshness --json
+```
+
+Interpretation:
+
+- `not-ready`: no manifest found
+- `manifest-ready`: manifest exists; execution analysis requiring run_results is unavailable
+- `execution-ready`: both manifest and run_results are present
+
+The command also returns `modified_at` / `age_seconds` for each artifact and the freshest available artifact.
 
 ### schema
 

--- a/packages/dbt-tools/cli/src/cli-actions.ts
+++ b/packages/dbt-tools/cli/src/cli-actions.ts
@@ -1,2 +1,9 @@
 export { runReportAction } from "./run-report-action";
 export { depsAction } from "./deps-action";
+export {
+  inventoryAction,
+  timelineAction,
+  searchAction,
+  statusAction,
+  graphAction,
+} from "./extended-actions";

--- a/packages/dbt-tools/cli/src/cli.test.ts
+++ b/packages/dbt-tools/cli/src/cli.test.ts
@@ -37,6 +37,11 @@ describe("CLI Integration", () => {
       expect(schemas).toHaveProperty("graph");
       expect(schemas).toHaveProperty("run-report");
       expect(schemas).toHaveProperty("schema");
+      expect(schemas).toHaveProperty("inventory");
+      expect(schemas).toHaveProperty("timeline");
+      expect(schemas).toHaveProperty("search");
+      expect(schemas).toHaveProperty("status");
+      expect(schemas).toHaveProperty("freshness");
     });
 
     it("should have correct deps command schema", () => {

--- a/packages/dbt-tools/cli/src/cli.ts
+++ b/packages/dbt-tools/cli/src/cli.ts
@@ -5,7 +5,6 @@ import {
   ManifestGraph,
   resolveArtifactPaths,
   loadManifest,
-  loadCatalog,
   validateSafePath,
   isTTY,
   shouldOutputJSON,
@@ -13,14 +12,18 @@ import {
   formatSummary,
   FieldFilter,
   ErrorHandler,
-  SQLAnalyzer,
-  sqlDialectFromDbtAdapterType,
   getCommandSchema,
   getAllSchemas,
-  exportGraphToFormat,
-  writeGraphOutput,
 } from "@dbt-tools/core";
-import { runReportAction, depsAction } from "./cli-actions";
+import {
+  runReportAction,
+  depsAction,
+  inventoryAction,
+  timelineAction,
+  searchAction,
+  statusAction,
+  graphAction,
+} from "./cli-actions";
 import { CLI_PACKAGE_VERSION } from "./version";
 
 const program = new Command();
@@ -60,46 +63,6 @@ function handleError(error: unknown, isTTY: boolean): void {
     console.error(JSON.stringify(formatted, null, 2));
   }
   process.exit(1);
-}
-
-function tryApplyFieldLevelLineageToGraph(
-  graph: ManifestGraph,
-  manifest: ReturnType<typeof loadManifest>,
-  catalogPath: string,
-): void {
-  validateSafePath(catalogPath);
-  let catalog: ReturnType<typeof loadCatalog> | undefined;
-  try {
-    catalog = loadCatalog(catalogPath);
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : "";
-    if (msg.startsWith("Catalog file not found:")) {
-      console.warn(
-        "Warning: --field-level requires catalog.json, but it was not found. Falling back to resource-level lineage.",
-      );
-      return;
-    }
-    throw error;
-  }
-  graph.addFieldNodes(catalog);
-
-  const analyzer = new SQLAnalyzer();
-  const adapterType = (
-    manifest.metadata as { adapter_type?: string } | undefined
-  )?.adapter_type;
-  const sqlDialect = sqlDialectFromDbtAdapterType(adapterType);
-
-  if (manifest.nodes) {
-    for (const [uniqueId, node] of Object.entries(manifest.nodes)) {
-      const compiledCode = (node as Record<string, unknown>).compiled_code as
-        | string
-        | undefined;
-      if (compiledCode) {
-        const fieldDeps = analyzer.analyze(compiledCode, sqlDialect);
-        graph.addFieldEdges(uniqueId, fieldDeps);
-      }
-    }
-  }
 }
 
 /**
@@ -173,6 +136,17 @@ program
   .option(OPT_FIELDS, DESC_FIELDS)
   .option("--field-level", "Include field-level (column-level) lineage")
   .option("--catalog-path <path>", "Path to catalog.json file")
+  .option("--focus <selector>", "Focus graph export on a node or selector")
+  .option("--depth <number>", "Max depth for --focus traversal", parseInt)
+  .option(
+    "--direction <direction>",
+    "Direction for --focus traversal: upstream|downstream|both",
+    "both",
+  )
+  .option(
+    "--resource-types <types>",
+    "Comma-separated resource types for focused graph",
+  )
   .action(
     (
       manifestPath: string | undefined,
@@ -183,42 +157,12 @@ program
         fields?: string;
         fieldLevel?: boolean;
         catalogPath?: string;
+        focus?: string;
+        depth?: number;
+        direction?: "upstream" | "downstream" | "both";
+        resourceTypes?: string;
       },
-    ) => {
-      try {
-        // Resolve artifact paths
-        const paths = resolveArtifactPaths(
-          manifestPath,
-          undefined,
-          options.targetDir,
-          options.catalogPath,
-        );
-
-        // Validate path
-        validateSafePath(paths.manifest);
-        if (options.output) {
-          validateSafePath(options.output);
-        }
-
-        // Load manifest
-        const manifest = loadManifest(paths.manifest);
-        const graph = new ManifestGraph(manifest);
-
-        // Enhance with field-level lineage if requested
-        if (options.fieldLevel && paths.catalog) {
-          tryApplyFieldLevelLineageToGraph(graph, manifest, paths.catalog);
-        }
-
-        const output = exportGraphToFormat(graph.getGraph(), {
-          format: options.format,
-          output: options.output,
-          fields: options.fields,
-        });
-        writeGraphOutput(output, options.output);
-      } catch (error) {
-        handleError(error, isTTY());
-      }
-    },
+    ) => graphAction(manifestPath, options, { handleError, isTTY }),
   );
 
 /**
@@ -422,6 +366,78 @@ program
       handleError(error, isTTY());
     }
   });
+
+program
+  .command("inventory")
+  .description("List and filter dbt resources from manifest")
+  .option("--manifest-path <path>", "Path to manifest.json file")
+  .option("--run-results-path <path>", "Path to run_results.json file")
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option("--type <type>", "Filter by resource type")
+  .option("--package <package>", "Filter by package name")
+  .option("--tag <tag>", "Filter by tag")
+  .option("--path <path>", "Filter by file path segment")
+  .option("--owner <owner>", "Filter by owner")
+  .option("--group <group>", "Filter by group")
+  .option("--status <status>", "Filter by run status")
+  .option(OPT_FIELDS, DESC_FIELDS)
+  .option("--format <format>", "Output format: json or table")
+  .option(OPT_JSON, DESC_JSON)
+  .option(OPT_NO_JSON, DESC_NO_JSON)
+  .action((options) => inventoryAction(options, { handleError, isTTY }));
+
+program
+  .command("timeline")
+  .description("Show per-node execution timeline rows from run_results.json")
+  .option("--manifest-path <path>", "Path to manifest.json file")
+  .option("--run-results-path <path>", "Path to run_results.json file")
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option("--sort <sort>", "Sort by duration or start", "duration")
+  .option("--top <n>", "Top N rows after sorting", parseInt)
+  .option("--failed-only", "Show only failed/error/warn entries")
+  .option("--status <status>", "Filter by status (comma-separated)")
+  .option("--format <format>", "Output format: json, table, csv")
+  .option(OPT_JSON, DESC_JSON)
+  .option(OPT_NO_JSON, DESC_NO_JSON)
+  .action((options) => timelineAction(options, { handleError, isTTY }));
+
+program
+  .command("search")
+  .description("Search dbt manifest resources")
+  .argument("[terms...]", "Search terms (supports scoped tokens like tag:finance)")
+  .option("--manifest-path <path>", "Path to manifest.json file")
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option("--type <type>", "Filter by resource type")
+  .option("--package <package>", "Filter by package name")
+  .option("--tag <tag>", "Filter by tag")
+  .option("--path <path>", "Filter by file path segment")
+  .option("--top <n>", "Limit number of results", parseInt)
+  .option("--format <format>", "Output format: json or table")
+  .option(OPT_JSON, DESC_JSON)
+  .option(OPT_NO_JSON, DESC_NO_JSON)
+  .action((terms: string[], options) =>
+    searchAction(terms, options, { handleError, isTTY }),
+  );
+
+program
+  .command("status")
+  .description("Report local artifact availability/readiness/freshness")
+  .option("--manifest-path <path>", "Path to manifest.json file")
+  .option("--run-results-path <path>", "Path to run_results.json file")
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option("--json", DESC_JSON)
+  .option("--no-json", DESC_NO_JSON)
+  .action((options) => statusAction(options, { handleError, isTTY }));
+
+program
+  .command("freshness")
+  .description("Alias for status")
+  .option("--manifest-path <path>", "Path to manifest.json file")
+  .option("--run-results-path <path>", "Path to run_results.json file")
+  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option("--json", DESC_JSON)
+  .option("--no-json", DESC_NO_JSON)
+  .action((options) => statusAction(options, { handleError, isTTY }));
 
 // Parse command line arguments
 program.parse();

--- a/packages/dbt-tools/cli/src/deps-action.ts
+++ b/packages/dbt-tools/cli/src/deps-action.ts
@@ -16,7 +16,6 @@ import {
   formatDeps,
   shouldOutputJSON,
 } from "@dbt-tools/core";
-import type { ParsedManifest } from "dbt-artifacts-parser/manifest";
 
 type DepsOptions = {
   direction?: string;
@@ -34,7 +33,7 @@ type DepsOptions = {
 
 /** Add field-level lineage to graph and return targetId */
 function addFieldLevelLineage(
-  manifest: ParsedManifest,
+  manifest: ReturnType<typeof loadManifest>,
   graph: ManifestGraph,
   paths: { catalog?: string },
   resourceId: string,
@@ -61,7 +60,7 @@ function addFieldLevelLineage(
     const nodes = manifest.nodes;
     if (nodes) {
       for (const [uniqueId, node] of Object.entries(nodes)) {
-        const compiledCode = node.compiled_code;
+        const compiledCode = (node as { compiled_code?: unknown }).compiled_code;
         if (typeof compiledCode === "string") {
           const fieldDeps = analyzer.analyze(compiledCode, sqlDialect);
           graph.addFieldEdges(uniqueId, fieldDeps);

--- a/packages/dbt-tools/cli/src/extended-actions.test.ts
+++ b/packages/dbt-tools/cli/src/extended-actions.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, copyFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getTestResourcePath } from "dbt-artifacts-parser/test-utils";
+import {
+  inventoryAction,
+  timelineAction,
+  searchAction,
+  statusAction,
+  graphAction,
+} from "./extended-actions";
+
+describe("extended CLI actions", () => {
+  const manifestPath = getTestResourcePath(
+    "manifest",
+    "v12",
+    "resources",
+    "jaffle_shop",
+    "manifest_1.10.json",
+  );
+  const runResultsPath = getTestResourcePath(
+    "run_results",
+    "v6",
+    "resources",
+    "jaffle_shop",
+    "run_results.json",
+  );
+
+  const handleError = (error: unknown) => {
+    throw error;
+  };
+  const isTTY = () => false;
+
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it("inventory outputs filtered JSON rows", () => {
+    inventoryAction(
+      {
+        manifestPath,
+        runResultsPath,
+        type: "model",
+        fields: "unique_id,name,resource_type",
+        json: true,
+      },
+      { handleError, isTTY },
+    );
+
+    const output = consoleLogSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as {
+      count: number;
+      resources: Array<{ unique_id: string; resource_type: string }>;
+    };
+    expect(parsed.count).toBeGreaterThan(0);
+    expect(parsed.resources.every((row) => row.resource_type === "model")).toBe(
+      true,
+    );
+  });
+
+  it("timeline supports failed-only and JSON shape", () => {
+    timelineAction(
+      {
+        manifestPath,
+        runResultsPath,
+        failedOnly: true,
+        json: true,
+      },
+      { handleError, isTTY },
+    );
+
+    const output = consoleLogSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as {
+      timeline: Array<{ status: string; unique_id: string }>;
+    };
+    expect(Array.isArray(parsed.timeline)).toBe(true);
+    expect(parsed.timeline.every((row) => row.unique_id.includes("."))).toBe(true);
+  });
+
+  it("timeline supports csv output", () => {
+    timelineAction(
+      {
+        runResultsPath,
+        format: "csv",
+        noJson: true,
+      },
+      { handleError, isTTY: () => true },
+    );
+
+    const output = consoleLogSpy.mock.calls[0][0] as string;
+    expect(output).toContain("unique_id,name,resource_type,status");
+  });
+
+  it("search supports scoped term and free text ranking", () => {
+    searchAction(
+      ["type:model", "orders"],
+      {
+        manifestPath,
+        json: true,
+      },
+      { handleError, isTTY },
+    );
+
+    const output = consoleLogSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as {
+      count: number;
+      results: Array<{ unique_id: string; resource_type: string }>;
+    };
+    expect(parsed.count).toBeGreaterThan(0);
+    expect(parsed.results[0]?.resource_type).toBe("model");
+  });
+
+  it("status reports manifest-ready when run_results missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dbt-tools-status-"));
+    try {
+      copyFileSync(manifestPath, join(dir, "manifest.json"));
+      statusAction(
+        {
+          targetDir: dir,
+          json: true,
+        },
+        { handleError, isTTY },
+      );
+
+      const output = consoleLogSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(output) as {
+        readiness: { state: string; execution_ready: boolean };
+      };
+      expect(parsed.readiness.state).toBe("manifest-ready");
+      expect(parsed.readiness.execution_ready).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("graph supports focused subgraph export", () => {
+    graphAction(
+      manifestPath,
+      {
+        format: "json",
+        focus: "model.jaffle_shop.orders",
+        direction: "upstream",
+        depth: 1,
+      },
+      { handleError, isTTY },
+    );
+
+    const output = consoleLogSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as {
+      nodes: Array<{ id: string }>;
+      edges: Array<{ source: string; target: string }>;
+    };
+    expect(parsed.nodes.length).toBeGreaterThan(0);
+    expect(
+      parsed.nodes.some((node) => node.id === "model.jaffle_shop.orders"),
+    ).toBe(true);
+    expect(parsed.edges.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it("graph focus throws for unknown selector", () => {
+    expect(() =>
+      graphAction(
+        manifestPath,
+        {
+          format: "json",
+          focus: "tag:definitely_missing",
+        },
+        { handleError, isTTY },
+      ),
+    ).toThrow(/No nodes matched --focus selector/);
+  });
+});

--- a/packages/dbt-tools/cli/src/extended-actions.ts
+++ b/packages/dbt-tools/cli/src/extended-actions.ts
@@ -18,7 +18,6 @@ import {
   SQLAnalyzer,
   sqlDialectFromDbtAdapterType,
 } from "@dbt-tools/core";
-import type { ParsedManifest } from "dbt-artifacts-parser/manifest";
 
 type CliEnv = {
   handleError: (error: unknown, isTTY: boolean) => void;
@@ -134,7 +133,9 @@ function deriveOwner(node: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
-function collectInventoryRows(manifest: ParsedManifest): InventoryRow[] {
+function collectInventoryRows(
+  manifest: ReturnType<typeof loadManifest>,
+): InventoryRow[] {
   const rows: InventoryRow[] = [];
 
   const addEntries = (
@@ -185,7 +186,7 @@ function collectInventoryRows(manifest: ParsedManifest): InventoryRow[] {
     "exposure",
   );
 
-  const optionalManifest = manifest as ParsedManifest & {
+  const optionalManifest = manifest as ReturnType<typeof loadManifest> & {
     metrics?: Record<string, unknown>;
   };
   addEntries(optionalManifest.metrics, "metric");

--- a/packages/dbt-tools/cli/src/extended-actions.ts
+++ b/packages/dbt-tools/cli/src/extended-actions.ts
@@ -1,0 +1,864 @@
+import * as fs from "fs";
+import * as path from "path";
+import {
+  ManifestGraph,
+  createFocusedGraph,
+  resolveArtifactPaths,
+  loadManifest,
+  loadRunResults,
+  loadCatalog,
+  validateSafePath,
+  validateDepth,
+  validateString,
+  buildNodeExecutionsFromRunResults,
+  formatOutput,
+  shouldOutputJSON,
+  exportGraphToFormat,
+  writeGraphOutput,
+  SQLAnalyzer,
+  sqlDialectFromDbtAdapterType,
+} from "@dbt-tools/core";
+import type { ParsedManifest } from "dbt-artifacts-parser/manifest";
+
+type CliEnv = {
+  handleError: (error: unknown, isTTY: boolean) => void;
+  isTTY: () => boolean;
+};
+
+type InventoryRow = {
+  unique_id: string;
+  resource_type: string;
+  name: string;
+  package_name: string;
+  path?: string;
+  tags?: string[];
+  group?: string;
+  owner?: string;
+  status?: string;
+};
+
+type InventoryOptions = {
+  manifestPath?: string;
+  runResultsPath?: string;
+  targetDir?: string;
+  type?: string;
+  package?: string;
+  tag?: string;
+  path?: string;
+  owner?: string;
+  group?: string;
+  status?: string;
+  fields?: string;
+  format?: "json" | "table";
+  json?: boolean;
+  noJson?: boolean;
+};
+
+type TimelineOptions = {
+  manifestPath?: string;
+  runResultsPath?: string;
+  targetDir?: string;
+  sort?: "duration" | "start";
+  top?: number;
+  failedOnly?: boolean;
+  status?: string;
+  format?: "json" | "table" | "csv";
+  json?: boolean;
+  noJson?: boolean;
+};
+
+type SearchOptions = {
+  manifestPath?: string;
+  targetDir?: string;
+  type?: string;
+  package?: string;
+  tag?: string;
+  path?: string;
+  format?: "json" | "table";
+  top?: number;
+  json?: boolean;
+  noJson?: boolean;
+};
+
+type StatusOptions = {
+  targetDir?: string;
+  manifestPath?: string;
+  runResultsPath?: string;
+  json?: boolean;
+  noJson?: boolean;
+};
+
+type GraphFocusOptions = {
+  format?: string;
+  output?: string;
+  targetDir?: string;
+  fields?: string;
+  fieldLevel?: boolean;
+  catalogPath?: string;
+  focus?: string;
+  depth?: number;
+  direction?: "upstream" | "downstream" | "both";
+  resourceTypes?: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value != null
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function splitCsv(input?: string): string[] {
+  if (!input) return [];
+  return input
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function deriveOwner(node: Record<string, unknown>): string | undefined {
+  const owner = node.owner;
+  if (typeof owner === "string" && owner.trim() !== "") return owner;
+
+  const config = asRecord(node.config);
+  const configOwner = config.owner;
+  if (typeof configOwner === "string" && configOwner.trim() !== "") {
+    return configOwner;
+  }
+
+  const meta = asRecord(node.meta);
+  const metaOwner = meta.owner;
+  if (typeof metaOwner === "string" && metaOwner.trim() !== "") {
+    return metaOwner;
+  }
+
+  return undefined;
+}
+
+function collectInventoryRows(manifest: ParsedManifest): InventoryRow[] {
+  const rows: InventoryRow[] = [];
+
+  const addEntries = (
+    entries: Record<string, unknown> | undefined,
+    fallbackType?: string,
+  ): void => {
+    if (!entries) return;
+    for (const [uniqueId, rawNode] of Object.entries(entries)) {
+      const node = asRecord(rawNode);
+      const tags = Array.isArray(node.tags)
+        ? node.tags.filter((entry): entry is string => typeof entry === "string")
+        : undefined;
+      rows.push({
+        unique_id: uniqueId,
+        resource_type:
+          (typeof node.resource_type === "string"
+            ? node.resource_type
+            : fallbackType) ?? "unknown",
+        name:
+          typeof node.name === "string" && node.name !== ""
+            ? node.name
+            : uniqueId,
+        package_name:
+          typeof node.package_name === "string" ? node.package_name : "",
+        path:
+          (typeof node.path === "string" && node.path) ||
+          (typeof node.original_file_path === "string" &&
+          node.original_file_path
+            ? node.original_file_path
+            : undefined),
+        tags,
+        group:
+          (typeof node.group === "string" && node.group) ||
+          (typeof asRecord(node.config).group === "string" &&
+          (asRecord(node.config).group as string)
+            ? (asRecord(node.config).group as string)
+            : undefined),
+        owner: deriveOwner(node),
+      });
+    }
+  };
+
+  addEntries(manifest.nodes as Record<string, unknown> | undefined);
+  addEntries(manifest.sources as Record<string, unknown> | undefined, "source");
+  addEntries(manifest.macros as Record<string, unknown> | undefined, "macro");
+  addEntries(
+    manifest.exposures as Record<string, unknown> | undefined,
+    "exposure",
+  );
+
+  const optionalManifest = manifest as ParsedManifest & {
+    metrics?: Record<string, unknown>;
+  };
+  addEntries(optionalManifest.metrics, "metric");
+
+  return rows;
+}
+
+function applyInventoryFilters(
+  rows: InventoryRow[],
+  options: Pick<
+    InventoryOptions,
+    "type" | "package" | "tag" | "path" | "owner" | "group" | "status"
+  >,
+): InventoryRow[] {
+  const normalizedType = options.type?.toLowerCase();
+  const normalizedPackage = options.package?.toLowerCase();
+  const normalizedTag = options.tag?.toLowerCase();
+  const normalizedPath = options.path?.toLowerCase();
+  const normalizedOwner = options.owner?.toLowerCase();
+  const normalizedGroup = options.group?.toLowerCase();
+  const normalizedStatus = options.status?.toLowerCase();
+
+  return rows.filter((row) => {
+    if (normalizedType && row.resource_type.toLowerCase() !== normalizedType) {
+      return false;
+    }
+    if (
+      normalizedPackage &&
+      row.package_name.toLowerCase() !== normalizedPackage
+    ) {
+      return false;
+    }
+    if (
+      normalizedTag &&
+      !(row.tags ?? []).some((tag) => tag.toLowerCase() === normalizedTag)
+    ) {
+      return false;
+    }
+    if (
+      normalizedPath &&
+      !((row.path ?? "").toLowerCase().includes(normalizedPath))
+    ) {
+      return false;
+    }
+    if (
+      normalizedOwner &&
+      !((row.owner ?? "").toLowerCase().includes(normalizedOwner))
+    ) {
+      return false;
+    }
+    if (
+      normalizedGroup &&
+      !((row.group ?? "").toLowerCase().includes(normalizedGroup))
+    ) {
+      return false;
+    }
+    if (normalizedStatus && (row.status ?? "unknown").toLowerCase() !== normalizedStatus) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function formatTable(rows: Array<Record<string, unknown>>, columns: string[]): string {
+  if (rows.length === 0) {
+    return "(no rows)";
+  }
+  const widths = new Map<string, number>();
+  for (const column of columns) {
+    const maxRow = Math.max(
+      column.length,
+      ...rows.map((row) => String(row[column] ?? "").length),
+    );
+    widths.set(column, Math.min(Math.max(maxRow, 6), 70));
+  }
+
+  const trimCell = (value: string, width: number): string =>
+    value.length > width ? `${value.slice(0, width - 3)}...` : value;
+
+  const renderRow = (row: Record<string, unknown>): string =>
+    columns
+      .map((column) => {
+        const width = widths.get(column) ?? column.length;
+        return trimCell(String(row[column] ?? ""), width).padEnd(width);
+      })
+      .join("  ");
+
+  const header = renderRow(
+    Object.fromEntries(columns.map((column) => [column, column])) as Record<
+      string,
+      unknown
+    >,
+  );
+  const divider = columns
+    .map((column) => "-".repeat(widths.get(column) ?? column.length))
+    .join("  ");
+  return [header, divider, ...rows.map(renderRow)].join("\n");
+}
+
+export function inventoryAction(options: InventoryOptions, env: CliEnv): void {
+  try {
+    const paths = resolveArtifactPaths(
+      options.manifestPath,
+      options.runResultsPath,
+      options.targetDir,
+    );
+    validateSafePath(paths.manifest);
+    const manifest = loadManifest(paths.manifest);
+
+    const statuses = new Map<string, string>();
+    try {
+      validateSafePath(paths.runResults);
+      const runResults = loadRunResults(paths.runResults);
+      for (const result of runResults.results ?? []) {
+        if (result.unique_id) {
+          statuses.set(result.unique_id, result.status ?? "unknown");
+        }
+      }
+    } catch {
+      // run_results is optional for inventory; ignore when unavailable.
+    }
+
+    const rows = collectInventoryRows(manifest).map((row) => ({
+      ...row,
+      status: statuses.get(row.unique_id),
+    }));
+
+    const filtered = applyInventoryFilters(rows, options);
+    const fields = splitCsv(options.fields);
+    const selectedColumns =
+      fields.length > 0
+        ? fields
+        : [
+            "unique_id",
+            "resource_type",
+            "name",
+            "package_name",
+            "status",
+            "path",
+          ];
+    const projected = filtered.map((row) => {
+      const out: Record<string, unknown> = {};
+      for (const column of selectedColumns) {
+        out[column] = row[column as keyof InventoryRow] ?? "";
+      }
+      return out;
+    });
+
+    const useJson = shouldOutputJSON(options.json, options.noJson);
+    if (useJson || options.format === "json") {
+      console.log(
+        formatOutput(
+          {
+            count: projected.length,
+            total_resources: rows.length,
+            filters: {
+              type: options.type,
+              package: options.package,
+              tag: options.tag,
+              path: options.path,
+              owner: options.owner,
+              group: options.group,
+              status: options.status,
+            },
+            resources: projected,
+          },
+          true,
+        ),
+      );
+      return;
+    }
+
+    console.log(
+      [
+        `Inventory results: ${projected.length} / ${rows.length}`,
+        formatTable(projected, selectedColumns),
+      ].join("\n\n"),
+    );
+  } catch (error) {
+    env.handleError(error, env.isTTY());
+  }
+}
+
+type TimelineRow = {
+  unique_id: string;
+  name: string;
+  resource_type: string;
+  status: string;
+  duration_seconds: number;
+  started_at?: string;
+  completed_at?: string;
+};
+
+function toCsv(rows: TimelineRow[]): string {
+  const headers = [
+    "unique_id",
+    "name",
+    "resource_type",
+    "status",
+    "duration_seconds",
+    "started_at",
+    "completed_at",
+  ];
+  const quote = (value: string): string => `"${value.replace(/\"/g, "\"\"")}"`;
+
+  return [
+    headers.join(","),
+    ...rows.map((row) =>
+      [
+        row.unique_id,
+        row.name,
+        row.resource_type,
+        row.status,
+        row.duration_seconds.toFixed(3),
+        row.started_at ?? "",
+        row.completed_at ?? "",
+      ]
+        .map((value) => quote(String(value)))
+        .join(","),
+    ),
+  ].join("\n");
+}
+
+export function timelineAction(options: TimelineOptions, env: CliEnv): void {
+  try {
+    const paths = resolveArtifactPaths(
+      options.manifestPath,
+      options.runResultsPath,
+      options.targetDir,
+    );
+    validateSafePath(paths.runResults);
+    const runResults = loadRunResults(paths.runResults);
+
+    const nameById = new Map<string, { name: string; resource_type: string }>();
+    try {
+      validateSafePath(paths.manifest);
+      const manifest = loadManifest(paths.manifest);
+      for (const row of collectInventoryRows(manifest)) {
+        nameById.set(row.unique_id, {
+          name: row.name,
+          resource_type: row.resource_type,
+        });
+      }
+    } catch {
+      // Manifest is optional for timeline enrichment.
+    }
+
+    let rows: TimelineRow[] = buildNodeExecutionsFromRunResults(runResults).map(
+      (entry) => {
+        const node = nameById.get(entry.unique_id);
+        return {
+          unique_id: entry.unique_id,
+          name: node?.name ?? entry.unique_id.split(".").pop() ?? entry.unique_id,
+          resource_type: node?.resource_type ?? entry.unique_id.split(".")[0] ?? "unknown",
+          status: entry.status,
+          duration_seconds: entry.execution_time,
+          started_at: entry.started_at,
+          completed_at: entry.completed_at,
+        };
+      },
+    );
+
+    if (options.failedOnly) {
+      rows = rows.filter((row) =>
+        ["error", "fail", "runtime error", "warn"].includes(
+          row.status.toLowerCase(),
+        ),
+      );
+    }
+
+    if (options.status) {
+      const statuses = new Set(
+        splitCsv(options.status).map((entry) => entry.toLowerCase()),
+      );
+      rows = rows.filter((row) => statuses.has(row.status.toLowerCase()));
+    }
+
+    const sortBy = options.sort ?? "duration";
+    rows.sort((a, b) => {
+      if (sortBy === "start") {
+        return (b.started_at ?? "").localeCompare(a.started_at ?? "");
+      }
+      return b.duration_seconds - a.duration_seconds;
+    });
+
+    if (options.top !== undefined) {
+      if (!Number.isInteger(options.top) || options.top < 1) {
+        throw new Error("--top must be a positive integer");
+      }
+      rows = rows.slice(0, options.top);
+    }
+
+    const useJson = shouldOutputJSON(options.json, options.noJson);
+    if (useJson || options.format === "json") {
+      console.log(formatOutput({ count: rows.length, timeline: rows }, true));
+      return;
+    }
+    if (options.format === "csv") {
+      console.log(toCsv(rows));
+      return;
+    }
+
+    console.log(
+      [
+        `Timeline rows: ${rows.length}`,
+        formatTable(rows as unknown as Array<Record<string, unknown>>, [
+          "unique_id",
+          "resource_type",
+          "status",
+          "duration_seconds",
+          "started_at",
+        ]),
+      ].join("\n\n"),
+    );
+  } catch (error) {
+    env.handleError(error, env.isTTY());
+  }
+}
+
+function scoreInventoryRow(row: InventoryRow, terms: string[]): number {
+  if (terms.length === 0) return 1;
+  let score = 0;
+  const id = row.unique_id.toLowerCase();
+  const name = row.name.toLowerCase();
+  const pkg = row.package_name.toLowerCase();
+  const p = (row.path ?? "").toLowerCase();
+  const tags = new Set((row.tags ?? []).map((tag) => tag.toLowerCase()));
+
+  for (const term of terms) {
+    const t = term.toLowerCase();
+    if (id === t || name === t) score += 100;
+    else if (id.includes(t) || name.includes(t)) score += 30;
+    if (pkg.includes(t)) score += 15;
+    if (p.includes(t)) score += 10;
+    if (tags.has(t)) score += 20;
+  }
+
+  return score;
+}
+
+function parseScopedTerms(terms: string[], options: SearchOptions): SearchOptions {
+  const next = { ...options };
+  for (const term of terms) {
+    const idx = term.indexOf(":");
+    if (idx < 1) continue;
+    const key = term.slice(0, idx).toLowerCase();
+    const value = term.slice(idx + 1);
+    if (value === "") continue;
+    if (key === "type") next.type = value;
+    if (key === "package") next.package = value;
+    if (key === "tag") next.tag = value;
+    if (key === "path" || key === "source") next.path = value;
+  }
+  return next;
+}
+
+export function searchAction(
+  terms: string[],
+  options: SearchOptions,
+  env: CliEnv,
+): void {
+  try {
+    const scoped = parseScopedTerms(terms, options);
+    const freeTextTerms = terms.filter((term) => !term.includes(":"));
+
+    const paths = resolveArtifactPaths(scoped.manifestPath, undefined, scoped.targetDir);
+    validateSafePath(paths.manifest);
+    const manifest = loadManifest(paths.manifest);
+
+    let rows = applyInventoryFilters(collectInventoryRows(manifest), {
+      type: scoped.type,
+      package: scoped.package,
+      tag: scoped.tag,
+      path: scoped.path,
+      owner: undefined,
+      group: undefined,
+      status: undefined,
+    });
+
+    const scored = rows
+      .map((row) => ({
+        ...row,
+        _score: scoreInventoryRow(row, freeTextTerms),
+      }))
+      .filter((row) => row._score > 0)
+      .sort((a, b) => b._score - a._score || a.unique_id.localeCompare(b.unique_id));
+
+    if (scoped.top !== undefined) {
+      if (!Number.isInteger(scoped.top) || scoped.top < 1) {
+        throw new Error("--top must be a positive integer");
+      }
+      rows = scored.slice(0, scoped.top);
+    } else {
+      rows = scored;
+    }
+
+    const outputRows = rows.map((row) => ({
+      unique_id: row.unique_id,
+      resource_type: row.resource_type,
+      name: row.name,
+      package_name: row.package_name,
+      path: row.path ?? "",
+      tags: (row.tags ?? []).join(","),
+    }));
+
+    const useJson = shouldOutputJSON(scoped.json, scoped.noJson);
+    if (useJson || scoped.format === "json") {
+      console.log(
+        formatOutput(
+          {
+            count: outputRows.length,
+            query: terms,
+            filters: {
+              type: scoped.type,
+              package: scoped.package,
+              tag: scoped.tag,
+              path: scoped.path,
+            },
+            results: outputRows,
+          },
+          true,
+        ),
+      );
+      return;
+    }
+
+    console.log(
+      [
+        `Search results: ${outputRows.length}`,
+        formatTable(outputRows, [
+          "unique_id",
+          "resource_type",
+          "name",
+          "package_name",
+          "path",
+        ]),
+      ].join("\n\n"),
+    );
+  } catch (error) {
+    env.handleError(error, env.isTTY());
+  }
+}
+
+type ArtifactFileStatus = {
+  path: string;
+  exists: boolean;
+  modified_at?: string;
+  age_seconds?: number;
+};
+
+function statArtifact(filePath: string): ArtifactFileStatus {
+  validateSafePath(filePath);
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    return { path: resolvedPath, exists: false };
+  }
+  const stat = fs.statSync(resolvedPath);
+  const modifiedAt = stat.mtime;
+  return {
+    path: resolvedPath,
+    exists: true,
+    modified_at: modifiedAt.toISOString(),
+    age_seconds: Math.max(0, Math.floor((Date.now() - modifiedAt.getTime()) / 1000)),
+  };
+}
+
+export function statusAction(options: StatusOptions, env: CliEnv): void {
+  try {
+    const paths = resolveArtifactPaths(
+      options.manifestPath,
+      options.runResultsPath,
+      options.targetDir,
+    );
+
+    const manifest = statArtifact(paths.manifest);
+    const runResults = statArtifact(paths.runResults);
+
+    const readiness = {
+      manifest_ready: manifest.exists,
+      execution_ready: manifest.exists && runResults.exists,
+      state:
+        manifest.exists && runResults.exists
+          ? "execution-ready"
+          : manifest.exists
+            ? "manifest-ready"
+            : "not-ready",
+    };
+
+    const existing = [manifest, runResults].filter(
+      (entry) => entry.exists && entry.modified_at,
+    );
+    const freshest = existing
+      .slice()
+      .sort((a, b) => (b.modified_at ?? "").localeCompare(a.modified_at ?? ""))[0];
+
+    const payload = {
+      target_dir: path.resolve(options.targetDir ?? "./target"),
+      artifacts: {
+        manifest,
+        run_results: runResults,
+      },
+      readiness,
+      freshness:
+        freshest != null
+          ? {
+              latest_artifact:
+                freshest.path === manifest.path ? "manifest" : "run_results",
+              modified_at: freshest.modified_at,
+              age_seconds: freshest.age_seconds,
+            }
+          : undefined,
+    };
+
+    const useJson = shouldOutputJSON(options.json, options.noJson);
+    if (useJson) {
+      console.log(formatOutput(payload, true));
+      return;
+    }
+
+    const lines = [
+      "dbt artifact status",
+      "===================",
+      `Target dir: ${payload.target_dir}`,
+      `Manifest: ${manifest.exists ? "present" : "missing"} (${manifest.path})`,
+      `Run results: ${runResults.exists ? "present" : "missing"} (${runResults.path})`,
+      `Readiness: ${readiness.state}`,
+    ];
+
+    if (payload.freshness) {
+      lines.push(
+        `Freshness: latest=${payload.freshness.latest_artifact}, age=${payload.freshness.age_seconds}s`,
+      );
+    }
+
+    console.log(lines.join("\n"));
+  } catch (error) {
+    env.handleError(error, env.isTTY());
+  }
+}
+
+function resolveFocusNodes(
+  graph: ManifestGraph,
+  rows: InventoryRow[],
+  focus: string,
+): string[] {
+  if (focus.includes(":")) {
+    const [prefix, rawValue] = focus.split(":", 2);
+    const value = rawValue?.toLowerCase() ?? "";
+    if (prefix === "tag") {
+      return rows
+        .filter((row) => (row.tags ?? []).some((tag) => tag.toLowerCase() === value))
+        .map((row) => row.unique_id);
+    }
+    if (prefix === "type") {
+      return rows
+        .filter((row) => row.resource_type.toLowerCase() === value)
+        .map((row) => row.unique_id);
+    }
+    if (prefix === "package") {
+      return rows
+        .filter((row) => row.package_name.toLowerCase() === value)
+        .map((row) => row.unique_id);
+    }
+    if (prefix === "path") {
+      return rows
+        .filter((row) => (row.path ?? "").toLowerCase().includes(value))
+        .map((row) => row.unique_id);
+    }
+  }
+
+  if (graph.getGraph().hasNode(focus)) {
+    return [focus];
+  }
+
+  return rows
+    .filter((row) => row.name.toLowerCase() === focus.toLowerCase())
+    .map((row) => row.unique_id);
+}
+
+export function graphAction(
+  manifestPath: string | undefined,
+  options: GraphFocusOptions,
+  env: CliEnv,
+): void {
+  try {
+    const paths = resolveArtifactPaths(
+      manifestPath,
+      undefined,
+      options.targetDir,
+      options.catalogPath,
+    );
+    validateSafePath(paths.manifest);
+    if (options.output) {
+      validateSafePath(options.output);
+    }
+
+    if (options.focus) {
+      validateString(options.focus);
+      validateDepth(options.depth);
+    }
+
+    const manifest = loadManifest(paths.manifest);
+    const graph = new ManifestGraph(manifest);
+
+    if (options.fieldLevel && paths.catalog) {
+      validateSafePath(paths.catalog);
+      try {
+        const catalog = loadCatalog(paths.catalog);
+        graph.addFieldNodes(catalog);
+        const analyzer = new SQLAnalyzer();
+        const adapterType = (
+          manifest.metadata as { adapter_type?: string } | undefined
+        )?.adapter_type;
+        const sqlDialect = sqlDialectFromDbtAdapterType(adapterType);
+        if (manifest.nodes) {
+          for (const [uniqueId, node] of Object.entries(manifest.nodes)) {
+            const compiledCode = (node as Record<string, unknown>)
+              .compiled_code as string | undefined;
+            if (compiledCode) {
+              const fieldDeps = analyzer.analyze(compiledCode, sqlDialect);
+              graph.addFieldEdges(uniqueId, fieldDeps);
+            }
+          }
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : "";
+        if (msg.startsWith("Catalog file not found:")) {
+          console.warn(
+            "Warning: --field-level requires catalog.json, but it was not found. Falling back to resource-level lineage.",
+          );
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    let graphToExport = graph.getGraph();
+
+    if (options.focus) {
+      const focusNodes = resolveFocusNodes(
+        graph,
+        collectInventoryRows(manifest),
+        options.focus,
+      );
+      if (focusNodes.length === 0) {
+        throw new Error(`No nodes matched --focus selector: ${options.focus}`);
+      }
+
+      const direction = options.direction ?? "both";
+      if (!["upstream", "downstream", "both"].includes(direction)) {
+        throw new Error("--direction must be one of: upstream, downstream, both");
+      }
+
+      const types = splitCsv(options.resourceTypes);
+      const typeSet = types.length
+        ? new Set(types.map((entry) => entry.toLowerCase()))
+        : undefined;
+      graphToExport = createFocusedGraph(
+        graph,
+        focusNodes,
+        direction,
+        options.depth,
+        typeSet,
+      );
+    }
+
+    const output = exportGraphToFormat(graphToExport, {
+      format: options.format,
+      output: options.output,
+      fields: options.fields,
+    });
+    writeGraphOutput(output, options.output);
+  } catch (error) {
+    env.handleError(error, env.isTTY());
+  }
+}

--- a/packages/dbt-tools/core/src/analysis/graph-focus.ts
+++ b/packages/dbt-tools/core/src/analysis/graph-focus.ts
@@ -1,0 +1,49 @@
+import { DirectedGraph } from "graphology";
+import type { ManifestGraph } from "./manifest-graph";
+import type { GraphEdgeAttributes, GraphNodeAttributes } from "../types";
+
+export function createFocusedGraph(
+  graph: ManifestGraph,
+  focusNodeIds: string[],
+  direction: "upstream" | "downstream" | "both",
+  depth?: number,
+  resourceTypes?: Set<string>,
+): DirectedGraph<GraphNodeAttributes, GraphEdgeAttributes> {
+  const base = graph.getGraph();
+  const kept = new Set<string>();
+
+  for (const nodeId of focusNodeIds) {
+    kept.add(nodeId);
+    if (direction === "upstream" || direction === "both") {
+      for (const entry of graph.getUpstream(nodeId, depth)) {
+        kept.add(entry.nodeId);
+      }
+    }
+    if (direction === "downstream" || direction === "both") {
+      for (const entry of graph.getDownstream(nodeId, depth)) {
+        kept.add(entry.nodeId);
+      }
+    }
+  }
+
+  const out = new DirectedGraph<GraphNodeAttributes, GraphEdgeAttributes>();
+  for (const nodeId of kept) {
+    if (!base.hasNode(nodeId)) continue;
+    const attributes = base.getNodeAttributes(nodeId);
+    if (
+      resourceTypes &&
+      !resourceTypes.has(String(attributes.resource_type).toLowerCase())
+    ) {
+      continue;
+    }
+    out.addNode(nodeId, attributes);
+  }
+
+  base.forEachEdge((edgeId, attributes, source, target) => {
+    if (out.hasNode(source) && out.hasNode(target) && !out.hasEdge(source, target)) {
+      out.addEdgeWithKey(edgeId, source, target, attributes);
+    }
+  });
+
+  return out;
+}

--- a/packages/dbt-tools/core/src/index.ts
+++ b/packages/dbt-tools/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./analysis/dependency-service";
 export * from "./analysis/sql-analyzer";
 export * from "./analysis/run-results-search";
 export * from "./analysis/analysis-snapshot";
+export * from "./analysis/graph-focus";
 
 // Config exports (Node; not re-exported from browser entry)
 export {

--- a/packages/dbt-tools/core/src/introspection/schema-generator.ts
+++ b/packages/dbt-tools/core/src/introspection/schema-generator.ts
@@ -121,9 +121,148 @@ function getGraphSchema(): CommandSchema {
         type: TYPE_STRING,
         description: "Path to catalog.json file",
       },
+      {
+        name: "--focus",
+        type: TYPE_STRING,
+        description: "Focus graph export on a node or selector (e.g., tag:finance)",
+      },
+      {
+        name: "--depth",
+        type: "number",
+        description: "Max traversal depth for --focus",
+      },
+      {
+        name: "--direction",
+        type: "enum",
+        values: ["upstream", "downstream", "both"],
+        default: "both",
+        description: "Traversal direction for --focus",
+      },
+      {
+        name: "--resource-types",
+        type: TYPE_STRING,
+        description: "Comma-separated resource types for focused graph",
+      },
     ],
     output_format: "json, dot, or gexf",
     example: "dbt-tools graph --format dot --output graph.dot",
+  };
+}
+
+function getInventorySchema(): CommandSchema {
+  return {
+    command: "inventory",
+    description: "List and filter dbt resources from manifest",
+    arguments: [],
+    options: [
+      { name: "--manifest-path", type: TYPE_STRING, description: DESC_MANIFEST_PATH },
+      { name: "--run-results-path", type: TYPE_STRING, description: DESC_RUN_RESULTS_PATH },
+      { name: OPT_TARGET_DIR, type: TYPE_STRING, description: DESC_TARGET_DIR },
+      { name: "--type", type: TYPE_STRING, description: "Filter by resource type" },
+      { name: "--package", type: TYPE_STRING, description: "Filter by package name" },
+      { name: "--tag", type: TYPE_STRING, description: "Filter by tag" },
+      { name: "--path", type: TYPE_STRING, description: "Filter by file path segment" },
+      { name: "--owner", type: TYPE_STRING, description: "Filter by owner" },
+      { name: "--group", type: TYPE_STRING, description: "Filter by group" },
+      { name: "--status", type: TYPE_STRING, description: "Filter by run status" },
+      { name: "--fields", type: TYPE_STRING, description: DESC_FIELDS },
+      {
+        name: "--format",
+        type: "enum",
+        values: ["json", "table"],
+        description: "Output format",
+      },
+      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
+    ],
+    output_format: OUTPUT_JSON_OR_HUMAN,
+    example: "dbt-tools inventory --type model --tag finance",
+  };
+}
+
+function getTimelineSchema(): CommandSchema {
+  return {
+    command: "timeline",
+    description: "Show per-node execution timeline rows from run_results.json",
+    arguments: [],
+    options: [
+      { name: "--manifest-path", type: TYPE_STRING, description: DESC_MANIFEST_PATH },
+      { name: "--run-results-path", type: TYPE_STRING, description: DESC_RUN_RESULTS_PATH },
+      { name: OPT_TARGET_DIR, type: TYPE_STRING, description: DESC_TARGET_DIR },
+      {
+        name: "--sort",
+        type: "enum",
+        values: ["duration", "start"],
+        default: "duration",
+        description: "Sort order",
+      },
+      { name: "--top", type: "number", description: "Top N rows after sorting" },
+      { name: "--failed-only", type: TYPE_BOOLEAN, description: "Only failed/error/warn rows" },
+      { name: "--status", type: TYPE_STRING, description: "Filter by status" },
+      {
+        name: "--format",
+        type: "enum",
+        values: ["json", "table", "csv"],
+        description: "Output format",
+      },
+      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
+    ],
+    output_format: "json, table, or csv",
+    example: "dbt-tools timeline --sort duration --top 20",
+  };
+}
+
+function getSearchSchema(): CommandSchema {
+  return {
+    command: "search",
+    description: "Search dbt manifest resources",
+    arguments: [
+      {
+        name: "terms",
+        required: false,
+        description: "Search terms (supports scoped tokens like tag:finance)",
+      },
+    ],
+    options: [
+      { name: "--manifest-path", type: TYPE_STRING, description: DESC_MANIFEST_PATH },
+      { name: OPT_TARGET_DIR, type: TYPE_STRING, description: DESC_TARGET_DIR },
+      { name: "--type", type: TYPE_STRING, description: "Filter by resource type" },
+      { name: "--package", type: TYPE_STRING, description: "Filter by package name" },
+      { name: "--tag", type: TYPE_STRING, description: "Filter by tag" },
+      { name: "--path", type: TYPE_STRING, description: "Filter by file path segment" },
+      { name: "--top", type: "number", description: "Limit number of results" },
+      {
+        name: "--format",
+        type: "enum",
+        values: ["json", "table"],
+        description: "Output format",
+      },
+      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
+    ],
+    output_format: OUTPUT_JSON_OR_HUMAN,
+    example: "dbt-tools search type:model orders",
+  };
+}
+
+function getStatusSchema(command = "status"): CommandSchema {
+  return {
+    command,
+    description:
+      command === "freshness"
+        ? "Alias for status"
+        : "Report local artifact availability/readiness/freshness",
+    arguments: [],
+    options: [
+      { name: "--manifest-path", type: TYPE_STRING, description: DESC_MANIFEST_PATH },
+      { name: "--run-results-path", type: TYPE_STRING, description: DESC_RUN_RESULTS_PATH },
+      { name: OPT_TARGET_DIR, type: TYPE_STRING, description: DESC_TARGET_DIR },
+      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
+    ],
+    output_format: OUTPUT_JSON_OR_HUMAN,
+    example: `dbt-tools ${command}`,
   };
 }
 
@@ -339,6 +478,11 @@ export function getAllSchemas(): Record<string, CommandSchema> {
     graph: getGraphSchema(),
     "run-report": getRunReportSchema(),
     deps: getDepsSchema(),
+    inventory: getInventorySchema(),
+    timeline: getTimelineSchema(),
+    search: getSearchSchema(),
+    status: getStatusSchema("status"),
+    freshness: getStatusSchema("freshness"),
     schema: getSchemaCommandSchema(),
   };
 }


### PR DESCRIPTION
### Motivation

- Provide CLI parity with web workflows for inventory, execution timeline, search, artifact readiness, and focused graph inspection.  
- Keep the CLI JSON-first for automation while preserving friendly human output in TTYs.  
- Reuse existing core parsing/analysis primitives and add the smallest reusable helpers needed for subgraph exports.

### Description

- Added new CLI commands and wiring: `inventory`, `timeline`, `search`, `status` and `freshness` (alias), and extended `graph` with `--focus`, `--depth`, `--direction`, and `--resource-types`; implemented handlers in `packages/dbt-tools/cli/src/extended-actions.ts` and hooked exports in `cli-actions.ts` and `cli.ts`.  
- Implemented row-level timeline construction, CSV/table/JSON output, inventory filtering/projection (type/package/tag/path/owner/group/status), and a lightweight search scorer; tests and fixtures live under the CLI tests file `packages/dbt-tools/cli/src/extended-actions.test.ts`.  
- Added a reusable focused-graph helper `createFocusedGraph` in `packages/dbt-tools/core/src/analysis/graph-focus.ts` and exported it from core, and enhanced `graph` to apply field-level lineage from catalog when requested.  
- Updated runtime schema introspection in `packages/dbt-tools/core/src/introspection/schema-generator.ts` and extended CLI README `packages/dbt-tools/cli/README.md` with examples, options, and guidance (including how `timeline` differs from `run-report`).

### Testing

- Ran the CLI unit test suite: `pnpm --filter @dbt-tools/cli test`, which executed the newly added tests and existing CLI tests and completed successfully (all tests passed; 32 tests).  
- During development a workspace `tsc` build of `@dbt-tools/core` was attempted and surfaced external type resolution issues for `dbt-artifacts-parser/*` in this environment; this did not block the CLI unit tests and is noted as a follow-up item for full workspace build validation in CI.  
- Verified focused-graph behavior, timeline CSV output, inventory filtering, search ranking, and status payload shapes via the new Vitest cases (added in `packages/dbt-tools/cli/src/extended-actions.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3da012994832c9eba152bc918a431)