### PR TITLE
feat(core): hybrid adapter-aware adapter_response normalization

### DIFF
--- a/packages/dbt-tools/core/src/analysis/adapter-response-metrics.test.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response-metrics.test.ts
@@ -6,9 +6,10 @@ import {
   extractAdapterResponseFields,
   isAdapterResponseObject,
   normalizeAdapterResponse,
+  normalizeAdapterResponseWithContext,
 } from "./adapter-response-metrics";
 
-describe("normalizeAdapterResponse", () => {
+describe("normalizeAdapterResponse generic fallback", () => {
   it("returns empty rawKeys for null and non-objects", () => {
     expect(normalizeAdapterResponse(null).rawKeys).toEqual([]);
     expect(normalizeAdapterResponse(undefined).rawKeys).toEqual([]);
@@ -16,71 +17,152 @@ describe("normalizeAdapterResponse", () => {
     expect(normalizeAdapterResponse([]).rawKeys).toEqual([]);
   });
 
-  it("normalizes BigQuery-shaped adapter_response", () => {
-    const ar = {
-      _message: "CREATE VIEW (0 processed)",
-      code: "CREATE VIEW",
-      bytes_processed: 0,
-      bytes_billed: 0,
-      location: "asia-northeast1",
-      project_id: "your-project",
-      job_id: "4825e532-3019-4417-bc75-64b304316b2f",
-      slot_ms: 0,
-    };
-    const m = normalizeAdapterResponse(ar);
-    expect(m.bytesProcessed).toBe(0);
-    expect(m.bytesBilled).toBe(0);
-    expect(m.slotMs).toBe(0);
-    expect(m.adapterCode).toBe("CREATE VIEW");
-    expect(m.adapterMessage).toBe("CREATE VIEW (0 processed)");
-    expect(m.queryId).toBe("4825e532-3019-4417-bc75-64b304316b2f");
-    expect(m.projectId).toBe("your-project");
-    expect(m.location).toBe("asia-northeast1");
-    expect(m.rawKeys.length).toBeGreaterThan(0);
-    expect(adapterMetricsHasData(m)).toBe(true);
-  });
-
-  it("normalizes rows_affected from seed-style response", () => {
-    const m = normalizeAdapterResponse({
-      _message: "INSERT 113",
-      code: "INSERT",
-      rows_affected: 113,
-    });
-    expect(m.rowsAffected).toBe(113);
-    expect(m.adapterCode).toBe("INSERT");
-    expect(adapterMetricsHasData(m)).toBe(true);
-  });
-
-  it("prefers query_id over job_id when both exist", () => {
-    const m = normalizeAdapterResponse({
-      query_id: "sf-1",
-      job_id: "bq-1",
-    });
-    expect(m.queryId).toBe("sf-1");
-  });
-
-  it("parses numeric strings", () => {
-    const m = normalizeAdapterResponse({
-      bytes_processed: "1024",
-      slot_ms: "99",
-    });
-    expect(m.bytesProcessed).toBe(1024);
-    expect(m.slotMs).toBe(99);
-  });
-
-  it("ignores non-finite numbers", () => {
-    const m = normalizeAdapterResponse({
-      bytes_processed: Number.NaN,
-      slot_ms: Number.POSITIVE_INFINITY,
-    });
-    expect(m.bytesProcessed).toBeUndefined();
-    expect(m.slotMs).toBeUndefined();
+  it("normalizes stringified JSON after coercion", () => {
+    const raw = coerceAdapterResponseInput(
+      JSON.stringify({ rows_affected: 3, _message: "OK" }),
+    );
+    const m = normalizeAdapterResponse(raw);
+    expect(m.rowsAffected).toBe(3);
+    expect(m.adapterMessage).toBe("OK");
   });
 
   it("treats empty object as no normalized fields but lists rawKeys", () => {
     const m = normalizeAdapterResponse({});
     expect(m.rawKeys).toEqual([]);
     expect(adapterMetricsHasData(m)).toBe(false);
+  });
+});
+
+describe("normalizeAdapterResponseWithContext adapter parsers", () => {
+  it("normalizes BigQuery response including job_id fallback for queryId", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        _message: "CREATE VIEW (0 processed)",
+        code: "CREATE VIEW",
+        bytes_processed: 100,
+        bytes_billed: 200,
+        location: "us-central1",
+        project_id: "your-project",
+        job_id: "job-123",
+        slot_ms: 77,
+      },
+      { adapterType: "bigquery" },
+    );
+
+    expect(m.bytesProcessed).toBe(100);
+    expect(m.bytesBilled).toBe(200);
+    expect(m.slotMs).toBe(77);
+    expect(m.adapterCode).toBe("CREATE VIEW");
+    expect(m.adapterMessage).toBe("CREATE VIEW (0 processed)");
+    expect(m.queryId).toBe("job-123");
+    expect(m.projectId).toBe("your-project");
+    expect(m.location).toBe("us-central1");
+  });
+
+  it("normalizes Snowflake base fields plus DML detail", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        _message: "SUCCESS 4",
+        rows_affected: 4,
+        code: "SUCCESS",
+        query_id: "sfqid-1",
+        rows_inserted: 3,
+        rows_deleted: 1,
+        rows_updated: 0,
+        rows_duplicates: 2,
+      },
+      { adapterType: "snowflake" },
+    );
+
+    expect(m.rowsAffected).toBe(4);
+    expect(m.queryId).toBe("sfqid-1");
+    expect(m.rowsInserted).toBe(3);
+    expect(m.rowsDeleted).toBe(1);
+    expect(m.rowsUpdated).toBe(0);
+    expect(m.rowsDuplicates).toBe(2);
+  });
+
+  it("normalizes Athena data_scanned_in_bytes as bytesProcessed", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        _message: "OK 5",
+        code: "OK",
+        rows_affected: 5,
+        data_scanned_in_bytes: 12345,
+      },
+      { adapterType: "athena" },
+    );
+
+    expect(m.bytesProcessed).toBe(12345);
+    expect(m.rowsAffected).toBe(5);
+    expect(m.adapterCode).toBe("OK");
+    expect(m.adapterMessage).toBe("OK 5");
+  });
+
+  it("normalizes Postgres base response", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        _message: "INSERT 0 3",
+        code: "INSERT",
+        rows_affected: 3,
+      },
+      { adapterType: "postgres" },
+    );
+    expect(m.rowsAffected).toBe(3);
+    expect(m.adapterCode).toBe("INSERT");
+    expect(m.adapterMessage).toBe("INSERT 0 3");
+  });
+
+  it("normalizes Redshift minimal response", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        _message: "SUCCESS",
+        rows_affected: 11,
+      },
+      { adapterType: "redshift" },
+    );
+    expect(m.rowsAffected).toBe(11);
+    expect(m.adapterMessage).toBe("SUCCESS");
+  });
+
+  it("normalizes Spark minimal response", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        _message: "OK",
+      },
+      { adapterType: "spark" },
+    );
+    expect(m.adapterMessage).toBe("OK");
+    expect(m.rowsAffected).toBeUndefined();
+  });
+});
+
+describe("adapter parser dispatch", () => {
+  it("uses heuristic parsing when adapter type is missing", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        data_scanned_in_bytes: 42,
+      },
+      {},
+    );
+    expect(m.bytesProcessed).toBe(42);
+  });
+
+  it("still yields useful metrics when adapter type is wrong", () => {
+    const m = normalizeAdapterResponseWithContext(
+      {
+        bytes_processed: 55,
+        job_id: "bq-job-1",
+      },
+      { adapterType: "snowflake" },
+    );
+    expect(m.bytesProcessed).toBe(55);
+    expect(m.queryId).toBe("bq-job-1");
+  });
+
+  it("keeps empty objects safe even with adapter type context", () => {
+    const m = normalizeAdapterResponseWithContext({}, { adapterType: "athena" });
+    expect(m).toEqual({ rawKeys: [] });
   });
 });
 

--- a/packages/dbt-tools/core/src/analysis/adapter-response-metrics.test.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response-metrics.test.ts
@@ -161,7 +161,10 @@ describe("adapter parser dispatch", () => {
   });
 
   it("keeps empty objects safe even with adapter type context", () => {
-    const m = normalizeAdapterResponseWithContext({}, { adapterType: "athena" });
+    const m = normalizeAdapterResponseWithContext(
+      {},
+      { adapterType: "athena" },
+    );
     expect(m).toEqual({ rawKeys: [] });
   });
 });

--- a/packages/dbt-tools/core/src/analysis/adapter-response-metrics.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response-metrics.ts
@@ -5,6 +5,12 @@
  * arbitrary UI rendering.
  */
 
+import {
+  normalizeAdapterResponse,
+  normalizeAdapterResponseWithContext,
+  normalizeGenericAdapterResponse,
+} from "./adapter-response";
+
 export type AdapterResponseFieldKind =
   | "number"
   | "string"
@@ -33,6 +39,10 @@ export interface AdapterResponseMetrics {
   queryId?: string;
   projectId?: string;
   location?: string;
+  rowsInserted?: number;
+  rowsDeleted?: number;
+  rowsUpdated?: number;
+  rowsDuplicates?: number;
   /** Top-level keys present on the raw object (for debugging). */
   rawKeys: string[];
 }
@@ -43,34 +53,6 @@ export interface AdapterTotalsSnapshot {
   totalBytesBilled?: number;
   totalSlotMs?: number;
   totalRowsAffected?: number;
-}
-
-function readFiniteNumber(
-  obj: Record<string, unknown>,
-  key: string,
-): number | undefined {
-  const v = obj[key];
-  if (typeof v === "number" && Number.isFinite(v)) {
-    return v;
-  }
-  if (typeof v === "string" && v.trim() !== "") {
-    const n = Number(v);
-    if (Number.isFinite(n)) {
-      return n;
-    }
-  }
-  return undefined;
-}
-
-function readNonEmptyString(
-  obj: Record<string, unknown>,
-  key: string,
-): string | undefined {
-  const v = obj[key];
-  if (typeof v === "string" && v.trim() !== "") {
-    return v;
-  }
-  return undefined;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -186,7 +168,11 @@ export function adapterMetricsHasData(
     metrics.adapterMessage !== undefined ||
     metrics.queryId !== undefined ||
     metrics.projectId !== undefined ||
-    metrics.location !== undefined
+    metrics.location !== undefined ||
+    metrics.rowsInserted !== undefined ||
+    metrics.rowsDeleted !== undefined ||
+    metrics.rowsUpdated !== undefined ||
+    metrics.rowsDuplicates !== undefined
   );
 }
 
@@ -200,6 +186,12 @@ export function isAdapterResponseObject(
  * Some exports / loaders stringify `adapter_response` even though artifacts are
  * normally objects. Parse JSON object/array strings so we can extract fields.
  */
+export {
+  normalizeAdapterResponse,
+  normalizeAdapterResponseWithContext,
+  normalizeGenericAdapterResponse,
+};
+
 export function coerceAdapterResponseInput(raw: unknown): unknown {
   if (typeof raw !== "string") {
     return raw;
@@ -217,48 +209,6 @@ export function coerceAdapterResponseInput(raw: unknown): unknown {
   } catch {
     return raw;
   }
-}
-
-/**
- * Normalize adapter_response from a single run_results result row.
- */
-export function normalizeAdapterResponse(
-  adapterResponse: unknown,
-): AdapterResponseMetrics {
-  if (!isPlainObject(adapterResponse)) {
-    return { rawKeys: [] };
-  }
-
-  const rawKeys = Object.keys(adapterResponse).filter(
-    (k) => typeof k === "string",
-  );
-
-  const bytesProcessed = readFiniteNumber(adapterResponse, "bytes_processed");
-  const bytesBilled = readFiniteNumber(adapterResponse, "bytes_billed");
-  const slotMs = readFiniteNumber(adapterResponse, "slot_ms");
-  const rowsAffected = readFiniteNumber(adapterResponse, "rows_affected");
-
-  const adapterCode = readNonEmptyString(adapterResponse, "code");
-  const adapterMessage = readNonEmptyString(adapterResponse, "_message");
-
-  const queryId =
-    readNonEmptyString(adapterResponse, "query_id") ??
-    readNonEmptyString(adapterResponse, "job_id");
-  const projectId = readNonEmptyString(adapterResponse, "project_id");
-  const location = readNonEmptyString(adapterResponse, "location");
-
-  return {
-    ...(bytesProcessed !== undefined ? { bytesProcessed } : {}),
-    ...(bytesBilled !== undefined ? { bytesBilled } : {}),
-    ...(slotMs !== undefined ? { slotMs } : {}),
-    ...(rowsAffected !== undefined ? { rowsAffected } : {}),
-    ...(adapterCode !== undefined ? { adapterCode } : {}),
-    ...(adapterMessage !== undefined ? { adapterMessage } : {}),
-    ...(queryId !== undefined ? { queryId } : {}),
-    ...(projectId !== undefined ? { projectId } : {}),
-    ...(location !== undefined ? { location } : {}),
-    rawKeys,
-  };
 }
 
 /**

--- a/packages/dbt-tools/core/src/analysis/adapter-response/dispatch.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/dispatch.ts
@@ -1,0 +1,52 @@
+import { athenaAdapterResponseParser } from "./parsers/athena";
+import { bigqueryAdapterResponseParser } from "./parsers/bigquery";
+import { genericAdapterResponseParser } from "./parsers/generic";
+import { postgresAdapterResponseParser } from "./parsers/postgres";
+import { redshiftAdapterResponseParser } from "./parsers/redshift";
+import { snowflakeAdapterResponseParser } from "./parsers/snowflake";
+import { sparkAdapterResponseParser } from "./parsers/spark";
+import type { AdapterResponseObject, AdapterResponseParser } from "./types";
+import { normalizeAdapterType } from "./types";
+
+const ADAPTER_PARSERS: readonly AdapterResponseParser[] = [
+  athenaAdapterResponseParser,
+  bigqueryAdapterResponseParser,
+  postgresAdapterResponseParser,
+  redshiftAdapterResponseParser,
+  snowflakeAdapterResponseParser,
+  sparkAdapterResponseParser,
+];
+
+const PARSER_BY_TYPE = new Map<string, AdapterResponseParser>(
+  ADAPTER_PARSERS.flatMap((parser) =>
+    parser.adapterTypes.map((adapterType) => [normalizeAdapterType(adapterType), parser] as const),
+  ),
+);
+
+/**
+ * Hybrid dispatch: use adapter_type as a hint, but always fall back to
+ * key-based detection and finally generic parsing for resilience.
+ */
+export function selectAdapterResponseParser(
+  adapterType: string | null | undefined,
+  adapterResponse: AdapterResponseObject,
+): AdapterResponseParser {
+  const normalizedType = normalizeAdapterType(adapterType);
+  const typeParser = PARSER_BY_TYPE.get(normalizedType);
+  if (typeParser && typeParser.canParse(adapterResponse)) {
+    return typeParser;
+  }
+
+  const heuristicParser = ADAPTER_PARSERS.find((parser) =>
+    parser.canParse(adapterResponse),
+  );
+  if (heuristicParser) {
+    return heuristicParser;
+  }
+
+  if (typeParser) {
+    return typeParser;
+  }
+
+  return genericAdapterResponseParser;
+}

--- a/packages/dbt-tools/core/src/analysis/adapter-response/dispatch.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/dispatch.ts
@@ -19,7 +19,9 @@ const ADAPTER_PARSERS: readonly AdapterResponseParser[] = [
 
 const PARSER_BY_TYPE = new Map<string, AdapterResponseParser>(
   ADAPTER_PARSERS.flatMap((parser) =>
-    parser.adapterTypes.map((adapterType) => [normalizeAdapterType(adapterType), parser] as const),
+    parser.adapterTypes.map(
+      (adapterType) => [normalizeAdapterType(adapterType), parser] as const,
+    ),
   ),
 );
 

--- a/packages/dbt-tools/core/src/analysis/adapter-response/generic.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/generic.ts
@@ -1,0 +1,9 @@
+import type { AdapterResponseMetrics } from "../adapter-response-metrics";
+import { genericAdapterResponseParser } from "./parsers/generic";
+import type { AdapterResponseObject } from "./types";
+
+export function normalizeGenericAdapterResponse(
+  adapterResponse: AdapterResponseObject,
+): AdapterResponseMetrics {
+  return genericAdapterResponseParser.parse(adapterResponse);
+}

--- a/packages/dbt-tools/core/src/analysis/adapter-response/index.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/index.ts
@@ -1,0 +1,28 @@
+import type { AdapterResponseMetrics } from "../adapter-response-metrics";
+import { selectAdapterResponseParser } from "./dispatch";
+import { normalizeGenericAdapterResponse } from "./generic";
+import type { AdapterResponseParseContext } from "./types";
+import { isPlainObject } from "./types";
+
+export function normalizeAdapterResponseWithContext(
+  adapterResponse: unknown,
+  context: AdapterResponseParseContext,
+): AdapterResponseMetrics {
+  if (!isPlainObject(adapterResponse)) {
+    return { rawKeys: [] };
+  }
+
+  const parser = selectAdapterResponseParser(
+    context.adapterType,
+    adapterResponse,
+  );
+  return parser.parse(adapterResponse);
+}
+
+export function normalizeAdapterResponse(
+  adapterResponse: unknown,
+): AdapterResponseMetrics {
+  return normalizeAdapterResponseWithContext(adapterResponse, {});
+}
+
+export { normalizeGenericAdapterResponse };

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/athena.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/athena.ts
@@ -1,0 +1,22 @@
+import type { AdapterResponseParser } from "../types";
+import { parseBaseMetrics, readFiniteNumber } from "../types";
+
+export const athenaAdapterResponseParser: AdapterResponseParser = {
+  id: "athena",
+  adapterTypes: ["athena"],
+  canParse(adapterResponse) {
+    return "data_scanned_in_bytes" in adapterResponse;
+  },
+  parse(adapterResponse) {
+    const base = parseBaseMetrics(adapterResponse);
+    const bytesProcessed = readFiniteNumber(
+      adapterResponse,
+      "data_scanned_in_bytes",
+    );
+
+    return {
+      ...base,
+      ...(bytesProcessed !== undefined ? { bytesProcessed } : {}),
+    };
+  },
+};

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/bigquery.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/bigquery.ts
@@ -1,0 +1,38 @@
+import type { AdapterResponseParser } from "../types";
+import {
+  parseBaseMetrics,
+  readFiniteNumber,
+  readNonEmptyString,
+} from "../types";
+
+export const bigqueryAdapterResponseParser: AdapterResponseParser = {
+  id: "bigquery",
+  adapterTypes: ["bigquery"],
+  canParse(adapterResponse) {
+    return (
+      "bytes_processed" in adapterResponse ||
+      "bytes_billed" in adapterResponse ||
+      "slot_ms" in adapterResponse ||
+      "job_id" in adapterResponse
+    );
+  },
+  parse(adapterResponse) {
+    const base = parseBaseMetrics(adapterResponse);
+    const bytesProcessed = readFiniteNumber(adapterResponse, "bytes_processed");
+    const bytesBilled = readFiniteNumber(adapterResponse, "bytes_billed");
+    const slotMs = readFiniteNumber(adapterResponse, "slot_ms");
+    const queryId = base.queryId ?? readNonEmptyString(adapterResponse, "job_id");
+    const projectId = readNonEmptyString(adapterResponse, "project_id");
+    const location = readNonEmptyString(adapterResponse, "location");
+
+    return {
+      ...base,
+      ...(bytesProcessed !== undefined ? { bytesProcessed } : {}),
+      ...(bytesBilled !== undefined ? { bytesBilled } : {}),
+      ...(slotMs !== undefined ? { slotMs } : {}),
+      ...(queryId !== undefined ? { queryId } : {}),
+      ...(projectId !== undefined ? { projectId } : {}),
+      ...(location !== undefined ? { location } : {}),
+    };
+  },
+};

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/bigquery.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/bigquery.ts
@@ -21,7 +21,8 @@ export const bigqueryAdapterResponseParser: AdapterResponseParser = {
     const bytesProcessed = readFiniteNumber(adapterResponse, "bytes_processed");
     const bytesBilled = readFiniteNumber(adapterResponse, "bytes_billed");
     const slotMs = readFiniteNumber(adapterResponse, "slot_ms");
-    const queryId = base.queryId ?? readNonEmptyString(adapterResponse, "job_id");
+    const queryId =
+      base.queryId ?? readNonEmptyString(adapterResponse, "job_id");
     const projectId = readNonEmptyString(adapterResponse, "project_id");
     const location = readNonEmptyString(adapterResponse, "location");
 

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/generic.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/generic.ts
@@ -1,0 +1,35 @@
+import type { AdapterResponseParser } from "../types";
+import {
+  parseBaseMetrics,
+  readFiniteNumber,
+  readNonEmptyString,
+} from "../types";
+
+export const genericAdapterResponseParser: AdapterResponseParser = {
+  id: "generic",
+  adapterTypes: [],
+  canParse: () => true,
+  parse(adapterResponse) {
+    const base = parseBaseMetrics(adapterResponse);
+    const bytesProcessed =
+      readFiniteNumber(adapterResponse, "bytes_processed") ??
+      readFiniteNumber(adapterResponse, "data_scanned_in_bytes");
+    const bytesBilled = readFiniteNumber(adapterResponse, "bytes_billed");
+    const slotMs = readFiniteNumber(adapterResponse, "slot_ms");
+    const queryId =
+      base.queryId ??
+      readNonEmptyString(adapterResponse, "job_id");
+    const projectId = readNonEmptyString(adapterResponse, "project_id");
+    const location = readNonEmptyString(adapterResponse, "location");
+
+    return {
+      ...base,
+      ...(bytesProcessed !== undefined ? { bytesProcessed } : {}),
+      ...(bytesBilled !== undefined ? { bytesBilled } : {}),
+      ...(slotMs !== undefined ? { slotMs } : {}),
+      ...(queryId !== undefined ? { queryId } : {}),
+      ...(projectId !== undefined ? { projectId } : {}),
+      ...(location !== undefined ? { location } : {}),
+    };
+  },
+};

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/generic.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/generic.ts
@@ -17,8 +17,7 @@ export const genericAdapterResponseParser: AdapterResponseParser = {
     const bytesBilled = readFiniteNumber(adapterResponse, "bytes_billed");
     const slotMs = readFiniteNumber(adapterResponse, "slot_ms");
     const queryId =
-      base.queryId ??
-      readNonEmptyString(adapterResponse, "job_id");
+      base.queryId ?? readNonEmptyString(adapterResponse, "job_id");
     const projectId = readNonEmptyString(adapterResponse, "project_id");
     const location = readNonEmptyString(adapterResponse, "location");
 

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/postgres.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/postgres.ts
@@ -1,0 +1,9 @@
+import type { AdapterResponseParser } from "../types";
+import { parseBaseMetrics } from "../types";
+
+export const postgresAdapterResponseParser: AdapterResponseParser = {
+  id: "postgres",
+  adapterTypes: ["postgres"],
+  canParse: () => false,
+  parse: parseBaseMetrics,
+};

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/redshift.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/redshift.ts
@@ -1,0 +1,9 @@
+import type { AdapterResponseParser } from "../types";
+import { parseBaseMetrics } from "../types";
+
+export const redshiftAdapterResponseParser: AdapterResponseParser = {
+  id: "redshift",
+  adapterTypes: ["redshift"],
+  canParse: () => false,
+  parse: parseBaseMetrics,
+};

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/snowflake.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/snowflake.ts
@@ -1,0 +1,30 @@
+import type { AdapterResponseParser } from "../types";
+import { parseBaseMetrics, readFiniteNumber } from "../types";
+
+export const snowflakeAdapterResponseParser: AdapterResponseParser = {
+  id: "snowflake",
+  adapterTypes: ["snowflake"],
+  canParse(adapterResponse) {
+    return (
+      "rows_inserted" in adapterResponse ||
+      "rows_deleted" in adapterResponse ||
+      "rows_updated" in adapterResponse ||
+      "rows_duplicates" in adapterResponse
+    );
+  },
+  parse(adapterResponse) {
+    const base = parseBaseMetrics(adapterResponse);
+    const rowsInserted = readFiniteNumber(adapterResponse, "rows_inserted");
+    const rowsDeleted = readFiniteNumber(adapterResponse, "rows_deleted");
+    const rowsUpdated = readFiniteNumber(adapterResponse, "rows_updated");
+    const rowsDuplicates = readFiniteNumber(adapterResponse, "rows_duplicates");
+
+    return {
+      ...base,
+      ...(rowsInserted !== undefined ? { rowsInserted } : {}),
+      ...(rowsDeleted !== undefined ? { rowsDeleted } : {}),
+      ...(rowsUpdated !== undefined ? { rowsUpdated } : {}),
+      ...(rowsDuplicates !== undefined ? { rowsDuplicates } : {}),
+    };
+  },
+};

--- a/packages/dbt-tools/core/src/analysis/adapter-response/parsers/spark.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/parsers/spark.ts
@@ -1,0 +1,9 @@
+import type { AdapterResponseParser } from "../types";
+import { parseBaseMetrics } from "../types";
+
+export const sparkAdapterResponseParser: AdapterResponseParser = {
+  id: "spark",
+  adapterTypes: ["spark"],
+  canParse: () => false,
+  parse: parseBaseMetrics,
+};

--- a/packages/dbt-tools/core/src/analysis/adapter-response/types.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/types.ts
@@ -13,8 +13,12 @@ export type AdapterResponseParseContext = {
   adapterType?: string | null;
 };
 
-export function normalizeAdapterType(adapterType: string | null | undefined): string {
-  return typeof adapterType === "string" ? adapterType.trim().toLowerCase() : "";
+export function normalizeAdapterType(
+  adapterType: string | null | undefined,
+): string {
+  return typeof adapterType === "string"
+    ? adapterType.trim().toLowerCase()
+    : "";
 }
 
 export function readFiniteNumber(
@@ -45,7 +49,9 @@ export function readNonEmptyString(
   return undefined;
 }
 
-export function isPlainObject(value: unknown): value is Record<string, unknown> {
+export function isPlainObject(
+  value: unknown,
+): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 

--- a/packages/dbt-tools/core/src/analysis/adapter-response/types.ts
+++ b/packages/dbt-tools/core/src/analysis/adapter-response/types.ts
@@ -1,0 +1,67 @@
+import type { AdapterResponseMetrics } from "../adapter-response-metrics";
+
+export type AdapterResponseObject = Record<string, unknown>;
+
+export type AdapterResponseParser = {
+  readonly id: string;
+  readonly adapterTypes: readonly string[];
+  canParse(adapterResponse: AdapterResponseObject): boolean;
+  parse(adapterResponse: AdapterResponseObject): AdapterResponseMetrics;
+};
+
+export type AdapterResponseParseContext = {
+  adapterType?: string | null;
+};
+
+export function normalizeAdapterType(adapterType: string | null | undefined): string {
+  return typeof adapterType === "string" ? adapterType.trim().toLowerCase() : "";
+}
+
+export function readFiniteNumber(
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const v = obj[key];
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return v;
+  }
+  if (typeof v === "string" && v.trim() !== "") {
+    const n = Number(v);
+    if (Number.isFinite(n)) {
+      return n;
+    }
+  }
+  return undefined;
+}
+
+export function readNonEmptyString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = obj[key];
+  if (typeof v === "string" && v.trim() !== "") {
+    return v;
+  }
+  return undefined;
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseBaseMetrics(
+  adapterResponse: AdapterResponseObject,
+): AdapterResponseMetrics {
+  const rowsAffected = readFiniteNumber(adapterResponse, "rows_affected");
+  const adapterCode = readNonEmptyString(adapterResponse, "code");
+  const adapterMessage = readNonEmptyString(adapterResponse, "_message");
+  const queryId = readNonEmptyString(adapterResponse, "query_id");
+
+  return {
+    ...(rowsAffected !== undefined ? { rowsAffected } : {}),
+    ...(adapterCode !== undefined ? { adapterCode } : {}),
+    ...(adapterMessage !== undefined ? { adapterMessage } : {}),
+    ...(queryId !== undefined ? { queryId } : {}),
+    rawKeys: Object.keys(adapterResponse),
+  };
+}

--- a/packages/dbt-tools/core/src/analysis/execution-analyzer.test.ts
+++ b/packages/dbt-tools/core/src/analysis/execution-analyzer.test.ts
@@ -143,7 +143,6 @@ describe("ExecutionAnalyzer", () => {
       ).toEqual(["bytes_processed", "job_id"]);
     });
 
-
     it("uses adapter type context when provided", () => {
       const runResults = parseRunResults({
         metadata: {

--- a/packages/dbt-tools/core/src/analysis/execution-analyzer.test.ts
+++ b/packages/dbt-tools/core/src/analysis/execution-analyzer.test.ts
@@ -143,6 +143,64 @@ describe("ExecutionAnalyzer", () => {
       ).toEqual(["bytes_processed", "job_id"]);
     });
 
+
+    it("uses adapter type context when provided", () => {
+      const runResults = parseRunResults({
+        metadata: {
+          dbt_schema_version:
+            "https://schemas.getdbt.com/dbt/run-results/v6.json",
+        },
+        results: [
+          {
+            unique_id: "model.pkg.athena",
+            status: "success",
+            execution_time: 1,
+            thread_id: "Thread-1",
+            adapter_response: {
+              data_scanned_in_bytes: 123,
+              _message: "OK 1",
+            },
+            timing: [],
+          },
+        ],
+      } as Record<string, unknown>);
+
+      const executions = buildNodeExecutionsFromRunResults(runResults, {
+        adapterType: "athena",
+      });
+
+      expect(executions[0]?.adapterMetrics?.bytesProcessed).toBe(123);
+    });
+
+    it("remains resilient with wrong adapter type via fallback heuristics", () => {
+      const runResults = parseRunResults({
+        metadata: {
+          dbt_schema_version:
+            "https://schemas.getdbt.com/dbt/run-results/v6.json",
+        },
+        results: [
+          {
+            unique_id: "model.pkg.mislabeled",
+            status: "success",
+            execution_time: 1,
+            thread_id: "Thread-1",
+            adapter_response: {
+              bytes_processed: 44,
+              job_id: "job-44",
+            },
+            timing: [],
+          },
+        ],
+      } as Record<string, unknown>);
+
+      const executions = buildNodeExecutionsFromRunResults(runResults, {
+        adapterType: "snowflake",
+      });
+
+      expect(executions[0]?.adapterMetrics?.bytesProcessed).toBe(44);
+      expect(executions[0]?.adapterMetrics?.queryId).toBe("job-44");
+    });
+
     it("maps non-empty run result message onto node executions", () => {
       const runResults = parseRunResults({
         metadata: {

--- a/packages/dbt-tools/core/src/analysis/execution-analyzer.ts
+++ b/packages/dbt-tools/core/src/analysis/execution-analyzer.ts
@@ -9,7 +9,7 @@ import {
   coerceAdapterResponseInput,
   extractAdapterResponseFields,
   isAdapterResponseObject,
-  normalizeAdapterResponse,
+  normalizeAdapterResponseWithContext,
 } from "./adapter-response-metrics";
 
 type RunResultLike = {
@@ -72,6 +72,7 @@ export interface ExecutionSummary {
  */
 export function buildNodeExecutionsFromRunResults(
   runResults: ParsedRunResults,
+  options?: { adapterType?: string | null },
 ): NodeExecution[] {
   if (!runResults.results || !Array.isArray(runResults.results)) {
     return [];
@@ -86,7 +87,9 @@ export function buildNodeExecutionsFromRunResults(
     const timing = executeTiming || compileTiming || timingArray[0];
 
     const adapterRaw = coerceAdapterResponseInput(result.adapter_response);
-    const adapterMetrics = normalizeAdapterResponse(adapterRaw);
+    const adapterMetrics = normalizeAdapterResponseWithContext(adapterRaw, {
+      adapterType: options?.adapterType,
+    });
     const adapterResponseFields = extractAdapterResponseFields(adapterRaw);
     const includeAdapter =
       adapterMetrics.rawKeys.length > 0 ||
@@ -116,10 +119,16 @@ export function buildNodeExecutionsFromRunResults(
 export class ExecutionAnalyzer {
   private runResults: ParsedRunResults;
   private graph: ManifestGraph;
+  private adapterType?: string | null;
 
-  constructor(runResults: ParsedRunResults, graph: ManifestGraph) {
+  constructor(
+    runResults: ParsedRunResults,
+    graph: ManifestGraph,
+    options?: { adapterType?: string | null },
+  ) {
     this.runResults = runResults;
     this.graph = graph;
+    this.adapterType = options?.adapterType;
   }
 
   /**
@@ -155,7 +164,9 @@ export class ExecutionAnalyzer {
    * Extract execution information for each node
    */
   getNodeExecutions(): NodeExecution[] {
-    return buildNodeExecutionsFromRunResults(this.runResults);
+    return buildNodeExecutionsFromRunResults(this.runResults, {
+      adapterType: this.adapterType,
+    });
   }
 
   /**

--- a/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot-build.ts
+++ b/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot-build.ts
@@ -51,7 +51,9 @@ export function buildAnalysisSnapshotFromParsedArtifacts(
   const warehouseType = buildWarehouseType(manifestJson);
   const graphStart = now();
   const graph = new ManifestGraph(manifest);
-  const analyzer = new ExecutionAnalyzer(runResults, graph, { adapterType: warehouseType });
+  const analyzer = new ExecutionAnalyzer(runResults, graph, {
+    adapterType: warehouseType,
+  });
   const graphBuildMs = now() - graphStart;
 
   const snapshotStart = now();

--- a/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot-build.ts
+++ b/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot-build.ts
@@ -48,13 +48,13 @@ export function buildAnalysisSnapshotFromParsedArtifacts(
   timings: AnalysisSnapshotBuildTimings;
   graph: ManifestGraph;
 } {
+  const warehouseType = buildWarehouseType(manifestJson);
   const graphStart = now();
   const graph = new ManifestGraph(manifest);
-  const analyzer = new ExecutionAnalyzer(runResults, graph);
+  const analyzer = new ExecutionAnalyzer(runResults, graph, { adapterType: warehouseType });
   const graphBuildMs = now() - graphStart;
 
   const snapshotStart = now();
-  const warehouseType = buildWarehouseType(manifestJson);
   const summary = analyzer.getSummary();
   const manifestEntryLookup = buildManifestEntryLookup(manifestJson);
   const ganttData = analyzer.getGanttData();

--- a/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot.test.ts
+++ b/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot.test.ts
@@ -94,6 +94,50 @@ describe("analysis snapshot facade", () => {
     expect(model?.rawCode).toBeNull();
   });
 
+
+  it("passes manifest warehouse type into adapter-response normalization context", () => {
+    const manifestJson = loadTestManifest(
+      "v12",
+      "manifest_1.10.json",
+    ) as Record<string, unknown>;
+    const metadata = manifestJson.metadata as Record<string, unknown>;
+    metadata.adapter_type = "snowflake";
+
+    const runResultsJson = loadTestRunResults(
+      "v6",
+      "run_results.json",
+    ) as Record<string, unknown>;
+
+    const results =
+      (runResultsJson.results as Array<Record<string, unknown>>) ?? [];
+    const first = results[0];
+    if (!first) {
+      throw new Error(
+        "Expected fixture run_results to contain at least one result",
+      );
+    }
+
+    first.adapter_response = {
+      _message: "SUCCESS",
+      rows_inserted: 5,
+    };
+
+    const manifest = parseManifest(manifestJson);
+    const runResults = parseRunResults(runResultsJson);
+    const { analysis } = buildAnalysisSnapshotFromParsedArtifacts(
+      manifestJson,
+      runResultsJson,
+      manifest,
+      runResults,
+    );
+
+    const execution = analysis.executions.find(
+      (item) => item.uniqueId === String(first.unique_id),
+    );
+
+    expect(execution?.adapterMetrics?.rowsInserted).toBe(5);
+  });
+
   it("preserves raw adapter_response fields in execution rows", () => {
     const manifestJson = loadTestManifest(
       "v12",

--- a/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot.test.ts
+++ b/packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot.test.ts
@@ -94,7 +94,6 @@ describe("analysis snapshot facade", () => {
     expect(model?.rawCode).toBeNull();
   });
 
-
   it("passes manifest warehouse type into adapter-response normalization context", () => {
     const manifestJson = loadTestManifest(
       "v12",


### PR DESCRIPTION
### Motivation
- Improve normalization of `run_results[].adapter_response` by making parsing adapter-aware while remaining resilient when `manifest.metadata.adapter_type` is missing or incorrect. 
- Support first-party dbt adapters' differing response shapes (athena, bigquery, postgres, redshift, snowflake, spark) without tightening upstream schemas and while preserving the existing stable normalized contract and browser-safe raw extraction. 

### Description
- Add a small modular parser registry under `packages/dbt-tools/core/src/analysis/adapter-response/` with explicit parsers for `athena`, `bigquery`, `postgres`, `redshift`, `snowflake`, and `spark`, plus a `generic` fallback parser and a hybrid dispatch in `dispatch.ts` that uses `adapter_type` only as a hint. 
- Expose a context-aware API `normalizeAdapterResponseWithContext(adapterResponse, { adapterType })` and keep `normalizeAdapterResponse(adapterResponse)` as a compatibility wrapper that calls the context-aware path. 
- Integrate adapter-type hinting into execution/snapshot plumbing by passing `warehouseType` (manifest `metadata.adapter_type`) into `ExecutionAnalyzer` and the snapshot builder so normalization receives a dispatch hint. 
- Extend the normalized `AdapterResponseMetrics` with optional Snowflake DML detail fields (`rowsInserted`, `rowsDeleted`, `rowsUpdated`, `rowsDuplicates`) while preserving all existing fields and `rawKeys`; keep raw-field extraction and coercion behavior unchanged. 
- Keep implementation small and testable: added `types.ts`, per-adapter parser modules, `dispatch.ts`, an index facade, and a minimal generic parser that preserves previous best-effort behavior and browser-safe outputs.

### Testing
- Ran targeted unit tests with Vitest: `pnpm --filter @dbt-tools/core exec vitest run packages/dbt-tools/core/src/analysis/adapter-response-metrics.test.ts packages/dbt-tools/core/src/analysis/execution-analyzer.test.ts packages/dbt-tools/core/src/analysis/snapshot/analysis-snapshot.test.ts` and all tests in those files passed. 
- Ran repository lint and coverage checks: `pnpm lint:report` succeeded and `pnpm coverage:report` produced a coverage report (no coverage threshold violations for the change). 
- Noted issues in this environment unrelated to the change: `pnpm knip` failed due to a local `dbt-artifacts-parser` dist module load during Knip config evaluation, and `pnpm --filter @dbt-tools/core build` failed in the workspace because of unresolved `dbt-artifacts-parser/*` dist subpath modules; these are environment/workspace packaging concerns and did not affect unit test verification of the new parser logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d675e9b3fc832ca1c3d0a31096d3ab)