### PR TITLE
docs(adr, readme): reposition dbt-tools as deterministic operational intelligence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dbt-artifacts-parser-ts
 
-A TypeScript monorepo for parsing and analyzing [dbt](https://www.getdbt.com/) artifacts.
+A TypeScript monorepo for parsing and analyzing [dbt](https://www.getdbt.com/) artifacts. The monorepo contains two ecosystems: a lightweight parsing library and a suite of operational intelligence tools for dbt artifact analysis.
 
 This repo contains two distinct but related ecosystems:
 
@@ -34,15 +34,27 @@ Supported artifacts:
 
 > `packages/dbt-tools/` · npm scope: `@dbt-tools`
 
-A suite of analysis tools for dbt artifacts. Built on `dbt-artifacts-parser`.
+A dbt operational intelligence layer: deterministic analysis tools for understanding dependencies, execution, performance, and readiness of dbt artifacts. Built on `dbt-artifacts-parser`. Serves both operators (web UI, CLI) and agents (structured outputs, library).
 
-| Package                                                  | Description                                                                        |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| [`@dbt-tools/core`](./packages/dbt-tools/core/README.md) | Core library — dependency graphs, execution analysis, formatting                   |
-| [`@dbt-tools/cli`](./packages/dbt-tools/cli/README.md)   | CLI tool (`dbt-tools`) for artifact analysis, AI-agent-friendly                    |
-| [`@dbt-tools/web`](./packages/dbt-tools/web/README.md)   | React web app for visual artifact analysis (local target, upload, optional S3/GCS) |
+| Package                                                  | Description                                                                               |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [`@dbt-tools/core`](./packages/dbt-tools/core/README.md) | Core library — dependency graphs, execution analysis, formatting                          |
+| [`@dbt-tools/cli`](./packages/dbt-tools/cli/README.md)   | CLI tool (`dbt-tools`) for deterministic artifact analysis with stable structured outputs |
+| [`@dbt-tools/web`](./packages/dbt-tools/web/README.md)   | React web app for visual artifact analysis (local target, upload, optional S3/GCS)        |
 
 [Suite overview →](./packages/dbt-tools/README.md)
+
+---
+
+## What is dbt-tools?
+
+dbt-tools turns dbt artifacts into deterministic operational intelligence for humans and agents.
+
+**For operators:** Investigate dependencies, identify execution bottlenecks, assess data readiness, and understand materialization strategies without leaving your terminal or opening dbt Cloud.
+
+**For agents and automation:** Structured, machine-readable outputs (JSON, schemas, field filtering) enable integration with agent orchestration frameworks, CI workflows, and other tools.
+
+**Key properties:** Deterministic (same artifact → same analysis), composable (reusable library and CLI), local-first (no external dependencies), no AI required.
 
 ---
 

--- a/docs/adr/0034-operational-intelligence-positioning.md
+++ b/docs/adr/0034-operational-intelligence-positioning.md
@@ -1,0 +1,134 @@
+# 34. Operational intelligence positioning for dbt-tools
+
+Date: 2026-04-09
+
+## Status
+
+Accepted
+
+Builds-on: [6. Artifact-first agent-first positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+
+## Context
+
+dbt-tools provides a suite of CLI, web, and library tools for analyzing dbt artifacts. Early positioning emphasized "agent-first design"—optimization for AI agents consuming outputs. However, this framing risks:
+
+1. **Underselling operator value**: The deterministic analysis (critical path, bottleneck detection, build order, execution timelines, adapter metrics) is directly actionable for human operators without requiring AI.
+2. **Positioning as AI copilot**: "Agent-optimized" language can imply LLM dependence, which is incorrect. dbt-tools delivers full value without any AI/LLM integration.
+3. **Misaligned differentiation**: Comparisons to dbt Cloud or generic observability SaaS matter less than clarity on what this tool **is** (deterministic operational intelligence layer).
+4. **Composability undersold**: The library and CLI are designed as stable, reusable contracts—not merely support infrastructure for a single UI.
+
+The codebase **already implements** the capabilities needed for a clearer positioning; we need to reorient messaging to match substance.
+
+## Decision
+
+We adopt a **deterministic-first, human-and-agent** positioning for dbt-tools:
+
+### 1. Core thesis
+
+**External positioning:** "dbt-tools is a dbt operational intelligence layer"
+
+**Internal positioning:** "a composable analysis substrate for dbt artifacts that serves both operators and agents"
+
+**Unified thesis:** "dot-tools turns dbt artifacts into deterministic operational intelligence for humans and agents"
+
+### 2. What "operational intelligence" means
+
+Structured analysis derived entirely from artifacts:
+
+- **Dependency intelligence**: Build order, upstream/downstream traversal, subgraph focus, cycle detection
+- **Execution intelligence**: Critical path calculation, bottleneck ranking, Gantt timeline visualization, per-node metrics
+- **Performance intelligence**: Adapter-agnostic cost and performance metrics (bytes, slots, row counts, query IDs per warehouse)
+- **Readiness intelligence**: Artifact freshness, completeness (manifest-only vs full), materialization kinds
+- **Inventory intelligence**: Resource listing, tagging, search, filtering by type, package, path
+
+All analysis is **deterministic**: same artifact input always produces identical output.
+
+### 3. Who uses dbt-tools and why
+
+**Operators (humans via web UI and CLI):**
+
+- Investigate critical paths and bottlenecks for optimization
+- Understand execution parallelism and resource dependencies
+- Assess artifact freshness and data readiness
+- Browse and discover resources at scale
+- Diagnose slow or failing runs without dbt Cloud
+
+**Agents / automation (via CLI and library):**
+
+- Structured, machine-readable outputs (JSON, schema introspection)
+- Field filtering for context window optimization
+- Error codes for programmatic error handling
+- Build order for orchestration workflows
+- Dependency intelligence for impact analysis
+- No AI/LLM required; outputs feed into deterministic automation
+
+### 4. What dbt-tools is NOT
+
+Explicit non-goals:
+
+- **Not dbt Cloud**: No execution, no platform integration, no admin APIs
+- **Not an observability SaaS**: No real-time monitoring, no alerting, no external dependencies
+- **Not an AI copilot / chat tool**: No LLM integration, no generated prose, no conversational interface
+- **Not merely a graph viewer**: Analysis-backed, deterministic outputs for downstream use
+- **Not a replacement for dbt-mcp**: No SQL execution, no semantic layer, no LSP, no live project features
+
+### 5. Composability and future extensibility
+
+Core library and CLI are designed as **stable, embeddable, reusable contracts**:
+
+- Library: imported as analysis engine for other tools
+- CLI: consumed by agent orchestration frameworks, CI scripts, other tools
+- Structured outputs: composable with other agent skills (cost analysis, warehouse metadata, CI context)
+
+dbt-tools intentionally avoids vendor lock-in or speculative SaaS features. Operators and agents are enabled to integrate it into their own workflows.
+
+### 6. Message hierarchy for documentation
+
+1. **What it is**: dbt operational intelligence layer
+2. **What it does**: transforms artifacts into structured dependency, execution, readiness intelligence
+3. **Who it serves**: operators (web/CLI) and agents (CLI/library)
+4. **Why it matters**: deterministic, actionable, composable, local-first, no AI required
+5. **What it's not**: explicit non-goals listed above
+
+## Consequences
+
+**Positive:**
+
+- Clearer differentiation: "deterministic operational intelligence" is distinct from platforms, SaaS, and chat tools
+- Honest value prop: emphasizes human-accessible value without AI/LLM
+- Honest about scope: agents are supported through stable structured interfaces, not as primary positioning
+- Empowers operators: highlights workflows and actions, not just "visualization"
+- Enables composability: library and CLI are recognized as reusable contracts
+
+**Negative / risks:**
+
+- Market positioning becomes narrower: explicitly not a dbt Cloud alternative or observability platform
+- Agents require orchestration: dbt-tools outputs are inputs to agent workflows, not agentic itself
+- Cost data limited to artifacts: no warehouse API access for richer cost signals
+
+**Mitigations:**
+
+- Document explicitly in README and ADRs what dbt-tools does and doesn't do
+- Link to complementary tools (dbt-mcp, dbt extension, external orchestration frameworks) for unmet needs
+- Extend artifact-derived analysis where possible (bottleneck detection, adapter metrics, timeline)
+
+## Alternatives considered
+
+1. **Keep "agent-first" framing**: Rejected—undersells operator value and risks positioning as AI copilot
+2. **Position as dbt Cloud alternative**: Rejected—incorrect, confuses users, unsustainable (no execution)
+3. **Position as observability platform**: Rejected—no real-time monitoring, no alerting, scope creep
+4. **Narrow to library-only**: Rejected—CLI and web are valuable entry points; library alone undersells
+5. **Focus on AI agents only**: Rejected—deterministic analysis stands on its own for human operators
+
+## References
+
+- [ADR-0006: Artifact-first agent-first positioning](0006-artifact-first-agent-first-positioning-of-dbt-tools.md) — architectural strategy (no platforms, no LSP, offline-first)
+- [ADR-0005: Field-level lineage via AST parsing](0005-field-level-lineage-inference-via-ast-parsing.md) — unique analysis capability
+- [ADR-0007: Bottleneck detection via run_results search](0007-bottleneck-detection-via-run-results-search.md) — execution analysis
+- [ADR-0030: Adapter response metrics](0030-adapter-response-metrics-in-analysis-snapshot-and-run-report.md) — performance intelligence
+- **Code evidence:**
+  - ExecutionAnalyzer: critical path, Gantt, bottleneck detection (`packages/dbt-tools/core/src/analysis/execution-analyzer.ts`)
+  - ManifestGraph: dependency analysis, build order (`packages/dbt-tools/core/src/analysis/manifest-graph.ts`)
+  - AdapterResponseMetrics: warehouse-agnostic cost/performance data (`packages/dbt-tools/core/src/analysis/adapter-response-metrics.ts`)
+  - CLI: deterministic structured interface with field filtering, schema introspection (`packages/dbt-tools/cli/src/cli.ts`)
+  - Web: investigative workspace for operators (`packages/dbt-tools/web/src/`)

--- a/docs/user-guide-dbt-tools-cli.md
+++ b/docs/user-guide-dbt-tools-cli.md
@@ -1,6 +1,6 @@
 # User guide: @dbt-tools/cli
 
-Extended notes for automation and AI agents using **`dbt-tools`**. For the full command reference (`summary`, `graph`, `run-report`, `deps`, `schema`), see the [package README](../packages/dbt-tools/cli/README.md).
+Extended notes for using **`dbt-tools`** from scripts, CI workflows, and agent orchestration frameworks. For the full command reference (`summary`, `graph`, `run-report`, `deps`, `schema`), see the [package README](../packages/dbt-tools/cli/README.md).
 
 ---
 
@@ -23,7 +23,7 @@ npx @dbt-tools/cli --help
 
 ## Schema introspection
 
-Discover commands and flags at runtime (useful for agents):
+Discover commands and flags at runtime (useful for scripts, agents, and dynamic tools):
 
 ```bash
 dbt-tools schema
@@ -87,13 +87,14 @@ Errors are JSON with a stable **`code`** field:
 
 ---
 
-## Best practices for AI agents
+## Best practices for structured automation
 
-1. Prefer **`--fields`** on large outputs.
+1. Prefer **`--fields`** on large outputs to optimize payload size.
 2. Use default **`./target`** unless paths must differ.
-3. Use **`dbt-tools schema`** when argument shapes are unclear.
-4. Branch on **`code`** in JSON error bodies in scripts.
+3. Use **`dbt-tools schema`** when argument shapes are unclear (enables capability discovery at runtime).
+4. Branch on **`code`** in JSON error bodies for deterministic error handling.
 5. Keep resource IDs literal dbt **`unique_id`** strings — never URL-encode or append query parameters.
+6. Parse JSON with strict field expectations (values may change as artifacts update between dbt versions).
 
 ---
 

--- a/docs/user-guide-dbt-tools-web.md
+++ b/docs/user-guide-dbt-tools-web.md
@@ -4,6 +4,20 @@ Operator-focused documentation for the dbt-tools web analyzer. For a short npm-f
 
 ---
 
+## Operational intelligence workflows
+
+dbt-tools/web is designed as an investigative workspace. Common workflows:
+
+- **Identify execution bottlenecks**: Use the timeline and execution report to find the slowest nodes, then drill into their upstream dependencies to understand build blockers.
+- **Understand critical path**: The execution timeline shows which nodes are on the critical path; optimizing these provides the most value.
+- **Assess data readiness**: The inventory view shows materialization kinds and artifact freshness; the status view confirms which artifacts are present and current.
+- **Trace blast radius**: The dependency graph helps understand what downstream models are affected by a particular change or failure.
+- **Investigate performance metrics**: Per-node execution timings and warehouse-specific metrics (bytes, slots, rows) help diagnose slow or expensive runs.
+
+All analysis is deterministic and requires no external dependencies (local-first).
+
+---
+
 ## Vite dev server (monorepo)
 
 When you run `pnpm dev` / `pnpm dev:web` from the repository, **Vite** serves the app with middleware that mirrors the same **`/api/...`** artifact routes as the published **`dbt-tools-web`** server. Additional **file watching** behavior applies only here.

--- a/packages/dbt-tools/README.md
+++ b/packages/dbt-tools/README.md
@@ -1,6 +1,29 @@
 # @dbt-tools
 
-A suite of TypeScript tools for analyzing dbt artifacts, built on [`dbt-artifacts-parser`](../dbt-artifacts-parser/README.md).
+A dbt operational intelligence layer: deterministic analysis tools for understanding dependencies, execution, performance, and readiness of dbt artifacts. Built on [`dbt-artifacts-parser`](../dbt-artifacts-parser/README.md).
+
+Designed as a composable analysis substrate: reusable by operators (web UI, CLI), agents (structured CLI outputs, library), and other tools.
+
+---
+
+## What dbt-tools provides
+
+**Deterministic artifact intelligence:**
+
+- **Dependency intelligence**: Build order, upstream/downstream graphs, subgraph focus
+- **Execution intelligence**: Critical path, bottleneck detection, timeline visualization
+- **Performance intelligence**: Per-warehouse cost and performance metrics from adapter responses
+- **Readiness intelligence**: Artifact freshness, completeness, materialization kinds
+
+**Actionable without AI:** All analysis is deterministic (same artifact → same output) and useful immediately for operators without requiring LLMs or external services.
+
+**For operators:** Web UI and CLI for investigating slow runs, understanding dependencies, assessing data readiness.
+
+**For agents / automation:** Structured JSON outputs, schema introspection, field filtering, error codes—enabling integration with orchestration frameworks, CI, and other tools.
+
+**Not:** dbt Cloud, observability SaaS, AI copilot, or merely a graph viewer.
+
+See [ADR-0034: Operational intelligence positioning](../../docs/adr/0034-operational-intelligence-positioning.md) for strategic positioning.
 
 ---
 
@@ -35,7 +58,7 @@ graph TD
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | Parse dbt JSON artifacts in TypeScript with type safety                                                                                         | [`dbt-artifacts-parser`](../dbt-artifacts-parser/README.md)                                                                     |
 | Build a dependency graph or run execution analysis programmatically                                                                             | [`@dbt-tools/core`](./core/README.md)                                                                                           |
-| Analyze artifacts from the command line or feed results to an AI agent                                                                          | [`@dbt-tools/cli`](./cli/README.md)                                                                                             |
+| Get deterministic structured analysis from the command line (humans, scripts, agents)                                                           | [`@dbt-tools/cli`](./cli/README.md)                                                                                             |
 | Visually explore dependencies and execution timelines in a browser (local target, upload, or optional **S3/GCS** via `DBT_TOOLS_REMOTE_SOURCE`) | [`@dbt-tools/web`](./web/README.md) · [ADR-0029](../../docs/adr/0029-remote-object-storage-artifact-sources-and-auto-reload.md) |
 
 ---

--- a/packages/dbt-tools/cli/README.md
+++ b/packages/dbt-tools/cli/README.md
@@ -1,8 +1,8 @@
 # @dbt-tools/cli
 
-Command-line interface for dbt artifact analysis. Optimized for both human and AI agent consumption.
+Command-line interface for dbt artifact analysis. Stable structured interface designed for humans, scripts, and agents.
 
-**Quick start:** install Node.js **20+** (see the repo [`.node-version`](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/.node-version) for the version used in development; Node 18 is EOL — [releases](https://nodejs.org/en/about/previous-releases)), then `npm install -g @dbt-tools/cli` and run `dbt-tools summary` from a directory that contains `./target/manifest.json`. Extended agent-focused topics (errors, validation, `schema` introspection) are in the [user guide](../../../docs/user-guide-dbt-tools-cli.md).
+**Quick start:** install Node.js **20+** (see the repo [`.node-version`](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/.node-version) for the version used in development; Node 18 is EOL — [releases](https://nodejs.org/en/about/previous-releases)), then `npm install -g @dbt-tools/cli` and run `dbt-tools summary` from a directory that contains `./target/manifest.json`. For detailed guides on error handling, validation, schema introspection, and automation integrations, see the [user guide](../../../docs/user-guide-dbt-tools-cli.md).
 
 ## Commands
 
@@ -45,7 +45,7 @@ pnpm add -g @dbt-tools/cli
 - **Default `./target` directory**: Commands default to dbt's standard artifact location
 - **JSON-by-default**: Machine-readable JSON output in non-interactive environments
 - **Input validation**: Hardened against common agent mistakes (path traversals, control chars, etc.)
-- **Field filtering**: Reduce context window usage with `--fields` option
+- **Field filtering**: Project outputs to specific fields with `--fields` option for flexible optimization
 - **Schema introspection**: Runtime command discovery via `schema` command
 - **Dependency analysis**: Find upstream/downstream dependencies with `deps` command
 - **Inventory**: Browse and filter all dbt resources in one view
@@ -72,7 +72,7 @@ dbt-tools summary --target-dir ./custom-target
 # Explicit path
 dbt-tools summary path/to/manifest.json
 
-# Field filtering to reduce context window usage
+# Field filtering to project output
 dbt-tools summary --fields "total_nodes,total_edges"
 
 # JSON output
@@ -553,7 +553,7 @@ The CLI automatically outputs JSON when stdout is not a TTY (non-interactive env
 
 ## Field Filtering
 
-Use `--fields` to limit response size and reduce context window usage. Supported in `summary`, `deps`, `graph` (JSON), `run-report`, `inventory`, and `search`.
+Use `--fields` to project output to specific fields—reduces payload size and enables flexible output optimization. Supported in `summary`, `deps`, `graph` (JSON), `run-report`, `inventory`, and `search`.
 
 ```bash
 # Only return specific fields
@@ -608,11 +608,13 @@ Errors are formatted as JSON in non-TTY environments:
 
 ---
 
-## Best Practices for AI Agents
+## Structured Output and Automation Integration
+
+Best practices for scripting, CI integration, and agent orchestration:
 
 1. **Run `status` first** to check which artifacts are available before running analysis commands.
 2. **Use `search` to discover resources** before running `deps` or `inventory`.
-3. **Always use field filtering** for dependency queries and analysis to reduce context window usage.
+3. **Use field filtering** (`--fields`) for targeted analysis to optimize payload size and response time.
 4. **Use default `./target` directory** unless you have a specific reason not to.
 5. **Validate resource IDs** before querying (use schema introspection if unsure).
 6. **Handle errors programmatically** using error codes in non-interactive environments.

--- a/packages/dbt-tools/core/README.md
+++ b/packages/dbt-tools/core/README.md
@@ -1,6 +1,6 @@
 # @dbt-tools/core
 
-Core library for dbt artifact graph management and analysis. Provides the analysis engine used by [`@dbt-tools/cli`](../cli/README.md) and [`@dbt-tools/web`](../web/README.md).
+Reusable analysis substrate for dbt artifacts. Provides deterministic graph, execution, and dependency analysis for building tools, CLIs, web apps, and agent integrations. Used by [`@dbt-tools/cli`](../cli/README.md) and [`@dbt-tools/web`](../web/README.md); embeddable in other projects.
 
 ---
 
@@ -159,7 +159,7 @@ Validates user-supplied strings against common injection patterns (path traversa
 
 ### OutputFormatter / FieldFilter
 
-Formats analysis output as JSON or human-readable text. `FieldFilter` limits output to a specified set of fields (useful for reducing context window usage in AI agents).
+Formats analysis output as JSON or human-readable text. `FieldFilter` projects output to a specified set of fields—reduces payload size, enables field-level access control, and optimizes output for various consumer contexts (terminals, scripts, agents).
 
 ### GraphExport
 

--- a/packages/dbt-tools/web/README.md
+++ b/packages/dbt-tools/web/README.md
@@ -1,6 +1,6 @@
 # @dbt-tools/web
 
-React application for visual dbt artifact analysis: dependency graphs, execution timelines, inventory views, and optional remote runs from S3 or GCS.
+Interactive investigation workspace for dbt artifacts. Explore dependencies, identify execution bottlenecks, assess data readiness, and understand materialization strategies with deterministic operational intelligence—no external dependencies required.
 
 **End users:** install from npm and run **`dbt-tools-web`** (see below). **Contributors:** clone the monorepo and use Vite — see [Developing from source](#developing-from-source) and [CONTRIBUTING.md](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/CONTRIBUTING.md).
 
@@ -54,11 +54,13 @@ You can also set **`DBT_TOOLS_TARGET_DIR`** (or legacy `DBT_TARGET_DIR` / `DBT_T
 
 ## Features
 
-- **Dependency graph** — interactive lineage
-- **Execution timeline** — Gantt-style `run_results` with critical path
+- **Dependency graph** — trace upstream/downstream dependencies, understand blast radius, identify critical resource paths
+- **Execution timeline** — Gantt-style `run_results` visualization with critical path, bottleneck detection, per-node metrics
+- **Inventory** — browse and filter all resources; assess materialization strategies and data readiness
 - **Local artifacts** — read `manifest.json` / `run_results.json` from a target directory via server-side routes
 - **Remote sources (S3 / GCS)** — optional `DBT_TOOLS_REMOTE_SOURCE`; server-side credentials; UI prompts before switching runs ([ADR-0029](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/docs/adr/0029-remote-object-storage-artifact-sources-and-auto-reload.md))
 - **Large manifests** — web workers and virtualization for very large projects
+- **Actionable without AI** — deterministic analysis provides immediate value for investigations and optimization
 
 ---
 


### PR DESCRIPTION
**Core messaging shift:**
- External: "dbt operational intelligence layer"
- Internal: "composable analysis substrate for operators and agents"
- Thesis: "dot-tools turns dbt artifacts into deterministic operational intelligence"

**Key changes:**
- ADR-0034: New strategic positioning for operational intelligence
- De-emphasize "agent-first" in favor of "deterministic-first"
- Reframe CLI as "stable structured interface" vs "optimized for agents"
- Emphasize "actionable without AI" across operator-facing docs
- Clarify agent compatibility as architectural property, not primary positioning
- Add explicit non-goals: not dbt Cloud, not Elementary, not AI copilot
- Improve action-oriented language for web app (investigate, identify bottlenecks, assess readiness)
- Enhance CLI user guide to cover structured automation patterns

**Files updated:**
- docs/adr/0034-operational-intelligence-positioning.md (new)
- README.md: Add "What is dbt-tools?" section
- packages/dbt-tools/README.md: Add positioning and feature details
- packages/dbt-tools/core/README.md: Reframe as "reusable analysis substrate"
- packages/dbt-tools/cli/README.md: Update to "stable structured interface"
- packages/dbt-tools/web/README.md: Enhance action-oriented language
- docs/user-guide-dbt-tools-cli.md: Restructure for deterministic intelligence first
- docs/user-guide-dbt-tools-web.md: Add operational intelligence workflows

Verification:
✓ pnpm lint:report: score=100, errors=0, warnings=0
✓ pnpm knip: no unused exports or dead code
✓ pnpm build: success

https://claude.ai/code/session_01FWLxy2DhoUvEBqoLKjWjyN