### PR TITLE
docs: position dot-tools as deterministic dbt operational intelligence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # dbt-artifacts-parser-ts
 
-A TypeScript monorepo for parsing and analyzing [dbt](https://www.getdbt.com/) artifacts.
+A TypeScript monorepo for parsing and operational analysis of [dbt](https://www.getdbt.com/) artifacts.
+
+For the `@dbt-tools/*` packages, the product thesis is: **dot-tools is a dbt operational intelligence layer**. It turns dbt artifacts into deterministic, structured intelligence for human operators and for automation/agents.
 
 This repo contains two distinct but related ecosystems:
 
 | Ecosystem                                                  | Description                                                                                     |
 | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [`dbt-artifacts-parser`](./packages/dbt-artifacts-parser/) | Standalone parsing library — type definitions and auto-version-detection for dbt JSON artifacts |
-| [`@dbt-tools/*`](./packages/dbt-tools/)                    | Analysis tools suite (CLI, core library, web app) built on top of the parser                    |
+| [`@dbt-tools/*`](./packages/dbt-tools/)                    | Operational intelligence layer (core substrate, CLI contract, web investigation workspace) built on top of the parser |
 
 ## Packages
 
@@ -38,13 +40,29 @@ A suite of analysis tools for dbt artifacts. Built on `dbt-artifacts-parser`.
 
 | Package                                                  | Description                                                                        |
 | -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| [`@dbt-tools/core`](./packages/dbt-tools/core/README.md) | Core library — dependency graphs, execution analysis, formatting                   |
-| [`@dbt-tools/cli`](./packages/dbt-tools/cli/README.md)   | CLI tool (`dbt-tools`) for artifact analysis, AI-agent-friendly                    |
-| [`@dbt-tools/web`](./packages/dbt-tools/web/README.md)   | React web app for visual artifact analysis (local target, upload, optional S3/GCS) |
+| [`@dbt-tools/core`](./packages/dbt-tools/core/README.md) | Composable analysis substrate — graph/dependency/execution primitives and schema/introspection exports |
+| [`@dbt-tools/cli`](./packages/dbt-tools/cli/README.md)   | Stable machine-readable interface (`dbt-tools`) for deterministic automation and agent workflows |
+| [`@dbt-tools/web`](./packages/dbt-tools/web/README.md)   | Investigation workspace for actionable artifact intelligence without requiring AI |
 
 [Suite overview →](./packages/dbt-tools/README.md)
 
 ---
+
+## Positioning and non-goals (`@dbt-tools/*`)
+
+- **External positioning:** a dbt operational intelligence layer.
+- **Internal architecture framing:** a composable analysis substrate for dbt artifacts serving both operators and agents.
+- **Deterministic-first:** core value comes from reproducible artifact analysis, not generated prose.
+- **AI-optional:** LLMs can consume outputs, but AI is not required for useful operator workflows.
+- **Local-first:** works with local artifacts and controlled environments, with optional remote object storage inputs.
+
+Explicit non-goals:
+
+- not a hosted dbt execution platform
+- not a replacement for dbt Cloud
+- not a replacement for Elementary
+- not a chat-first dbt copilot
+- not only a DAG viewer
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ For the `@dbt-tools/*` packages, the product thesis is: **dot-tools is a dbt ope
 
 This repo contains two distinct but related ecosystems:
 
-| Ecosystem                                                  | Description                                                                                     |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`dbt-artifacts-parser`](./packages/dbt-artifacts-parser/) | Standalone parsing library — type definitions and auto-version-detection for dbt JSON artifacts |
+| Ecosystem                                                  | Description                                                                                                           |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| [`dbt-artifacts-parser`](./packages/dbt-artifacts-parser/) | Standalone parsing library — type definitions and auto-version-detection for dbt JSON artifacts                       |
 | [`@dbt-tools/*`](./packages/dbt-tools/)                    | Operational intelligence layer (core substrate, CLI contract, web investigation workspace) built on top of the parser |
 
 ## Packages
@@ -38,11 +38,11 @@ Supported artifacts:
 
 A suite of analysis tools for dbt artifacts. Built on `dbt-artifacts-parser`.
 
-| Package                                                  | Description                                                                        |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Package                                                  | Description                                                                                            |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | [`@dbt-tools/core`](./packages/dbt-tools/core/README.md) | Composable analysis substrate — graph/dependency/execution primitives and schema/introspection exports |
-| [`@dbt-tools/cli`](./packages/dbt-tools/cli/README.md)   | Stable machine-readable interface (`dbt-tools`) for deterministic automation and agent workflows |
-| [`@dbt-tools/web`](./packages/dbt-tools/web/README.md)   | Investigation workspace for actionable artifact intelligence without requiring AI |
+| [`@dbt-tools/cli`](./packages/dbt-tools/cli/README.md)   | Stable machine-readable interface (`dbt-tools`) for deterministic automation and agent workflows       |
+| [`@dbt-tools/web`](./packages/dbt-tools/web/README.md)   | Investigation workspace for actionable artifact intelligence without requiring AI                      |
 
 [Suite overview →](./packages/dbt-tools/README.md)
 

--- a/docs/adr/0005-field-level-lineage-inference-via-ast-parsing.md
+++ b/docs/adr/0005-field-level-lineage-inference-via-ast-parsing.md
@@ -6,7 +6,7 @@ Date: 2026-03-13
 
 Accepted
 
-Builds on field-level lineage [6. Artifact-first agent-first positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Builds on field-level lineage [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 ## Context
 

--- a/docs/adr/0005-field-level-lineage-inference-via-ast-parsing.md
+++ b/docs/adr/0005-field-level-lineage-inference-via-ast-parsing.md
@@ -6,7 +6,7 @@ Date: 2026-03-13
 
 Accepted
 
-Builds on field-level lineage [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Builds on field-level lineage [6. Artifact-first and agent-compatible positioning of dbt-tools (superseded in part)](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 ## Context
 

--- a/docs/adr/0006-artifact-first-agent-first-positioning-of-dbt-tools.md
+++ b/docs/adr/0006-artifact-first-agent-first-positioning-of-dbt-tools.md
@@ -10,8 +10,6 @@ Superseded-by [34. Position dot-tools as a deterministic operational intelligenc
 
 Depends-on [5. Field-level lineage inference via AST parsing](0005-field-level-lineage-inference-via-ast-parsing.md)
 
-Depends-on [5. Field-level lineage inference via AST parsing](0005-field-level-lineage-inference-via-ast-parsing.md)
-
 Supports [10. Per-package coverage breakdown and fixture-based CLI tests for agent feedback](0010-per-package-coverage-breakdown-and-fixture-based-cli-tests-for-agent-feedback.md)
 
 ## Context

--- a/docs/adr/0006-artifact-first-agent-first-positioning-of-dbt-tools.md
+++ b/docs/adr/0006-artifact-first-agent-first-positioning-of-dbt-tools.md
@@ -1,10 +1,12 @@
-# 6. Artifact-first agent-first positioning of dbt-tools
+# 6. Artifact-first and agent-compatible positioning of dbt-tools (superseded in part)
 
 Date: 2026-03-13
 
 ## Status
 
 Accepted
+
+Superseded-by [34. Position dot-tools as a deterministic operational intelligence layer for dbt artifacts](0034-position-dot-tools-as-deterministic-operational-intelligence-layer.md)
 
 Depends-on [5. Field-level lineage inference via AST parsing](0005-field-level-lineage-inference-via-ast-parsing.md)
 

--- a/docs/adr/0010-per-package-coverage-breakdown-and-fixture-based-cli-tests-for-agent-feedback.md
+++ b/docs/adr/0010-per-package-coverage-breakdown-and-fixture-based-cli-tests-for-agent-feedback.md
@@ -6,7 +6,7 @@ Date: 2026-03-13
 
 Accepted
 
-Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools (superseded in part)](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 Depends-on [8. Stricter ESLint complexity rules for AI agent feedback](0008-stricter-eslint-complexity-rules-for-ai-agent-feedback.md)
 

--- a/docs/adr/0010-per-package-coverage-breakdown-and-fixture-based-cli-tests-for-agent-feedback.md
+++ b/docs/adr/0010-per-package-coverage-breakdown-and-fixture-based-cli-tests-for-agent-feedback.md
@@ -6,7 +6,7 @@ Date: 2026-03-13
 
 Accepted
 
-Depends-on [6. Artifact-first agent-first positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 Depends-on [8. Stricter ESLint complexity rules for AI agent feedback](0008-stricter-eslint-complexity-rules-for-ai-agent-feedback.md)
 

--- a/docs/adr/0011-web-workspace-mvp-for-visual-dbt-analysis.md
+++ b/docs/adr/0011-web-workspace-mvp-for-visual-dbt-analysis.md
@@ -6,7 +6,7 @@ Date: 2026-03-13
 
 Accepted
 
-Depends-on [6. Artifact-first agent-first positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 Extends web workspace MVP [12. Optional default dbt target directory for web dev server](0012-optional-default-dbt-target-directory-for-web-dev-server.md)
 

--- a/docs/adr/0011-web-workspace-mvp-for-visual-dbt-analysis.md
+++ b/docs/adr/0011-web-workspace-mvp-for-visual-dbt-analysis.md
@@ -6,7 +6,7 @@ Date: 2026-03-13
 
 Accepted
 
-Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools (superseded in part)](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 Extends web workspace MVP [12. Optional default dbt target directory for web dev server](0012-optional-default-dbt-target-directory-for-web-dev-server.md)
 

--- a/docs/adr/0029-remote-object-storage-artifact-sources-and-auto-reload.md
+++ b/docs/adr/0029-remote-object-storage-artifact-sources-and-auto-reload.md
@@ -6,7 +6,7 @@ Date: 2026-03-29
 
 Accepted
 
-Depends-on [6. Artifact-first agent-first positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 Depends-on [15. MVC-style layering for web app](0015-mvc-style-layering-for-web-app.md)
 

--- a/docs/adr/0029-remote-object-storage-artifact-sources-and-auto-reload.md
+++ b/docs/adr/0029-remote-object-storage-artifact-sources-and-auto-reload.md
@@ -6,7 +6,7 @@ Date: 2026-03-29
 
 Accepted
 
-Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools (superseded in part)](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
 
 Depends-on [15. MVC-style layering for web app](0015-mvc-style-layering-for-web-app.md)
 

--- a/docs/adr/0034-position-dot-tools-as-deterministic-operational-intelligence-layer.md
+++ b/docs/adr/0034-position-dot-tools-as-deterministic-operational-intelligence-layer.md
@@ -1,0 +1,98 @@
+# 34. Position dot-tools as a deterministic operational intelligence layer for dbt artifacts
+
+Date: 2026-04-09
+
+## Status
+
+Accepted
+
+Depends-on [6. Artifact-first and agent-compatible positioning of dbt-tools (superseded in part)](0006-artifact-first-agent-first-positioning-of-dbt-tools.md)
+
+## Context
+
+Current repository messaging often describes dot-tools as “CLI + web + core,” which is implementation-accurate but strategically incomplete. It underspecifies:
+
+- the operator outcome (actionable investigation, not only visualization),
+- the automation outcome (stable structured contract, not chat UX), and
+- the architectural center (`@dbt-tools/core` as reusable substrate, not only package internals).
+
+The codebase already provides deterministic artifact analysis primitives and interfaces:
+
+- graph/dependency/execution analysis from dbt artifacts,
+- machine-readable CLI behavior in non-TTY contexts,
+- schema introspection and field filtering for low-noise consumers,
+- web workflows for timeline, lineage, inventory, and readiness checks,
+- local-first operation with optional remote artifact source ingestion.
+
+Without an explicit product thesis, docs drift toward one of two failure modes: (1) “just another DAG viewer,” or (2) “AI copilot” framing that overstates current capabilities and obscures deterministic value.
+
+## Decision
+
+Adopt the following canonical framing across repository documentation and future ADRs:
+
+1. **External positioning:** dot-tools is a **dbt operational intelligence layer**.
+2. **Internal architecture framing:** dot-tools is a **composable analysis substrate for dbt artifacts serving operators and agents**.
+3. **Primary artifact:** structured deterministic intelligence (JSON objects, graph exports, typed analysis results), not generated prose.
+4. **AI stance:** AI is optional and downstream; value must remain actionable without AI.
+5. **Package roles:**
+   - `@dbt-tools/core`: reusable analysis substrate and primitives,
+   - `@dbt-tools/cli`: stable structured contract for automation/agents,
+   - `@dbt-tools/web`: operator investigation workspace for action-oriented diagnostics.
+
+## Non-goals
+
+- Build a hosted dbt execution platform.
+- Replicate dbt Cloud functionality end-to-end.
+- Replicate Elementary functionality end-to-end.
+- Position dot-tools as a chat-first dbt copilot.
+- Reduce the product proposition to a DAG viewer.
+
+## Why deterministic, non-AI workflows come first
+
+- **Reproducibility:** operators and CI systems need stable results from fixed artifacts.
+- **Auditability:** deterministic JSON outputs and typed interfaces are inspectable and testable.
+- **Controlled environments:** many teams operate without broad external API access or model dependencies.
+- **Composability:** stable structured outputs can be consumed by scripts, CI, and future agent skills uniformly.
+
+AI can summarize or prioritize findings, but it should consume deterministic outputs rather than replace them.
+
+## Why agent compatibility is architectural (but not the whole product)
+
+Agent compatibility is achieved through interface properties (schema discovery, stable error codes, field filters, machine-readable output modes), not through a chat frontend. This improves reliability for automation while preserving direct value for human operators in the web UI and CLI text mode.
+
+## Alternatives considered
+
+### 1) Keep package-by-package implementation messaging only
+
+Rejected. Accurate but too low-level; it does not communicate why the pieces exist or how they compose into operator + automation value.
+
+### 2) Reposition as AI copilot first
+
+Rejected. Not supported by current architecture as primary value and would de-emphasize deterministic strengths.
+
+### 3) Reposition as generic observability SaaS
+
+Rejected. Over-broad relative to current capabilities and would imply hosted monitoring/alerting commitments not present in this repository.
+
+### 4) Frame mainly against competitor substitutes
+
+Rejected as primary framing. Distinctions matter, but constant comparator-led messaging creates unnecessary coupling to external products.
+
+## Consequences
+
+### Positive
+
+- Clear, technically defensible product thesis across docs.
+- Better separation of package responsibilities and user expectations.
+- Stronger foundation for future composition with adjacent data (for example warehouse metadata, CI context, or job telemetry) without changing the core thesis.
+
+### Negative
+
+- Existing docs must be kept aligned to avoid regressions into tool-centric or comparator-centric language.
+- The phrase “operational intelligence” may be interpreted broadly; documentation must continue to tie claims to concrete implemented capabilities.
+
+### Mitigations
+
+- Require concrete capability references in docs (commands/views/interfaces).
+- Keep explicit non-goals in strategy-facing docs and ADRs.
+- Prefer deterministic-interface wording in CLI/core documentation.

--- a/docs/user-guide-dbt-tools-cli.md
+++ b/docs/user-guide-dbt-tools-cli.md
@@ -1,6 +1,6 @@
 # User guide: @dbt-tools/cli
 
-Extended notes for automation and AI agents using **`dbt-tools`**. For the full command reference (`summary`, `graph`, `run-report`, `deps`, `schema`), see the [package README](../packages/dbt-tools/cli/README.md).
+Extended notes for automation and agents using **`dbt-tools`** as a deterministic structured interface. For the full command reference (`summary`, `graph`, `run-report`, `deps`, `schema`), see the [package README](../packages/dbt-tools/cli/README.md).
 
 ---
 
@@ -20,6 +20,18 @@ npx @dbt-tools/cli --help
 ```
 
 ---
+
+## Contract assumptions for automation
+
+Treat the CLI as a stable machine contract over dbt artifacts:
+
+- outputs are deterministic for a given artifact set and flags
+- non-TTY defaults to JSON for programmatic consumption
+- `schema` exposes command/option shapes for dynamic clients
+- `--fields` supports low-noise payload shaping
+- error `code` values are intended for branching/retries
+
+This contract is useful with or without AI; shell scripts and CI jobs are first-class consumers.
 
 ## Schema introspection
 

--- a/docs/user-guide-dbt-tools-web.md
+++ b/docs/user-guide-dbt-tools-web.md
@@ -1,8 +1,19 @@
 # User guide: @dbt-tools/web
 
-Operator-focused documentation for the dbt-tools web analyzer. For a short npm-first overview, see the [package README](../packages/dbt-tools/web/README.md). For development setup, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+Operator-focused documentation for the dbt-tools web investigation workspace. For a short npm-first overview, see the [package README](../packages/dbt-tools/web/README.md). For development setup, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ---
+
+## Investigation outcomes (without AI)
+
+The web app is designed to support deterministic investigation workflows directly from artifacts:
+
+- trace dependencies to understand likely blast radius
+- inspect timeline data to identify bottlenecks and critical path contributors
+- review inventory context (resource type/package/tag/path) before deeper checks
+- assess whether artifact pairs are present and fresh enough to trust
+
+This value does not require an AI copilot; AI can consume the same structured artifact outputs separately.
 
 ## Vite dev server (monorepo)
 

--- a/packages/dbt-tools/README.md
+++ b/packages/dbt-tools/README.md
@@ -6,7 +6,6 @@ Internally, `@dbt-tools/*` is designed as a **composable analysis substrate for 
 
 ---
 
-
 ## Product thesis
 
 `@dbt-tools/*` turns dbt artifacts into deterministic operational intelligence:
@@ -25,11 +24,11 @@ Internally, `@dbt-tools/*` is designed as a **composable analysis substrate for 
 
 ## Packages
 
-| Package                               | Description                                                     |
-| ------------------------------------- | --------------------------------------------------------------- |
+| Package                               | Description                                                                       |
+| ------------------------------------- | --------------------------------------------------------------------------------- |
 | [`@dbt-tools/core`](./core/README.md) | Reusable analysis substrate (graph/dependency/execution/introspection primitives) |
-| [`@dbt-tools/cli`](./cli/README.md)   | Stable structured contract (`dbt-tools`) for automation and agent skills |
-| [`@dbt-tools/web`](./web/README.md)   | Actionable investigation workspace for operators (no AI required) |
+| [`@dbt-tools/cli`](./cli/README.md)   | Stable structured contract (`dbt-tools`) for automation and agent skills          |
+| [`@dbt-tools/web`](./web/README.md)   | Actionable investigation workspace for operators (no AI required)                 |
 
 ---
 

--- a/packages/dbt-tools/README.md
+++ b/packages/dbt-tools/README.md
@@ -1,16 +1,35 @@
 # @dbt-tools
 
-A suite of TypeScript tools for analyzing dbt artifacts, built on [`dbt-artifacts-parser`](../dbt-artifacts-parser/README.md).
+A suite of TypeScript packages that forms a **dbt operational intelligence layer**, built on [`dbt-artifacts-parser`](../dbt-artifacts-parser/README.md).
+
+Internally, `@dbt-tools/*` is designed as a **composable analysis substrate for dbt artifacts** that serves both operators and agents.
 
 ---
+
+
+## Product thesis
+
+`@dbt-tools/*` turns dbt artifacts into deterministic operational intelligence:
+
+- **What it does:** derives dependency, execution, inventory, and artifact readiness intelligence from `manifest.json`, `run_results.json`, and related artifacts.
+- **Who it serves:** operators/investigators in the web workspace; automation and agents via CLI + core APIs.
+- **What differentiates it:** deterministic outputs, schema/introspection support, local-first deployment, and composable interfaces.
+- **AI stance:** AI can consume the outputs, but the product is useful and actionable without AI.
+
+### Non-goals
+
+- Not a hosted dbt execution platform.
+- Not a generic observability SaaS.
+- Not a chat wrapper around dbt metadata.
+- Not a replacement for dbt Cloud or Elementary.
 
 ## Packages
 
 | Package                               | Description                                                     |
 | ------------------------------------- | --------------------------------------------------------------- |
-| [`@dbt-tools/core`](./core/README.md) | Core library — dependency graphs, execution analysis, utilities |
-| [`@dbt-tools/cli`](./cli/README.md)   | CLI tool (`dbt-tools`) for artifact analysis                    |
-| [`@dbt-tools/web`](./web/README.md)   | React web app for visual artifact analysis                      |
+| [`@dbt-tools/core`](./core/README.md) | Reusable analysis substrate (graph/dependency/execution/introspection primitives) |
+| [`@dbt-tools/cli`](./cli/README.md)   | Stable structured contract (`dbt-tools`) for automation and agent skills |
+| [`@dbt-tools/web`](./web/README.md)   | Actionable investigation workspace for operators (no AI required) |
 
 ---
 

--- a/packages/dbt-tools/cli/README.md
+++ b/packages/dbt-tools/cli/README.md
@@ -1,8 +1,23 @@
 # @dbt-tools/cli
 
-Command-line interface for dbt artifact analysis. Optimized for both human and AI agent consumption.
+Command-line interface for deterministic dbt artifact intelligence.
+
+`dbt-tools` is a stable structured contract for operators, automation, and agent skills: machine-readable by default in non-interactive contexts, while still usable by humans in a terminal.
 
 **Quick start:** install Node.js **20+** (see the repo [`.node-version`](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/.node-version) for the version used in development; Node 18 is EOL — [releases](https://nodejs.org/en/about/previous-releases)), then `npm install -g @dbt-tools/cli` and run `dbt-tools summary` from a directory that contains `./target/manifest.json`. Extended agent-focused topics (errors, validation, `schema` introspection) are in the [user guide](../../../docs/user-guide-dbt-tools-cli.md).
+
+## Positioning
+
+- **Role in dot-tools:** machine interface to the operational intelligence layer.
+- **Deterministic-first:** outputs are derived from artifacts, not generated narratives.
+- **Agent-ready:** schema introspection + field filtering + stable error codes support orchestration.
+- **AI-optional:** useful for shell scripts/CI without any LLM in the loop.
+
+### Non-goals
+
+- Not a chat interface for dbt.
+- Not a dbt execution platform.
+- Not intended to replicate dbt Cloud or Elementary workflows.
 
 ## Commands
 
@@ -45,8 +60,8 @@ pnpm add -g @dbt-tools/cli
 - **Default `./target` directory**: Commands default to dbt's standard artifact location
 - **JSON-by-default**: Machine-readable JSON output in non-interactive environments
 - **Input validation**: Hardened against common agent mistakes (path traversals, control chars, etc.)
-- **Field filtering**: Reduce context window usage with `--fields` option
-- **Schema introspection**: Runtime command discovery via `schema` command
+- **Field filtering**: Reduce payload size and context noise with `--fields`
+- **Schema introspection**: Runtime command/option discovery via `schema` command
 - **Dependency analysis**: Find upstream/downstream dependencies with `deps` command
 - **Inventory**: Browse and filter all dbt resources in one view
 - **Timeline**: Inspect per-node execution timing (row-level, unlike `run-report`)

--- a/packages/dbt-tools/core/README.md
+++ b/packages/dbt-tools/core/README.md
@@ -1,6 +1,17 @@
 # @dbt-tools/core
 
-Core library for dbt artifact graph management and analysis. Provides the analysis engine used by [`@dbt-tools/cli`](../cli/README.md) and [`@dbt-tools/web`](../web/README.md).
+Composable analysis substrate for deterministic dbt artifact intelligence.
+
+`@dbt-tools/core` is reusable infrastructure: it powers [`@dbt-tools/cli`](../cli/README.md) and [`@dbt-tools/web`](../web/README.md), and is intended to be embedded in other tools that need graph/dependency/execution analysis over dbt artifacts.
+
+---
+
+## Positioning
+
+- **Primary role:** reusable engine for artifact-derived operational intelligence.
+- **Deterministic-first:** analysis is reproducible from artifacts; no LLM dependency.
+- **Agent-compatible by construction:** stable types, schema generation, and field filtering make outputs easy to compose in automation.
+- **Not just an internal helper:** `@dbt-tools/core` is published for direct embedding in scripts, services, and controlled-environment tooling.
 
 ---
 
@@ -159,7 +170,7 @@ Validates user-supplied strings against common injection patterns (path traversa
 
 ### OutputFormatter / FieldFilter
 
-Formats analysis output as JSON or human-readable text. `FieldFilter` limits output to a specified set of fields (useful for reducing context window usage in AI agents).
+Formats analysis output as JSON or human-readable text. `FieldFilter` limits output to a specified set of fields so automation/agents receive low-noise payloads.
 
 ### GraphExport
 

--- a/packages/dbt-tools/web/README.md
+++ b/packages/dbt-tools/web/README.md
@@ -1,12 +1,26 @@
 # @dbt-tools/web
 
-React application for visual dbt artifact analysis: dependency graphs, execution timelines, inventory views, and optional remote runs from S3 or GCS.
+Web investigation workspace for **actionable dbt operational intelligence** from artifacts: trace dependencies, inspect execution timing, identify bottlenecks, assess blast radius, and review inventory/readiness context.
+
+The web app is intentionally useful without AI. It supports deterministic investigation workflows in local-first or controlled environments, with optional remote run discovery from S3/GCS.
 
 **End users:** install from npm and run **`dbt-tools-web`** (see below). **Contributors:** clone the monorepo and use Vite — see [Developing from source](#developing-from-source) and [CONTRIBUTING.md](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/CONTRIBUTING.md).
 
 Full operator topics (Docker, GHCR, remote sources, Vite-only options) live in the [user guide](../../../docs/user-guide-dbt-tools-web.md).
 
 ---
+
+## Positioning
+
+- **Role in dot-tools:** operator-facing investigation workspace on top of deterministic artifact analysis.
+- **Actionability over visualization-only:** views are designed to move from symptom to likely next checks (critical path, bottlenecks, dependencies, resource inventory, freshness/readiness).
+- **AI stance:** no chat/copilot dependency; AI can be layered later on structured outputs if needed.
+
+### Non-goals
+
+- Not a hosted dbt execution platform.
+- Not a generic observability SaaS replacement.
+- Not merely a DAG viewer.
 
 ## Prerequisites
 
@@ -54,11 +68,11 @@ You can also set **`DBT_TOOLS_TARGET_DIR`** (or legacy `DBT_TARGET_DIR` / `DBT_T
 
 ## Features
 
-- **Dependency graph** — interactive lineage
-- **Execution timeline** — Gantt-style `run_results` with critical path
-- **Local artifacts** — read `manifest.json` / `run_results.json` from a target directory via server-side routes
+- **Dependency graph** — trace upstream/downstream blast radius and likely impact paths
+- **Execution timeline** — inspect per-node timings, critical path, and bottlenecks
+- **Local artifacts** — investigate runs in local or controlled environments from `manifest.json` / `run_results.json`
 - **Remote sources (S3 / GCS)** — optional `DBT_TOOLS_REMOTE_SOURCE`; server-side credentials; UI prompts before switching runs ([ADR-0029](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/docs/adr/0029-remote-object-storage-artifact-sources-and-auto-reload.md))
-- **Large manifests** — web workers and virtualization for very large projects
+- **Large manifests** — web workers and virtualization keep investigation workflows usable at high scale
 
 ---
 


### PR DESCRIPTION
### Motivation
- Align repository messaging to a single, technically defensible product thesis: dot-tools is a dbt operational intelligence layer that provides deterministic intelligence to humans and automation. 
- Emphasize deterministic-first, AI-optional workflows and clarify the product is composable infrastructure rather than a hosted execution platform or chat-first copilot. 
- Make package responsibilities explicit so `@dbt-tools/core` is framed as an embeddable substrate, `@dbt-tools/cli` as a stable machine contract, and `@dbt-tools/web` as an operator investigation workspace. 

### Description
- Updated top-level `README.md` to state the product thesis, add positioning and explicit non-goals, and reframe the `@dbt-tools/*` suite description. 
- Revised `packages/dbt-tools/README.md`, `packages/dbt-tools/core/README.md`, `packages/dbt-tools/cli/README.md`, and `packages/dbt-tools/web/README.md` to: (1) declare the product thesis, (2) clarify package roles, (3) emphasize deterministic outputs and agent compatibility, and (4) surface explicit non-goals. 
- Updated user guides `docs/user-guide-dbt-tools-cli.md` and `docs/user-guide-dbt-tools-web.md` to document the CLI automation contract and web investigation outcomes that are actionable without AI. 
- Added ADR `docs/adr/0034-position-dot-tools-as-deterministic-operational-intelligence-layer.md` to codify the decision, and marked `docs/adr/0006-...` as partially superseded to preserve ADR continuity. 

### Testing
- Ran `pnpm lint:report` which wrote `lint-report.json` and exited cleanly (score=100, errors=0, warnings=0). 
- Ran `pnpm coverage:report` which executed the test suite and wrote `coverage-report.json` with coverage artifacts (report written, overall coverage computed, belowThreshold=false). 
- Validated dependency/static analysis with `pnpm knip`; it initially failed until build artifacts existed, and then passed after building `dbt-artifacts-parser` and `@dbt-tools/core` via `pnpm --filter dbt-artifacts-parser build && pnpm --filter @dbt-tools/core build && pnpm knip`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7908f7060832cb6f7cbc63f7a337e)