### PR TITLE
feat(web): introduce generated layered design tokens, design-system foundation, and governance

### DIFF
--- a/.agent/prompts/implement-component.md
+++ b/.agent/prompts/implement-component.md
@@ -1,0 +1,10 @@
+# Prompt template: implement a shared component
+
+When adding or changing a component in `@dbt-tools/web`, follow this sequence:
+
+1. Confirm required semantic/component tokens exist under `packages/dbt-tools/web/tokens`.
+2. If missing, add tokens first and run `pnpm tokens:build`.
+3. Implement component in `src/design-system/components` with limited variants.
+4. Map every visual decision (color/space/radius/typography/shadow/motion/z-index) to tokens.
+5. Do not add arbitrary style override props.
+6. Add/update tests and run `pnpm tokens:validate` plus package build.

--- a/.agent/ui-rules.md
+++ b/.agent/ui-rules.md
@@ -1,0 +1,26 @@
+# UI implementation rules (dbt-tools/web)
+
+## Token contract
+
+- Use semantic tokens (`--dt-semantic-*`) in feature and page code.
+- Use component tokens (`--dt-component-*`) only inside shared design-system components.
+- Never use primitive tokens directly in feature code.
+
+## Hard constraints
+
+- No hardcoded hex/rgb/px/radius/shadow values in `src/design-system` or `src/styles`.
+- If a visual value is missing, add a token in `tokens/` and regenerate.
+- Prefer `src/design-system/components` over one-off styled wrappers.
+
+## Theming
+
+- Light/dark must be implemented through CSS custom properties.
+- Theme toggles may only set `data-theme`; components should remain theme-agnostic.
+
+## Verification
+
+Run before commit:
+
+1. `pnpm tokens:build`
+2. `pnpm tokens:validate`
+3. `pnpm --filter @dbt-tools/web build`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+-
+
+## UI Consistency Checklist
+
+- [ ] I used semantic tokens in feature/product code.
+- [ ] I only used component tokens inside shared design-system components.
+- [ ] I did not add hardcoded hex/rgb/px/radius/shadow values in guarded UI paths.
+- [ ] I ran `pnpm tokens:build` and committed generated outputs.
+- [ ] I ran `pnpm tokens:validate`.
+- [ ] Light and dark themes both render correctly for changed UI.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "pnpm --filter @dbt-tools/web test:e2e",
-    "verify:normalize": "pnpm format && pnpm lint"
+    "verify:normalize": "pnpm format && pnpm lint",
+    "tokens:build": "node scripts/build-tokens.mjs",
+    "tokens:validate": "node scripts/validate-tokens.mjs",
+    "tokens:check": "pnpm tokens:build && pnpm tokens:validate"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.58.0",
@@ -55,6 +58,7 @@
     "jsdom": "^29.0.1",
     "json-schema-to-typescript": "^15.0.4",
     "knip": "^6.3.0",
+    "style-dictionary": "^4.4.0",
     "stylelint": "^17.6.0",
     "stylelint-config-standard": "^40.0.0",
     "typescript": "^6.0.2",

--- a/packages/dbt-tools/web/src/components/AppShell/LoadingCard.tsx
+++ b/packages/dbt-tools/web/src/components/AppShell/LoadingCard.tsx
@@ -1,13 +1,14 @@
+import { LoadingStatePattern } from "@web/design-system/patterns/states";
 import { Skeleton } from "../ui/Skeleton";
 
 export function LoadingCard() {
   return (
-    <div className="loading-card">
+    <LoadingStatePattern label="Loading workspace…">
       <Skeleton className="loading-card__skeleton-icon" />
       <div>
         <Skeleton className="loading-card__skeleton-title" />
         <Skeleton className="loading-card__skeleton-body" />
       </div>
-    </div>
+    </LoadingStatePattern>
   );
 }

--- a/packages/dbt-tools/web/src/components/EmptyState.tsx
+++ b/packages/dbt-tools/web/src/components/EmptyState.tsx
@@ -1,29 +1,15 @@
 import type { ReactNode } from "react";
+import { Card } from "@web/design-system/components";
 
 interface EmptyStateProps {
-  /** An emoji or small icon element shown above the headline. */
   icon?: string | ReactNode;
-  /** The primary message — short, specific, and actionable. */
   headline: string;
-  /** Optional supporting text with more context. */
   subtext?: string;
 }
 
-/**
- * A polished empty-state block for use inside workspace cards and panes.
- * Replace bare `<div className="empty-state">…</div>` text with this
- * component wherever the empty state is prominent.
- *
- * @example
- * <EmptyState
- *   icon="🔍"
- *   headline="No matching rows"
- *   subtext="Try adjusting the status filter or search query."
- * />
- */
 export function EmptyState({ icon, headline, subtext }: EmptyStateProps) {
   return (
-    <div className="empty-state-block">
+    <Card className="empty-state-block ds-empty-state">
       {icon !== undefined && (
         <span className="empty-state-block__icon" aria-hidden="true">
           {icon}
@@ -31,6 +17,6 @@ export function EmptyState({ icon, headline, subtext }: EmptyStateProps) {
       )}
       <strong className="empty-state-block__headline">{headline}</strong>
       {subtext && <p className="empty-state-block__subtext">{subtext}</p>}
-    </div>
+    </Card>
   );
 }

--- a/packages/dbt-tools/web/src/design-system/README.md
+++ b/packages/dbt-tools/web/src/design-system/README.md
@@ -1,0 +1,16 @@
+# `src/design-system`
+
+Shared UI foundation for `@dbt-tools/web`.
+
+- `components/` — reusable components with intentional variants (`Button`, `Input`, `Card`).
+- `patterns/` — reusable composition patterns (`LoadingStatePattern`, `EmptyStatePattern`).
+- `foundations/` — low-level helpers (`cx`).
+
+Planned next shared components to add in this area:
+
+- Table
+- Badge
+- Tabs
+- Dialog
+
+All visual decisions in this folder must map to token variables from `src/styles/tokens.css` / `src/styles/theme.css`.

--- a/packages/dbt-tools/web/src/design-system/components/Button.tsx
+++ b/packages/dbt-tools/web/src/design-system/components/Button.tsx
@@ -1,0 +1,25 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from "react";
+import { cx } from "../foundations/cx";
+
+type ButtonVariant = "primary" | "secondary";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+export function Button({
+  children,
+  className,
+  variant = "primary",
+  ...props
+}: PropsWithChildren<ButtonProps>) {
+  return (
+    <button
+      className={cx("ds-button", className)}
+      data-variant={variant}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/dbt-tools/web/src/design-system/components/Card.tsx
+++ b/packages/dbt-tools/web/src/design-system/components/Card.tsx
@@ -1,0 +1,16 @@
+import type { HTMLAttributes, PropsWithChildren } from "react";
+import { cx } from "../foundations/cx";
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function Card({
+  children,
+  className,
+  ...props
+}: PropsWithChildren<CardProps>) {
+  return (
+    <section className={cx("ds-card", className)} {...props}>
+      {children}
+    </section>
+  );
+}

--- a/packages/dbt-tools/web/src/design-system/components/Input.tsx
+++ b/packages/dbt-tools/web/src/design-system/components/Input.tsx
@@ -1,0 +1,8 @@
+import type { InputHTMLAttributes } from "react";
+import { cx } from "../foundations/cx";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export function Input({ className, ...props }: InputProps) {
+  return <input className={cx("ds-input", className)} {...props} />;
+}

--- a/packages/dbt-tools/web/src/design-system/components/index.ts
+++ b/packages/dbt-tools/web/src/design-system/components/index.ts
@@ -1,0 +1,3 @@
+export { Button } from "./Button";
+export { Card } from "./Card";
+export { Input } from "./Input";

--- a/packages/dbt-tools/web/src/design-system/foundations/cx.ts
+++ b/packages/dbt-tools/web/src/design-system/foundations/cx.ts
@@ -1,0 +1,3 @@
+export function cx(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(" ");
+}

--- a/packages/dbt-tools/web/src/design-system/patterns/states.tsx
+++ b/packages/dbt-tools/web/src/design-system/patterns/states.tsx
@@ -1,0 +1,30 @@
+import type { PropsWithChildren } from "react";
+import { Card } from "../components";
+
+interface EmptyStatePatternProps {
+  title: string;
+  description: string;
+}
+
+export function EmptyStatePattern({
+  title,
+  description,
+}: EmptyStatePatternProps) {
+  return (
+    <Card className="ds-empty-state">
+      <strong>{title}</strong>
+      <p>{description}</p>
+    </Card>
+  );
+}
+
+interface LoadingStatePatternProps {
+  label: string;
+}
+
+export function LoadingStatePattern({
+  label,
+  children,
+}: PropsWithChildren<LoadingStatePatternProps>) {
+  return <Card className="ds-loading-state">{children ?? label}</Card>;
+}

--- a/packages/dbt-tools/web/src/index.css
+++ b/packages/dbt-tools/web/src/index.css
@@ -1,7 +1,7 @@
-/* Stylesheet barrel — @import order is cascade order. tokens.css MUST load first
-   so every later file can safely use var(--*). See src/styles/README.md. */
-@import url("./styles/tokens.css");
+/* Stylesheet barrel — app.css loads generated design tokens + theme contract first. */
+@import url("./styles/app.css");
 @import url("./styles/base.css");
+@import url("./styles/design-system.css");
 @import url("./styles/app-shell.css");
 @import url("./styles/ui-primitives.css");
 @import url("./styles/lineage-graph.css");

--- a/packages/dbt-tools/web/src/lib/tailwind-theme-bridge.ts
+++ b/packages/dbt-tools/web/src/lib/tailwind-theme-bridge.ts
@@ -1,0 +1,23 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
+ */
+
+export const tailwindSemanticColors = {
+  "bg-canvas": "rgb(from var(--dt-semantic-color-bg-canvas) r g b / <alpha-value>)",
+  "bg-surface": "rgb(from var(--dt-semantic-color-bg-surface) r g b / <alpha-value>)",
+  "bg-surfaceMuted": "rgb(from var(--dt-semantic-color-bg-surfaceMuted) r g b / <alpha-value>)",
+  "bg-accentSoft": "rgb(from var(--dt-semantic-color-bg-accentSoft) r g b / <alpha-value>)",
+  "text-primary": "rgb(from var(--dt-semantic-color-text-primary) r g b / <alpha-value>)",
+  "text-secondary": "rgb(from var(--dt-semantic-color-text-secondary) r g b / <alpha-value>)",
+  "text-muted": "rgb(from var(--dt-semantic-color-text-muted) r g b / <alpha-value>)",
+  "text-inverse": "rgb(from var(--dt-semantic-color-text-inverse) r g b / <alpha-value>)",
+  "border-subtle": "rgb(from var(--dt-semantic-color-border-subtle) r g b / <alpha-value>)",
+  "border-default": "rgb(from var(--dt-semantic-color-border-default) r g b / <alpha-value>)",
+  "border-focus": "rgb(from var(--dt-semantic-color-border-focus) r g b / <alpha-value>)",
+  "action-primary": "rgb(from var(--dt-semantic-color-action-primary) r g b / <alpha-value>)",
+  "action-primaryHover": "rgb(from var(--dt-semantic-color-action-primaryHover) r g b / <alpha-value>)",
+  "status-success": "rgb(from var(--dt-semantic-color-status-success) r g b / <alpha-value>)",
+  "status-warning": "rgb(from var(--dt-semantic-color-status-warning) r g b / <alpha-value>)",
+  "status-danger": "rgb(from var(--dt-semantic-color-status-danger) r g b / <alpha-value>)",
+  "status-info": "rgb(from var(--dt-semantic-color-status-info) r g b / <alpha-value>)",
+} as const;

--- a/packages/dbt-tools/web/src/lib/tokens.ts
+++ b/packages/dbt-tools/web/src/lib/tokens.ts
@@ -1,0 +1,81 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
+ */
+
+export const tokens = {
+  "semantic.color.bg.canvas": "var(--dt-semantic-color-bg-canvas)",
+  "semantic.color.bg.surface": "var(--dt-semantic-color-bg-surface)",
+  "semantic.color.bg.surfaceMuted": "var(--dt-semantic-color-bg-surfaceMuted)",
+  "semantic.color.bg.accentSoft": "var(--dt-semantic-color-bg-accentSoft)",
+  "semantic.color.text.primary": "var(--dt-semantic-color-text-primary)",
+  "semantic.color.text.secondary": "var(--dt-semantic-color-text-secondary)",
+  "semantic.color.text.muted": "var(--dt-semantic-color-text-muted)",
+  "semantic.color.text.inverse": "var(--dt-semantic-color-text-inverse)",
+  "semantic.color.border.subtle": "var(--dt-semantic-color-border-subtle)",
+  "semantic.color.border.default": "var(--dt-semantic-color-border-default)",
+  "semantic.color.border.focus": "var(--dt-semantic-color-border-focus)",
+  "semantic.color.action.primary": "var(--dt-semantic-color-action-primary)",
+  "semantic.color.action.primaryHover": "var(--dt-semantic-color-action-primaryHover)",
+  "semantic.color.status.success": "var(--dt-semantic-color-status-success)",
+  "semantic.color.status.warning": "var(--dt-semantic-color-status-warning)",
+  "semantic.color.status.danger": "var(--dt-semantic-color-status-danger)",
+  "semantic.color.status.info": "var(--dt-semantic-color-status-info)",
+  "component.button.primary.bg": "var(--dt-component-button-primary-bg)",
+  "component.button.primary.bgHover": "var(--dt-component-button-primary-bgHover)",
+  "component.button.primary.text": "var(--dt-component-button-primary-text)",
+  "component.button.primary.radius": "var(--dt-component-button-primary-radius)",
+  "component.button.primary.paddingInline": "var(--dt-component-button-primary-paddingInline)",
+  "component.button.primary.paddingBlock": "var(--dt-component-button-primary-paddingBlock)",
+  "component.button.secondary.bg": "var(--dt-component-button-secondary-bg)",
+  "component.button.secondary.text": "var(--dt-component-button-secondary-text)",
+  "component.button.secondary.border": "var(--dt-component-button-secondary-border)",
+  "component.input.bg": "var(--dt-component-input-bg)",
+  "component.input.text": "var(--dt-component-input-text)",
+  "component.input.placeholder": "var(--dt-component-input-placeholder)",
+  "component.input.border": "var(--dt-component-input-border)",
+  "component.input.focusRing": "var(--dt-component-input-focusRing)",
+  "component.input.radius": "var(--dt-component-input-radius)",
+  "component.input.paddingInline": "var(--dt-component-input-paddingInline)",
+  "component.input.paddingBlock": "var(--dt-component-input-paddingBlock)",
+} as const;
+
+export type TokenName =
+  | "semantic.color.bg.canvas"
+  | "semantic.color.bg.surface"
+  | "semantic.color.bg.surfaceMuted"
+  | "semantic.color.bg.accentSoft"
+  | "semantic.color.text.primary"
+  | "semantic.color.text.secondary"
+  | "semantic.color.text.muted"
+  | "semantic.color.text.inverse"
+  | "semantic.color.border.subtle"
+  | "semantic.color.border.default"
+  | "semantic.color.border.focus"
+  | "semantic.color.action.primary"
+  | "semantic.color.action.primaryHover"
+  | "semantic.color.status.success"
+  | "semantic.color.status.warning"
+  | "semantic.color.status.danger"
+  | "semantic.color.status.info"
+  | "component.button.primary.bg"
+  | "component.button.primary.bgHover"
+  | "component.button.primary.text"
+  | "component.button.primary.radius"
+  | "component.button.primary.paddingInline"
+  | "component.button.primary.paddingBlock"
+  | "component.button.secondary.bg"
+  | "component.button.secondary.text"
+  | "component.button.secondary.border"
+  | "component.input.bg"
+  | "component.input.text"
+  | "component.input.placeholder"
+  | "component.input.border"
+  | "component.input.focusRing"
+  | "component.input.radius"
+  | "component.input.paddingInline"
+  | "component.input.paddingBlock"
+;
+
+export function tokenVar(name: TokenName): string {
+  return tokens[name];
+}

--- a/packages/dbt-tools/web/src/styles/README.md
+++ b/packages/dbt-tools/web/src/styles/README.md
@@ -2,21 +2,33 @@
 
 ## Import order
 
-`src/index.css` is the only stylesheet entry from `main.tsx`. It imports slices in this order:
+`src/index.css` is the single stylesheet entry from `main.tsx`.
 
-1. **`tokens.css`** — `:root`, `[data-theme="dark"]`, and CSS variable aliases only.
-2. **`base.css`** — global element rules (`*`, `html`, `body`, etc.).
-3. **`app-shell.css`** — layout shell (sidebar, frame, header) and many analyzer/landing rules that sat **before** the lineage section in the original monolith. Shell and workspace selectors are interleaved there on purpose: **cascade order matches the old `index.css`**.
-4. **`ui-primitives.css`** — spinner, skeleton, tooltip, toast, empty state, plus blocks that followed them in the monolith (sidebar link icons, signals, upload/overview landing). Kept in one file to avoid reordering rules.
-5. **`lineage-graph.css`** — dependency graph, lineage viewport, graph toolbars/menus.
-6. **`workspace.css`** — explorer tree, overview modules/bands, type donut, shared legend rows.
+1. **`styles/app.css`** — app-level contract; imports generated token files (`tokens.css`, `theme.css`) and publishes compatibility aliases used by existing styles.
+2. **`styles/base.css`** — global element rules (`*`, `html`, `body`, etc.) and tokenized typography defaults.
+3. **`styles/design-system.css`** — shared component and pattern classes (`.ds-*`) that must map visual decisions to design tokens.
+4. **`styles/app-shell.css`**
+5. **`styles/ui-primitives.css`**
+6. **`styles/lineage-graph.css`**
+7. **`styles/workspace.css`**
 
-Do not change `@import` order without checking for specificity/cascade regressions.
+## Token source of truth
 
-## CSS ↔ TypeScript colors
+Design tokens live in `packages/dbt-tools/web/tokens/` with layered folders:
 
-Canvas and chart code cannot read CSS variables directly in all paths. **`src/constants/themeColors.ts` mirrors** the chart-related custom properties in `tokens.css` (light and dark). When you change chart or graph palette tokens, update **both** places until a codegen pipeline (ADR 0022 Phase 2) exists.
+- `primitives/`
+- `semantics/`
+- `components/`
+- `themes/`
 
-## Status colors in TypeScript
+Generated outputs are produced by `pnpm tokens:build`:
 
-**`src/constants/colors.ts`** defines `STATUS_COLORS` and helpers (`getStatusColor`, `getResourceTypeColor`) for execution/run status and resource-type accents. Chart code uses **`getStatusTonePalette`** from `src/lib/analysis-workspace/constants.ts` for **StatusTone**-aligned palettes (Gantt legend, donuts, etc.).
+- `src/styles/tokens.css`
+- `src/styles/theme.css`
+- `src/lib/tokens.ts`
+- `src/lib/tailwind-theme-bridge.ts`
+
+## Guardrails
+
+- `pnpm tokens:validate` checks token schema and blocks hardcoded design literals in guarded UI paths.
+- Agent-facing implementation rules live at `.agent/ui-rules.md`.

--- a/packages/dbt-tools/web/src/styles/app.css
+++ b/packages/dbt-tools/web/src/styles/app.css
@@ -1,0 +1,30 @@
+@import url("./tokens.css");
+@import url("./theme.css");
+
+:root {
+  --bg-canvas: var(--dt-semantic-color-bg-canvas);
+  --bg-surface: var(--dt-semantic-color-bg-surface);
+  --bg-surface-muted: var(--dt-semantic-color-bg-surfaceMuted);
+  --bg-accent-soft: var(--dt-semantic-color-bg-accentSoft);
+
+  --text-primary: var(--dt-semantic-color-text-primary);
+  --text-secondary: var(--dt-semantic-color-text-secondary);
+  --text-tertiary: var(--dt-semantic-color-text-muted);
+  --text-inverse: var(--dt-semantic-color-text-inverse);
+
+  --border-subtle: var(--dt-semantic-color-border-subtle);
+  --border-default: var(--dt-semantic-color-border-default);
+  --border-focus: var(--dt-semantic-color-border-focus);
+
+  --accent-primary: var(--dt-semantic-color-action-primary);
+  --accent-hover: var(--dt-semantic-color-action-primaryHover);
+
+  --bg: var(--bg-canvas);
+  --panel: var(--bg-surface);
+  --panel-strong: var(--bg-surface-muted);
+  --panel-border: var(--border-default);
+  --text: var(--text-primary);
+  --text-muted: var(--text-secondary);
+  --text-soft: var(--text-tertiary);
+  --accent: var(--accent-primary);
+}

--- a/packages/dbt-tools/web/src/styles/base.css
+++ b/packages/dbt-tools/web/src/styles/base.css
@@ -9,7 +9,7 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+  font-family: var(--dt-typography-fontFamily-sans);
   color: var(--text-primary);
   background: var(--bg-canvas);
   -webkit-font-smoothing: antialiased;
@@ -26,7 +26,7 @@ button {
 }
 
 code {
-  font-family: "IBM Plex Mono", SFMono-Regular, Consolas, monospace;
+  font-family: var(--dt-typography-fontFamily-mono);
 }
 
 #root {

--- a/packages/dbt-tools/web/src/styles/design-system.css
+++ b/packages/dbt-tools/web/src/styles/design-system.css
@@ -1,0 +1,70 @@
+.ds-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--dt-space-2xs);
+  border-radius: var(--dt-component-button-primary-radius);
+  border: var(--dt-border-width-default) solid transparent;
+  font-weight: var(--dt-typography-fontWeight-medium);
+  font-size: var(--dt-typography-fontSize-sm);
+  line-height: var(--dt-typography-lineHeight-tight);
+  cursor: pointer;
+  transition: background-color var(--dt-motion-duration-fast)
+    var(--dt-motion-easing-standard);
+  padding: var(--dt-component-button-primary-paddingBlock)
+    var(--dt-component-button-primary-paddingInline);
+}
+
+.ds-button[data-variant="primary"] {
+  background: var(--dt-component-button-primary-bg);
+  color: var(--dt-component-button-primary-text);
+}
+
+.ds-button[data-variant="primary"]:hover {
+  background: var(--dt-component-button-primary-bgHover);
+}
+
+.ds-button[data-variant="secondary"] {
+  background: var(--dt-component-button-secondary-bg);
+  color: var(--dt-component-button-secondary-text);
+  border-color: var(--dt-component-button-secondary-border);
+}
+
+.ds-card {
+  border-radius: var(--dt-component-input-radius);
+  border: var(--dt-border-width-default) solid
+    var(--dt-semantic-color-border-subtle);
+  background: var(--dt-semantic-color-bg-surface);
+  box-shadow: var(--dt-shadow-surface);
+  padding: var(--dt-space-md);
+}
+
+.ds-input {
+  border-radius: var(--dt-component-input-radius);
+  border: var(--dt-border-width-default) solid var(--dt-component-input-border);
+  background: var(--dt-component-input-bg);
+  color: var(--dt-component-input-text);
+  padding: var(--dt-component-input-paddingBlock)
+    var(--dt-component-input-paddingInline);
+}
+
+.ds-input::placeholder {
+  color: var(--dt-component-input-placeholder);
+}
+
+.ds-input:focus-visible {
+  outline: none;
+  box-shadow: var(--dt-component-input-focusRing);
+  border-color: var(--dt-semantic-color-border-focus);
+}
+
+.ds-empty-state,
+.ds-loading-state {
+  border-radius: var(--dt-radius-md);
+  border: var(--dt-border-width-default) dashed
+    var(--dt-semantic-color-border-subtle);
+  padding: var(--dt-space-lg);
+  text-align: center;
+  color: var(--dt-semantic-color-text-secondary);
+  background: var(--dt-semantic-color-bg-surfaceMuted);
+}

--- a/packages/dbt-tools/web/src/styles/theme.css
+++ b/packages/dbt-tools/web/src/styles/theme.css
@@ -1,0 +1,41 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
+ */
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --dt-semantic-color-bg-canvas: #0d1120;
+  --dt-semantic-color-bg-surface: #151a2e;
+  --dt-semantic-color-bg-surfaceMuted: #101527;
+  --dt-semantic-color-bg-accentSoft: #232845;
+  --dt-semantic-color-text-primary: #f3f6fc;
+  --dt-semantic-color-text-secondary: #c6cee0;
+  --dt-semantic-color-text-muted: #98a3bc;
+  --dt-semantic-color-text-inverse: #121622;
+  --dt-semantic-color-border-subtle: #262e47;
+  --dt-semantic-color-border-default: #313a58;
+  --dt-semantic-color-border-focus: #8a7cff;
+  --dt-semantic-color-action-primary: #8a7cff;
+  --dt-semantic-color-action-primaryHover: #9b90ff;
+  --dt-semantic-color-status-success: #59d38c;
+  --dt-semantic-color-status-warning: #f5b95c;
+  --dt-semantic-color-status-danger: #ff8d86;
+  --dt-semantic-color-status-info: #79b7ff;
+  --dt-component-button-primary-bg: #8a7cff;
+  --dt-component-button-primary-bgHover: #9b90ff;
+  --dt-component-button-primary-text: #121622;
+  --dt-component-button-primary-radius: 0.75rem;
+  --dt-component-button-primary-paddingInline: 1rem;
+  --dt-component-button-primary-paddingBlock: 0.75rem;
+  --dt-component-button-secondary-bg: #151a2e;
+  --dt-component-button-secondary-text: #c6cee0;
+  --dt-component-button-secondary-border: #313a58;
+  --dt-component-input-bg: #151a2e;
+  --dt-component-input-text: #f3f6fc;
+  --dt-component-input-placeholder: #98a3bc;
+  --dt-component-input-border: #313a58;
+  --dt-component-input-focusRing: 0 0 0 3px rgb(99 91 255 / 30%);
+  --dt-component-input-radius: 0.75rem;
+  --dt-component-input-paddingInline: 1rem;
+  --dt-component-input-paddingBlock: 0.75rem;
+}

--- a/packages/dbt-tools/web/src/styles/tokens.css
+++ b/packages/dbt-tools/web/src/styles/tokens.css
@@ -1,255 +1,92 @@
+/**
+ * AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
+ */
+
 :root {
   color-scheme: light;
-
-  /* Background roles */
-  --bg-canvas: #f6f7fb;
-  --bg-sidebar: #f3f5fa;
-  --bg-surface: #fff;
-  --bg-surface-muted: #f1f3f8;
-  --bg-elevated: #fff;
-  --bg-overlay: rgb(17 24 39 / 40%);
-  --bg-code: #f8f9fc;
-  --bg-selection-soft: #eef0ff;
-  --bg-accent-soft: #eef0ff;
-  --bg-success-soft: #eaf8f0;
-  --bg-warning-soft: #fff5e8;
-  --bg-danger-soft: #fdedec;
-  --bg-info-soft: #eaf2ff;
-
-  /* Border roles */
-  --border-subtle: #e6e9f0;
-  --border-default: #d7dce7;
-  --border-strong: #b8c0d4;
-  --border-focus: #6d5ef7;
-  --border-accent: #6d5ef7;
-  --border-success: #0f8a4b;
-  --border-warning: #a56315;
-  --border-danger: #c0352b;
-  --border-info: #1769e0;
-
-  /* Text roles */
-  --text-primary: #171c28;
-  --text-secondary: #475067;
-  --text-tertiary: #6b7385;
-  --text-inverse: #f8fafc;
-  --text-accent: #554ceb;
-  --text-success: #0f8a4b;
-  --text-warning: #a56315;
-  --text-danger: #c0352b;
-  --text-info: #1769e0;
-  --text-disabled: #98a1b3;
-
-  /* Icon roles */
-  --icon-primary: #2a3142;
-  --icon-secondary: #5a6478;
-  --icon-tertiary: #8a93a5;
-  --icon-accent: #635bff;
-  --icon-success: #0f8a4b;
-  --icon-warning: #a56315;
-  --icon-danger: #c0352b;
-  --icon-info: #1769e0;
-
-  /* Action roles */
-  --accent-primary: #635bff;
-  --accent-hover: #554ceb;
-  --accent-active: #473ed0;
-  --accent-soft: #eef0ff;
-  --accent-focus-ring: #6d5ef7;
-
-  /* Status roles (legacy/convenience aliases) */
-  --success-fg: #0f8a4b;
-  --success-soft: #eaf8f0;
-  --warning-fg: #a56315;
-  --warning-soft: #fff5e8;
-  --danger-fg: #c0352b;
-  --danger-soft: #fdedec;
-  --info-fg: #1769e0;
-  --info-soft: #eaf2ff;
-
-  /* Data visualization roles */
-  --chart-1: #635bff; /* violet / indigo */
-  --chart-2: #1d4ed8; /* blue */
-  --chart-3: #0891b2; /* cyan / teal */
-  --chart-4: #059669; /* green */
-  --chart-5: #d97706; /* amber */
-  --chart-6: #ea580c; /* orange */
-  --chart-7: #db2777; /* pink / magenta */
-  --chart-8: #64748b; /* slate-neutral */
-
-  /* Radius and shadows — kept from previous for consistency */
-  --radius-lg: 16px;
-  --radius-md: 12px;
-  --radius-sm: 8px;
-  --panel-shadow: 0 1px 3px rgb(15 15 35 / 6%), 0 4px 12px rgb(15 15 35 / 4%);
-
-  /* Legacy variable mapping (for gradual migration / safety) */
-  --bg: var(--bg-canvas);
-  --bg-soft: var(--bg-surface-muted);
-  --panel: var(--bg-surface);
-  --panel-strong: var(--bg-surface-muted);
-  --panel-border: var(--border-default);
-  --text: var(--text-primary);
-  --text-muted: var(--text-secondary);
-  --text-soft: var(--text-tertiary);
-  --accent: var(--accent-primary);
-
-  /* Legacy metric / tone aliases (map to semantic status tokens) */
-  --mint: var(--text-success);
-  --rose: var(--text-danger);
-  --amber: var(--text-warning);
-  --mint-soft: var(--bg-success-soft);
-  --rose-soft: var(--bg-danger-soft);
-
-  /* dbt resource types (mapped to semantic status/accent where possible, or kept for uniqueness) */
-  --dbt-type-source: var(--chart-4);
-  --dbt-type-source-soft: rgb(5 150 105 / 14%);
-  --dbt-type-seed: var(--chart-1);
-  --dbt-type-seed-soft: rgb(99 91 255 / 14%);
-  --dbt-type-snapshot: var(--chart-5);
-  --dbt-type-snapshot-soft: rgb(217 119 6 / 14%);
-  --dbt-type-model: var(--chart-2);
-  --dbt-type-model-soft: rgb(29 78 216 / 14%);
-  --dbt-type-semantic-model: var(--chart-3);
-  --dbt-type-semantic-model-soft: rgb(8 145 178 / 14%);
-  --dbt-type-metric: var(--chart-7);
-  --dbt-type-metric-soft: rgb(219 39 119 / 14%);
-  --dbt-type-exposure: var(--chart-6);
-  --dbt-type-exposure-soft: rgb(234 88 12 / 14%);
-  --dbt-type-test: var(--chart-8);
-  --dbt-type-test-soft: rgb(100 116 139 / 14%);
-
-  /* Fallbacks for lineage type lens (unknown types, macro, operation) — must exist or SVG fill can fall back to black */
-  --dbt-type-generic: var(--chart-8);
-  --dbt-type-generic-soft: rgb(100 116 139 / 14%);
-  --dbt-type-macro: var(--chart-8);
-  --dbt-type-macro-soft: rgb(100 116 139 / 16%);
-  --dbt-type-operation: var(--chart-3);
-  --dbt-type-operation-soft: rgb(8 145 178 / 14%);
-
-  /* Graph surface aliases */
-  --graph-bg-top: var(--bg-canvas);
-  --graph-bg-bottom: var(--bg-surface-muted);
-  --graph-bg-accent: var(--bg-accent-soft);
-  --graph-panel: var(--bg-surface);
-  --graph-panel-hover: var(--bg-surface-muted);
-  --graph-panel-active: var(--bg-selection-soft);
-  --graph-border: var(--border-subtle);
-  --graph-border-strong: var(--border-strong);
-  --graph-text: var(--text-primary);
-  --graph-text-muted: var(--text-secondary);
-  --graph-text-soft: var(--text-tertiary);
-  --graph-edge: var(--border-default);
-  --graph-hotspot: var(--bg-accent-soft);
-  --graph-node-stroke: var(--border-subtle);
-  --graph-node-selected-stroke: var(--accent-primary);
-}
-
-[data-theme="dark"] {
-  color-scheme: dark;
-
-  /* Background roles */
-  --bg-canvas: #0d1120;
-  --bg-sidebar: #101527;
-  --bg-surface: #151a2e;
-  --bg-surface-muted: #101527;
-  --bg-elevated: #1b223a;
-  --bg-overlay: rgb(2 6 23 / 60%);
-  --bg-code: #11182b;
-  --bg-selection-soft: #232845;
-  --bg-accent-soft: #232845;
-  --bg-success-soft: #113222;
-  --bg-warning-soft: #3a2a12;
-  --bg-danger-soft: #3d1919;
-  --bg-info-soft: #16263f;
-
-  /* Border roles */
-  --border-subtle: #262e47;
-  --border-default: #313a58;
-  --border-strong: #465172;
-  --border-focus: #8a7cff;
-  --border-accent: #8a7cff;
-  --border-success: #59d38c;
-  --border-warning: #f5b95c;
-  --border-danger: #ff8d86;
-  --border-info: #79b7ff;
-
-  /* Text roles */
-  --text-primary: #f3f6fc;
-  --text-secondary: #c6cee0;
-  --text-tertiary: #98a3bc;
-  --text-inverse: #121622;
-  --text-accent: #a89fff;
-  --text-success: #59d38c;
-  --text-warning: #f5b95c;
-  --text-danger: #ff8d86;
-  --text-info: #79b7ff;
-  --text-disabled: #6e7893;
-
-  /* Icon roles */
-  --icon-primary: #e5eaf6;
-  --icon-secondary: #bac4d8;
-  --icon-tertiary: #8e9ab4;
-  --icon-accent: #8a7cff;
-  --icon-success: #59d38c;
-  --icon-warning: #f5b95c;
-  --icon-danger: #ff8d86;
-  --icon-info: #79b7ff;
-
-  /* Action roles */
-  --accent-primary: #8a7cff;
-  --accent-hover: #9b90ff;
-  --accent-active: #7363f5;
-  --accent-soft: #232845;
-  --accent-focus-ring: #8a7cff;
-
-  /* Status roles (legacy/convenience aliases) */
-  --success-fg: #59d38c;
-  --success-soft: #113222;
-  --warning-fg: #f5b95c;
-  --warning-soft: #3a2a12;
-  --danger-fg: #ff8d86;
-  --danger-soft: #3d1919;
-  --info-fg: #79b7ff;
-  --info-soft: #16263f;
-
-  /* Chart palette (theme-tuned for dark bg — muted, legible on #0D1120–#151A2E) */
-  --chart-1: #9588e8;
-  --chart-2: #5c8deb;
-  --chart-3: #3eb0c8;
-  --chart-4: #45c49a;
-  --chart-5: #d4a24a;
-  --chart-6: #d9845c;
-  --chart-7: #d172ae;
-  --chart-8: #8690aa;
-  --panel-shadow: 0 4px 24px rgb(0 0 0 / 50%);
-
-  /* dbt resource type soft fills — rgba matches dark chart hues */
-  --dbt-type-source-soft: rgb(69 196 154 / 20%);
-  --dbt-type-seed-soft: rgb(149 136 232 / 22%);
-  --dbt-type-snapshot-soft: rgb(212 162 74 / 22%);
-  --dbt-type-model-soft: rgb(92 141 235 / 22%);
-  --dbt-type-semantic-model-soft: rgb(62 176 200 / 22%);
-  --dbt-type-metric-soft: rgb(209 114 174 / 22%);
-  --dbt-type-exposure-soft: rgb(217 132 92 / 22%);
-  --dbt-type-test-soft: rgb(134 144 170 / 20%);
-  --dbt-type-generic-soft: rgb(134 144 170 / 18%);
-  --dbt-type-macro-soft: rgb(134 144 170 / 20%);
-  --dbt-type-operation-soft: rgb(62 176 200 / 18%);
-
-  /* Graph surface aliases (Dark) */
-  --graph-bg-top: #dde2ea;
-  --graph-bg-bottom: #cfd6e1;
-  --graph-bg-accent: rgb(175 184 205 / 22%);
-  --graph-panel: #e7ebf3;
-  --graph-panel-hover: #dfe5ef;
-  --graph-panel-active: #d6deec;
-  --graph-border: #aab4c6;
-  --graph-border-strong: #8896af;
-  --graph-text: #171c28;
-  --graph-text-muted: #465066;
-  --graph-text-soft: #647087;
-  --graph-edge: #8794aa;
-  --graph-hotspot: rgb(99 91 255 / 18%);
-  --graph-node-stroke: #aab4c6;
-  --graph-node-selected-stroke: var(--accent-primary);
+  --dt-border-width-default: 1px;
+  --dt-color-neutral-0: #ffffff;
+  --dt-color-neutral-50: #f8f9fc;
+  --dt-color-neutral-100: #f1f3f8;
+  --dt-color-neutral-200: #e6e9f0;
+  --dt-color-neutral-300: #d7dce7;
+  --dt-color-neutral-500: #6b7385;
+  --dt-color-neutral-700: #2a3142;
+  --dt-color-neutral-900: #171c28;
+  --dt-color-violet-100: #eef0ff;
+  --dt-color-violet-400: #8a7cff;
+  --dt-color-violet-500: #635bff;
+  --dt-color-violet-600: #554ceb;
+  --dt-color-green-100: #eaf8f0;
+  --dt-color-green-500: #0f8a4b;
+  --dt-color-amber-100: #fff5e8;
+  --dt-color-amber-500: #a56315;
+  --dt-color-red-100: #fdedec;
+  --dt-color-red-500: #c0352b;
+  --dt-color-blue-100: #eaf2ff;
+  --dt-color-blue-500: #1769e0;
+  --dt-motion-duration-fast: 120ms;
+  --dt-motion-duration-normal: 180ms;
+  --dt-motion-easing-standard: cubic-bezier(0.2, 0, 0, 1);
+  --dt-radius-sm: 0.5rem;
+  --dt-radius-md: 0.75rem;
+  --dt-radius-lg: 1rem;
+  --dt-radius-pill: 9999px;
+  --dt-shadow-surface: 0 1px 3px rgb(15 15 35 / 6%), 0 4px 12px rgb(15 15 35 / 4%);
+  --dt-shadow-focus: 0 0 0 3px rgb(99 91 255 / 30%);
+  --dt-space-2xs: 0.25rem;
+  --dt-space-xs: 0.5rem;
+  --dt-space-sm: 0.75rem;
+  --dt-space-md: 1rem;
+  --dt-space-lg: 1.5rem;
+  --dt-space-xl: 2rem;
+  --dt-typography-fontFamily-sans: '"IBM Plex Sans"', '"Avenir Next"', '"Segoe UI"', sans-serif;
+  --dt-typography-fontFamily-mono: '"IBM Plex Mono"', SFMono-Regular, Consolas, monospace;
+  --dt-typography-fontSize-sm: 0.875rem;
+  --dt-typography-fontSize-md: 1rem;
+  --dt-typography-fontSize-lg: 1.125rem;
+  --dt-typography-fontWeight-regular: 400;
+  --dt-typography-fontWeight-medium: 500;
+  --dt-typography-fontWeight-semibold: 600;
+  --dt-typography-lineHeight-tight: 1.25;
+  --dt-typography-lineHeight-normal: 1.5;
+  --dt-zIndex-base: 1;
+  --dt-zIndex-sticky: 10;
+  --dt-zIndex-overlay: 100;
+  --dt-zIndex-dialog: 200;
+  --dt-semantic-color-bg-canvas: #f8f9fc;
+  --dt-semantic-color-bg-surface: #ffffff;
+  --dt-semantic-color-bg-surfaceMuted: #f1f3f8;
+  --dt-semantic-color-bg-accentSoft: #eef0ff;
+  --dt-semantic-color-text-primary: #171c28;
+  --dt-semantic-color-text-secondary: #2a3142;
+  --dt-semantic-color-text-muted: #6b7385;
+  --dt-semantic-color-text-inverse: #ffffff;
+  --dt-semantic-color-border-subtle: #e6e9f0;
+  --dt-semantic-color-border-default: #d7dce7;
+  --dt-semantic-color-border-focus: #635bff;
+  --dt-semantic-color-action-primary: #635bff;
+  --dt-semantic-color-action-primaryHover: #554ceb;
+  --dt-semantic-color-status-success: #0f8a4b;
+  --dt-semantic-color-status-warning: #a56315;
+  --dt-semantic-color-status-danger: #c0352b;
+  --dt-semantic-color-status-info: #1769e0;
+  --dt-component-button-primary-bg: #635bff;
+  --dt-component-button-primary-bgHover: #554ceb;
+  --dt-component-button-primary-text: #ffffff;
+  --dt-component-button-primary-radius: 0.75rem;
+  --dt-component-button-primary-paddingInline: 1rem;
+  --dt-component-button-primary-paddingBlock: 0.75rem;
+  --dt-component-button-secondary-bg: #ffffff;
+  --dt-component-button-secondary-text: #2a3142;
+  --dt-component-button-secondary-border: #d7dce7;
+  --dt-component-input-bg: #ffffff;
+  --dt-component-input-text: #171c28;
+  --dt-component-input-placeholder: #6b7385;
+  --dt-component-input-border: #d7dce7;
+  --dt-component-input-focusRing: 0 0 0 3px rgb(99 91 255 / 30%);
+  --dt-component-input-radius: 0.75rem;
+  --dt-component-input-paddingInline: 1rem;
+  --dt-component-input-paddingBlock: 0.75rem;
+  --dt-theme-name: light;
 }

--- a/packages/dbt-tools/web/tokens/components/button.json
+++ b/packages/dbt-tools/web/tokens/components/button.json
@@ -1,0 +1,25 @@
+{
+  "component": {
+    "button": {
+      "primary": {
+        "bg": { "value": "{semantic.color.action.primary}", "type": "color" },
+        "bgHover": {
+          "value": "{semantic.color.action.primaryHover}",
+          "type": "color"
+        },
+        "text": { "value": "{semantic.color.text.inverse}", "type": "color" },
+        "radius": { "value": "{radius.md}", "type": "dimension" },
+        "paddingInline": { "value": "{space.md}", "type": "dimension" },
+        "paddingBlock": { "value": "{space.sm}", "type": "dimension" }
+      },
+      "secondary": {
+        "bg": { "value": "{semantic.color.bg.surface}", "type": "color" },
+        "text": { "value": "{semantic.color.text.secondary}", "type": "color" },
+        "border": {
+          "value": "{semantic.color.border.default}",
+          "type": "color"
+        }
+      }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/components/input.json
+++ b/packages/dbt-tools/web/tokens/components/input.json
@@ -1,0 +1,17 @@
+{
+  "component": {
+    "input": {
+      "bg": { "value": "{semantic.color.bg.surface}", "type": "color" },
+      "text": { "value": "{semantic.color.text.primary}", "type": "color" },
+      "placeholder": {
+        "value": "{semantic.color.text.muted}",
+        "type": "color"
+      },
+      "border": { "value": "{semantic.color.border.default}", "type": "color" },
+      "focusRing": { "value": "{shadow.focus}", "type": "shadow" },
+      "radius": { "value": "{radius.md}", "type": "dimension" },
+      "paddingInline": { "value": "{space.md}", "type": "dimension" },
+      "paddingBlock": { "value": "{space.sm}", "type": "dimension" }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/border.json
+++ b/packages/dbt-tools/web/tokens/primitives/border.json
@@ -1,0 +1,7 @@
+{
+  "border": {
+    "width": {
+      "default": { "value": "1px", "type": "dimension" }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/color.json
+++ b/packages/dbt-tools/web/tokens/primitives/color.json
@@ -1,0 +1,36 @@
+{
+  "color": {
+    "neutral": {
+      "0": { "value": "#ffffff", "type": "color" },
+      "50": { "value": "#f8f9fc", "type": "color" },
+      "100": { "value": "#f1f3f8", "type": "color" },
+      "200": { "value": "#e6e9f0", "type": "color" },
+      "300": { "value": "#d7dce7", "type": "color" },
+      "500": { "value": "#6b7385", "type": "color" },
+      "700": { "value": "#2a3142", "type": "color" },
+      "900": { "value": "#171c28", "type": "color" }
+    },
+    "violet": {
+      "100": { "value": "#eef0ff", "type": "color" },
+      "400": { "value": "#8a7cff", "type": "color" },
+      "500": { "value": "#635bff", "type": "color" },
+      "600": { "value": "#554ceb", "type": "color" }
+    },
+    "green": {
+      "100": { "value": "#eaf8f0", "type": "color" },
+      "500": { "value": "#0f8a4b", "type": "color" }
+    },
+    "amber": {
+      "100": { "value": "#fff5e8", "type": "color" },
+      "500": { "value": "#a56315", "type": "color" }
+    },
+    "red": {
+      "100": { "value": "#fdedec", "type": "color" },
+      "500": { "value": "#c0352b", "type": "color" }
+    },
+    "blue": {
+      "100": { "value": "#eaf2ff", "type": "color" },
+      "500": { "value": "#1769e0", "type": "color" }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/motion.json
+++ b/packages/dbt-tools/web/tokens/primitives/motion.json
@@ -1,0 +1,14 @@
+{
+  "motion": {
+    "duration": {
+      "fast": { "value": "120ms", "type": "duration" },
+      "normal": { "value": "180ms", "type": "duration" }
+    },
+    "easing": {
+      "standard": {
+        "value": "cubic-bezier(0.2, 0, 0, 1)",
+        "type": "cubicBezier"
+      }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/radius.json
+++ b/packages/dbt-tools/web/tokens/primitives/radius.json
@@ -1,0 +1,8 @@
+{
+  "radius": {
+    "sm": { "value": "0.5rem", "type": "dimension" },
+    "md": { "value": "0.75rem", "type": "dimension" },
+    "lg": { "value": "1rem", "type": "dimension" },
+    "pill": { "value": "9999px", "type": "dimension" }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/shadow.json
+++ b/packages/dbt-tools/web/tokens/primitives/shadow.json
@@ -1,0 +1,12 @@
+{
+  "shadow": {
+    "surface": {
+      "value": "0 1px 3px rgb(15 15 35 / 6%), 0 4px 12px rgb(15 15 35 / 4%)",
+      "type": "shadow"
+    },
+    "focus": {
+      "value": "0 0 0 3px rgb(99 91 255 / 30%)",
+      "type": "shadow"
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/space.json
+++ b/packages/dbt-tools/web/tokens/primitives/space.json
@@ -1,0 +1,10 @@
+{
+  "space": {
+    "2xs": { "value": "0.25rem", "type": "dimension" },
+    "xs": { "value": "0.5rem", "type": "dimension" },
+    "sm": { "value": "0.75rem", "type": "dimension" },
+    "md": { "value": "1rem", "type": "dimension" },
+    "lg": { "value": "1.5rem", "type": "dimension" },
+    "xl": { "value": "2rem", "type": "dimension" }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/typography.json
+++ b/packages/dbt-tools/web/tokens/primitives/typography.json
@@ -1,0 +1,28 @@
+{
+  "typography": {
+    "fontFamily": {
+      "sans": {
+        "value": "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+        "type": "fontFamily"
+      },
+      "mono": {
+        "value": "\"IBM Plex Mono\", SFMono-Regular, Consolas, monospace",
+        "type": "fontFamily"
+      }
+    },
+    "fontSize": {
+      "sm": { "value": "0.875rem", "type": "dimension" },
+      "md": { "value": "1rem", "type": "dimension" },
+      "lg": { "value": "1.125rem", "type": "dimension" }
+    },
+    "fontWeight": {
+      "regular": { "value": "400", "type": "fontWeight" },
+      "medium": { "value": "500", "type": "fontWeight" },
+      "semibold": { "value": "600", "type": "fontWeight" }
+    },
+    "lineHeight": {
+      "tight": { "value": "1.25", "type": "number" },
+      "normal": { "value": "1.5", "type": "number" }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/primitives/z-index.json
+++ b/packages/dbt-tools/web/tokens/primitives/z-index.json
@@ -1,0 +1,8 @@
+{
+  "zIndex": {
+    "base": { "value": "1", "type": "number" },
+    "sticky": { "value": "10", "type": "number" },
+    "overlay": { "value": "100", "type": "number" },
+    "dialog": { "value": "200", "type": "number" }
+  }
+}

--- a/packages/dbt-tools/web/tokens/semantics/color.json
+++ b/packages/dbt-tools/web/tokens/semantics/color.json
@@ -1,0 +1,33 @@
+{
+  "semantic": {
+    "color": {
+      "bg": {
+        "canvas": { "value": "{color.neutral.50}", "type": "color" },
+        "surface": { "value": "{color.neutral.0}", "type": "color" },
+        "surfaceMuted": { "value": "{color.neutral.100}", "type": "color" },
+        "accentSoft": { "value": "{color.violet.100}", "type": "color" }
+      },
+      "text": {
+        "primary": { "value": "{color.neutral.900}", "type": "color" },
+        "secondary": { "value": "{color.neutral.700}", "type": "color" },
+        "muted": { "value": "{color.neutral.500}", "type": "color" },
+        "inverse": { "value": "{color.neutral.0}", "type": "color" }
+      },
+      "border": {
+        "subtle": { "value": "{color.neutral.200}", "type": "color" },
+        "default": { "value": "{color.neutral.300}", "type": "color" },
+        "focus": { "value": "{color.violet.500}", "type": "color" }
+      },
+      "action": {
+        "primary": { "value": "{color.violet.500}", "type": "color" },
+        "primaryHover": { "value": "{color.violet.600}", "type": "color" }
+      },
+      "status": {
+        "success": { "value": "{color.green.500}", "type": "color" },
+        "warning": { "value": "{color.amber.500}", "type": "color" },
+        "danger": { "value": "{color.red.500}", "type": "color" },
+        "info": { "value": "{color.blue.500}", "type": "color" }
+      }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/themes/dark.json
+++ b/packages/dbt-tools/web/tokens/themes/dark.json
@@ -1,0 +1,33 @@
+{
+  "semantic": {
+    "color": {
+      "bg": {
+        "canvas": { "value": "#0d1120", "type": "color" },
+        "surface": { "value": "#151a2e", "type": "color" },
+        "surfaceMuted": { "value": "#101527", "type": "color" },
+        "accentSoft": { "value": "#232845", "type": "color" }
+      },
+      "text": {
+        "primary": { "value": "#f3f6fc", "type": "color" },
+        "secondary": { "value": "#c6cee0", "type": "color" },
+        "muted": { "value": "#98a3bc", "type": "color" },
+        "inverse": { "value": "#121622", "type": "color" }
+      },
+      "border": {
+        "subtle": { "value": "#262e47", "type": "color" },
+        "default": { "value": "#313a58", "type": "color" },
+        "focus": { "value": "#8a7cff", "type": "color" }
+      },
+      "action": {
+        "primary": { "value": "#8a7cff", "type": "color" },
+        "primaryHover": { "value": "#9b90ff", "type": "color" }
+      },
+      "status": {
+        "success": { "value": "#59d38c", "type": "color" },
+        "warning": { "value": "#f5b95c", "type": "color" },
+        "danger": { "value": "#ff8d86", "type": "color" },
+        "info": { "value": "#79b7ff", "type": "color" }
+      }
+    }
+  }
+}

--- a/packages/dbt-tools/web/tokens/themes/light.json
+++ b/packages/dbt-tools/web/tokens/themes/light.json
@@ -1,0 +1,5 @@
+{
+  "theme": {
+    "name": { "value": "light", "type": "string" }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       knip:
         specifier: ^6.3.0
         version: 6.3.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      style-dictionary:
+        specifier: ^4.4.0
+        version: 4.4.0(tslib@2.8.1)
       stylelint:
         specifier: ^17.6.0
         version: 17.6.0(typescript@6.0.2)
@@ -432,6 +435,15 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
+  '@bundled-es-modules/deepmerge@4.3.1':
+    resolution: {integrity: sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==}
+
+  '@bundled-es-modules/glob@10.4.2':
+    resolution: {integrity: sha512-740y5ofkzydsFao5EXJrGilcIL6EFEw/cmPf2uhTw9J6G1YOhiIFjNFCHdpgEiiH5VlU3G0SARSjlFlimRRSMA==}
+
+  '@bundled-es-modules/memfs@4.17.0':
+    resolution: {integrity: sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==}
+
   '@cacheable/memory@2.0.8':
     resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
 
@@ -729,6 +741,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -747,6 +763,126 @@ packages:
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
+  '@jsonjoy.com/base64@1.1.2':
+    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@1.2.1':
+    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@1.0.0':
+    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-core@4.57.1':
+    resolution: {integrity: sha512-YrEi/ZPmgc+GfdO0esBF04qv8boK9Dg9WpRQw/+vM8Qt3nnVIJWIa8HwZ/LXVZ0DB11XUROM8El/7yYTJX+WtA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-fsa@4.57.1':
+    resolution: {integrity: sha512-ooEPvSW/HQDivPDPZMibHGKZf/QS4WRir1czGZmXmp3MsQqLECZEpN0JobrD8iV9BzsuwdIv+PxtWX9WpPLsIA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-builtins@4.57.1':
+    resolution: {integrity: sha512-XHkFKQ5GSH3uxm8c3ZYXVrexGdscpWKIcMWKFQpMpMJc8gA3AwOMBJXJlgpdJqmrhPyQXxaY9nbkNeYpacC0Og==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.1':
+    resolution: {integrity: sha512-pqGHyWWzNck4jRfaGV39hkqpY5QjRUQ/nRbNT7FYbBa0xf4bDG+TE1Gt2KWZrSkrkZZDE3qZUjYMbjwSliX6pg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-utils@4.57.1':
+    resolution: {integrity: sha512-vp+7ZzIB8v43G+GLXTS4oDUSQmhAsRz532QmmWBbdYA20s465JvwhkSFvX9cVTqRRAQg+vZ7zWDaIEh0lFe2gw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node@4.57.1':
+    resolution: {integrity: sha512-3YaKhP8gXEKN+2O49GLNfNb5l2gbnCFHyAaybbA2JkkbQP3dpdef7WcUaHAulg/c5Dg4VncHsA3NWAUSZMR5KQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-print@4.57.1':
+    resolution: {integrity: sha512-Ynct7ZJmfk6qoXDOKfpovNA36ITUx8rChLmRQtW08J73VOiuNsU8PB6d/Xs7fxJC2ohWR3a5AqyjmLojfrw5yw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-snapshot@4.57.1':
+    resolution: {integrity: sha512-/oG8xBNFMbDXTq9J7vepSA1kerS5vpgd3p5QZSPd+nX59uwodGJftI51gDYyHRpP57P3WCQf7LHtBYPqwUg2Bg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.21.0':
+    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@1.0.2':
+    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.9.0':
+    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   '@keyv/bigmap@1.3.1':
     resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
@@ -999,6 +1135,10 @@ packages:
     resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -1526,6 +1666,13 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  '@yarnpkg/lockfile@1.1.0':
+    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
+
+  '@zip.js/zip.js@2.8.26':
+    resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
+    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1566,6 +1713,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1604,6 +1755,9 @@ packages:
   arrify@2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
+
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1675,6 +1829,9 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -1690,6 +1847,9 @@ packages:
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -1728,6 +1888,17 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1739,6 +1910,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1757,9 +1932,17 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  component-emitter@2.0.0:
+    resolution: {integrity: sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==}
+    engines: {node: '>=18'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1833,6 +2016,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -1866,6 +2053,9 @@ packages:
 
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -2092,6 +2282,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  find-yarn-workspace-root@2.0.0:
+    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -2106,6 +2299,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@2.5.5:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
@@ -2114,6 +2311,10 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2181,6 +2382,17 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob-to-regex.js@1.2.0:
+    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
     engines: {node: '>=6'}
@@ -2215,6 +2427,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphology-dag@0.4.1:
     resolution: {integrity: sha512-3ch9oOAnHZDoT043vyg7ukmSkKJ505nFzaHaYOn0IF2PgGo5VtIavyVK4UpbIa4tli3hhGm1ZTdBsubTmaxu/w==}
@@ -2320,6 +2535,13 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2339,6 +2561,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.3:
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -2357,6 +2582,10 @@ packages:
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2396,6 +2625,11 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2421,6 +2655,10 @@ packages:
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
@@ -2490,6 +2728,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -2511,6 +2753,9 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2563,10 +2808,20 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
   jsx-ast-utils-x@0.1.0:
     resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
@@ -2591,6 +2846,9 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  klaw-sync@6.0.0:
+    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
 
   knip@6.3.0:
     resolution: {integrity: sha512-g6dVPoTw6iNm3cubC5IWxVkVsd0r5hXhTBTbAGIEQN53GdA2ZM/slMTPJ7n5l8pBebNQPHpxjmKxuR4xVQ2/hQ==}
@@ -2701,6 +2959,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.3.2:
     resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
     engines: {node: 20 || >=22}
@@ -2775,6 +3036,11 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  memfs@4.57.1:
+    resolution: {integrity: sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==}
+    peerDependencies:
+      tslib: '2'
 
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
@@ -2892,8 +3158,16 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mnemonist@0.39.8:
     resolution: {integrity: sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==}
@@ -2941,6 +3215,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -2970,6 +3248,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2993,6 +3275,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3006,6 +3291,11 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  patch-package@8.0.1:
+    resolution: {integrity: sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==}
+    engines: {node: '>=14', npm: '>5'}
+    hasBin: true
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3021,6 +3311,16 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-unified@0.2.0:
+    resolution: {integrity: sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg==}
+
+  path@0.12.7:
+    resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3076,11 +3376,18 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3089,6 +3396,10 @@ packages:
   qified@0.9.1:
     resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==}
     engines: {node: '>=20'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3257,6 +3568,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slash@2.0.0:
+    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
+    engines: {node: '>=6'}
+
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
@@ -3292,9 +3607,16 @@ packages:
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
+  stream@0.0.3:
+    resolution: {integrity: sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
@@ -3346,6 +3668,11 @@ packages:
 
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
+  style-dictionary@4.4.0:
+    resolution: {integrity: sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -3400,8 +3727,17 @@ packages:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
 
+  thingies@2.6.0:
+    resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
@@ -3422,6 +3758,10 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3436,6 +3776,12 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  tree-dump@1.1.0:
+    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3514,6 +3860,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3523,8 +3873,18 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url@0.11.4:
+    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
+    engines: {node: '>= 0.4'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.10.4:
+    resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -3677,6 +4037,14 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -4295,6 +4663,33 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  '@bundled-es-modules/deepmerge@4.3.1':
+    dependencies:
+      deepmerge: 4.3.1
+
+  '@bundled-es-modules/glob@10.4.2':
+    dependencies:
+      buffer: 6.0.3
+      events: 3.3.0
+      glob: 10.5.0
+      patch-package: 8.0.1
+      path: 0.12.7
+      stream: 0.0.3
+      string_decoder: 1.3.0
+      url: 0.11.4
+
+  '@bundled-es-modules/memfs@4.17.0(tslib@2.8.1)':
+    dependencies:
+      assert: 2.1.0
+      buffer: 6.0.3
+      events: 3.3.0
+      memfs: 4.57.1(tslib@2.8.1)
+      path: 0.12.7
+      stream: 0.0.3
+      util: 0.12.5
+    transitivePeerDependencies:
+      - tslib
+
   '@cacheable/memory@2.0.8':
     dependencies:
       '@cacheable/utils': 2.4.1
@@ -4511,6 +4906,15 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4531,6 +4935,133 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsdevtools/ono@7.1.3': {}
+
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-core@4.57.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.1(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-fsa@4.57.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.1(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-builtins@4.57.1(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.1(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-utils@4.57.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.1(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node@4.57.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.1(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-print@4.57.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.57.1(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-snapshot@4.57.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -4691,6 +5222,9 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@playwright/test@1.59.1':
@@ -5330,6 +5864,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@yarnpkg/lockfile@1.1.0': {}
+
+  '@zip.js/zip.js@2.8.26': {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -5369,6 +5907,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -5433,6 +5973,14 @@ snapshots:
 
   arrify@2.0.1: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -5486,6 +6034,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -5503,6 +6055,11 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-equal-constant-time@1.0.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
 
@@ -5541,6 +6098,15 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  change-case@5.4.4: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -5548,6 +6114,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  ci-info@3.9.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -5563,7 +6131,11 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@12.1.0: {}
+
   commander@14.0.3: {}
+
+  component-emitter@2.0.0: {}
 
   concat-map@0.0.1: {}
 
@@ -5634,6 +6206,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -5672,6 +6246,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
+
+  eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -6046,6 +6622,10 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  find-yarn-workspace-root@2.0.0:
+    dependencies:
+      micromatch: 4.0.8
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
@@ -6063,6 +6643,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@2.5.5:
     dependencies:
       asynckit: 0.4.0
@@ -6075,6 +6660,12 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
 
   fsevents@2.3.2:
     optional: true
@@ -6159,6 +6750,19 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-to-regex.js@1.2.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   global-modules@2.0.0:
     dependencies:
       global-prefix: 3.0.0
@@ -6202,6 +6806,8 @@ snapshots:
   google-logging-utils@0.0.2: {}
 
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   graphology-dag@0.4.1(graphology-types@0.24.8):
     dependencies:
@@ -6326,6 +6932,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hyperdyperid@1.2.0: {}
+
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -6338,6 +6948,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.3: {}
 
   inherits@2.0.4: {}
 
@@ -6357,6 +6969,11 @@ snapshots:
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -6402,6 +7019,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@2.2.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -6425,6 +7044,11 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-map@2.0.3: {}
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -6484,6 +7108,10 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -6509,6 +7137,12 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
 
@@ -6574,7 +7208,23 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
   json5@2.2.3: {}
+
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonify@0.0.1: {}
 
   jsx-ast-utils-x@0.1.0: {}
 
@@ -6605,6 +7255,10 @@ snapshots:
       '@keyv/serialize': 1.1.1
 
   kind-of@6.0.3: {}
+
+  klaw-sync@6.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
 
   knip@6.3.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
@@ -6704,6 +7358,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.3.2: {}
 
@@ -6885,6 +7541,23 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
+
+  memfs@4.57.1(tslib@2.8.1):
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.1(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
 
   meow@14.1.0: {}
 
@@ -7102,7 +7775,13 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.13
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.3
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mnemonist@0.39.8:
     dependencies:
@@ -7137,6 +7816,11 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -7177,6 +7861,11 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -7255,6 +7944,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -7280,6 +7971,23 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  patch-package@8.0.1:
+    dependencies:
+      '@yarnpkg/lockfile': 1.1.0
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      cross-spawn: 7.0.6
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 10.1.0
+      json-stable-stringify: 1.3.0
+      klaw-sync: 6.0.0
+      minimist: 1.2.8
+      open: 7.4.2
+      semver: 7.7.4
+      slash: 2.0.0
+      tmp: 0.2.5
+      yaml: 2.8.3
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.2.1: {}
@@ -7287,6 +7995,18 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-unified@0.2.0: {}
+
+  path@0.12.7:
+    dependencies:
+      process: 0.11.10
+      util: 0.10.4
 
   pathe@2.0.3: {}
 
@@ -7327,6 +8047,8 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  process@0.11.10: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7335,11 +8057,17 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  punycode@1.4.1: {}
+
   punycode@2.3.1: {}
 
   qified@0.9.1:
     dependencies:
       hookified: 2.1.1
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
 
@@ -7592,6 +8320,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  slash@2.0.0: {}
+
   slash@5.1.0: {}
 
   slice-ansi@4.0.0:
@@ -7621,11 +8351,21 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
+  stream@0.0.3:
+    dependencies:
+      component-emitter: 2.0.0
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string-width@8.2.0:
     dependencies:
@@ -7704,6 +8444,24 @@ snapshots:
   strnum@2.2.2: {}
 
   stubs@3.0.0: {}
+
+  style-dictionary@4.4.0(tslib@2.8.1):
+    dependencies:
+      '@bundled-es-modules/deepmerge': 4.3.1
+      '@bundled-es-modules/glob': 10.4.2
+      '@bundled-es-modules/memfs': 4.17.0(tslib@2.8.1)
+      '@zip.js/zip.js': 2.8.26
+      chalk: 5.6.2
+      change-case: 5.4.4
+      commander: 12.1.0
+      is-plain-obj: 4.1.0
+      json5: 2.2.3
+      patch-package: 8.0.1
+      path-unified: 0.2.0
+      prettier: 3.8.1
+      tinycolor2: 1.6.0
+    transitivePeerDependencies:
+      - tslib
 
   style-to-js@1.1.21:
     dependencies:
@@ -7800,7 +8558,13 @@ snapshots:
       - encoding
       - supports-color
 
+  thingies@2.6.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@1.0.4: {}
 
@@ -7817,6 +8581,8 @@ snapshots:
     dependencies:
       tldts-core: 7.0.28
 
+  tmp@0.2.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -7830,6 +8596,10 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  tree-dump@1.1.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
 
   trim-lines@3.0.1: {}
 
@@ -7928,6 +8698,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universalify@2.0.1: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -7938,7 +8710,24 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url@0.11.4:
+    dependencies:
+      punycode: 1.4.1
+      qs: 6.15.1
+
   util-deprecate@1.0.2: {}
+
+  util@0.10.4:
+    dependencies:
+      inherits: 2.0.3
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   uuid@8.3.2: {}
 
@@ -8079,6 +8868,18 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/scripts/build-tokens.mjs
+++ b/scripts/build-tokens.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import StyleDictionary from "style-dictionary";
+
+const repoRoot = process.cwd();
+const webRoot = path.join(repoRoot, "packages/dbt-tools/web");
+const tokenRoot = path.join(webRoot, "tokens");
+const srcRoot = path.join(webRoot, "src");
+const stylesOutDir = path.join(srcRoot, "styles");
+const libOutDir = path.join(srcRoot, "lib");
+
+const fileHeader = [
+  "/**",
+  " * AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.",
+  " */",
+  "",
+];
+
+StyleDictionary.registerFormat({
+  name: "dbt-tools/css-semantic-vars",
+  format: ({ dictionary }) => {
+    const allBaseTokens = dictionary.allTokens;
+
+    const lines = allBaseTokens.map((token) => {
+      const name = `--dt-${token.path.join("-")}`;
+      return `  ${name}: ${token.value};`;
+    });
+
+    return [
+      ...fileHeader,
+      ":root {",
+      "  color-scheme: light;",
+      ...lines,
+      "}",
+      "",
+    ].join("\n");
+  },
+});
+
+StyleDictionary.registerFormat({
+  name: "dbt-tools/css-dark-theme-overrides",
+  format: ({ dictionary }) => {
+    const semanticAndComponent = dictionary.allTokens.filter(
+      (token) => token.path[0] === "semantic" || token.path[0] === "component",
+    );
+    const lines = semanticAndComponent.map((token) => {
+      const name = `--dt-${token.path.join("-")}`;
+      return `  ${name}: ${token.value};`;
+    });
+
+    return [
+      ...fileHeader,
+      '[data-theme="dark"] {',
+      "  color-scheme: dark;",
+      ...lines,
+      "}",
+      "",
+    ].join("\n");
+  },
+});
+
+StyleDictionary.registerFormat({
+  name: "dbt-tools/typed-tokens",
+  format: ({ dictionary }) => {
+    const semanticAndComponent = dictionary.allTokens.filter(
+      (token) => token.path[0] === "semantic" || token.path[0] === "component",
+    );
+
+    const rows = semanticAndComponent.map((token) => {
+      const key = token.path.join(".");
+      const cssVar = `--dt-${token.path.join("-")}`;
+      return `  "${key}": "var(${cssVar})",`;
+    });
+
+    const tokenNames = semanticAndComponent.map(
+      (token) => `  | "${token.path.join(".")}"`,
+    );
+
+    return [
+      ...fileHeader,
+      "export const tokens = {",
+      ...rows,
+      "} as const;",
+      "",
+      "export type TokenName =",
+      ...tokenNames,
+      ";",
+      "",
+      "export function tokenVar(name: TokenName): string {",
+      "  return tokens[name];",
+      "}",
+      "",
+    ].join("\n");
+  },
+});
+
+StyleDictionary.registerFormat({
+  name: "dbt-tools/tailwind-bridge",
+  format: ({ dictionary }) => {
+    const semanticColor = dictionary.allTokens.filter(
+      (token) => token.path.slice(0, 2).join(".") === "semantic.color",
+    );
+
+    const rows = semanticColor.map((token) => {
+      const tailwindName = token.path.slice(2).join("-");
+      const cssVar = `--dt-${token.path.join("-")}`;
+      return `  "${tailwindName}": "rgb(from var(${cssVar}) r g b / <alpha-value>)",`;
+    });
+
+    return [
+      ...fileHeader,
+      "export const tailwindSemanticColors = {",
+      ...rows,
+      "} as const;",
+      "",
+    ].join("\n");
+  },
+});
+
+const baseConfig = {
+  source: [
+    `${tokenRoot}/primitives/**/*.json`,
+    `${tokenRoot}/semantics/**/*.json`,
+    `${tokenRoot}/components/**/*.json`,
+    `${tokenRoot}/themes/light.json`,
+  ],
+  platforms: {
+    css: {
+      transformGroup: "css",
+      buildPath: `${stylesOutDir}/`,
+      files: [
+        {
+          destination: "tokens.css",
+          format: "dbt-tools/css-semantic-vars",
+        },
+      ],
+    },
+    ts: {
+      transformGroup: "js",
+      buildPath: `${libOutDir}/`,
+      files: [
+        { destination: "tokens.ts", format: "dbt-tools/typed-tokens" },
+        {
+          destination: "tailwind-theme-bridge.ts",
+          format: "dbt-tools/tailwind-bridge",
+        },
+      ],
+    },
+  },
+};
+
+const darkConfig = {
+  include: [
+    `${tokenRoot}/primitives/**/*.json`,
+    `${tokenRoot}/semantics/**/*.json`,
+    `${tokenRoot}/components/**/*.json`,
+    `${tokenRoot}/themes/light.json`,
+  ],
+  source: [`${tokenRoot}/themes/dark.json`],
+  platforms: {
+    css: {
+      transformGroup: "css",
+      buildPath: `${stylesOutDir}/`,
+      files: [
+        {
+          destination: "theme.css",
+          format: "dbt-tools/css-dark-theme-overrides",
+        },
+      ],
+    },
+  },
+};
+
+await fs.mkdir(stylesOutDir, { recursive: true });
+await fs.mkdir(libOutDir, { recursive: true });
+
+await new StyleDictionary(baseConfig).buildAllPlatforms();
+await new StyleDictionary(darkConfig).buildAllPlatforms();
+
+console.log("Built design tokens for @dbt-tools/web.");

--- a/scripts/validate-tokens.mjs
+++ b/scripts/validate-tokens.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const webRoot = path.join(repoRoot, "packages/dbt-tools/web");
+const tokenRoot = path.join(webRoot, "tokens");
+
+const guardedDirs = ["packages/dbt-tools/web/src/design-system"];
+
+const guardedFiles = [
+  "packages/dbt-tools/web/src/styles/app.css",
+  "packages/dbt-tools/web/src/styles/design-system.css",
+  "packages/dbt-tools/web/src/index.css",
+];
+
+const guardedExt = new Set([".tsx", ".ts", ".css"]);
+const allowedFiles = new Set([
+  "packages/dbt-tools/web/src/lib/tokens.ts",
+  "packages/dbt-tools/web/src/lib/tailwind-theme-bridge.ts",
+  "packages/dbt-tools/web/src/styles/tokens.css",
+  "packages/dbt-tools/web/src/styles/theme.css",
+]);
+
+const forbiddenPatterns = [
+  { label: "hex color", regex: /#[0-9a-fA-F]{3,8}\b/g },
+  { label: "pixel literal", regex: /\b\d+px\b/g },
+  { label: "rgba/rgb literal", regex: /\brgba?\(/g },
+];
+
+async function listFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const absolute = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(absolute)));
+      continue;
+    }
+    if (!guardedExt.has(path.extname(entry.name))) continue;
+    files.push(absolute);
+  }
+  return files;
+}
+
+function validateTokenTree(node, nodePath, findings) {
+  if (!node || typeof node !== "object") return;
+  const maybeToken = "value" in node || "type" in node;
+  if (maybeToken) {
+    if (!("value" in node) || !("type" in node)) {
+      findings.push(
+        `${nodePath.join(".")}: token leaves must define both value and type`,
+      );
+    }
+    return;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    validateTokenTree(value, [...nodePath, key], findings);
+  }
+}
+
+async function validateTokenSchema(findings) {
+  const tokenFiles = [
+    "primitives/color.json",
+    "primitives/space.json",
+    "primitives/border.json",
+    "primitives/radius.json",
+    "primitives/typography.json",
+    "primitives/shadow.json",
+    "primitives/motion.json",
+    "primitives/z-index.json",
+    "semantics/color.json",
+    "components/button.json",
+    "components/input.json",
+    "themes/light.json",
+    "themes/dark.json",
+  ];
+
+  for (const rel of tokenFiles) {
+    const absolute = path.join(tokenRoot, rel);
+    try {
+      const json = JSON.parse(await fs.readFile(absolute, "utf8"));
+      validateTokenTree(json, [rel], findings);
+    } catch (error) {
+      findings.push(`${rel}: unable to parse token JSON (${String(error)})`);
+    }
+  }
+}
+
+const findings = [];
+await validateTokenSchema(findings);
+
+const filesToCheck = [];
+for (const dir of guardedDirs) {
+  const absolute = path.join(repoRoot, dir);
+  filesToCheck.push(...(await listFiles(absolute)));
+}
+for (const rel of guardedFiles) {
+  filesToCheck.push(path.join(repoRoot, rel));
+}
+
+for (const file of filesToCheck) {
+  const rel = path.relative(repoRoot, file);
+  if (allowedFiles.has(rel)) continue;
+  const text = await fs.readFile(file, "utf8");
+  for (const { label, regex } of forbiddenPatterns) {
+    if (regex.test(text)) {
+      findings.push(`${rel}: found forbidden ${label}`);
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error("Token validation failed:\n" + findings.join("\n"));
+  process.exit(1);
+}
+
+console.log("Token validation passed for schema and guarded UI paths.");


### PR DESCRIPTION
### Motivation

- Provide a DTCG-style, layered token source-of-truth so visual values are edited in one place and propagate reliably at runtime.  
- Enforce a semantic-token-first contract for feature code while allowing shared components to map to component tokens.  
- Add generation, runtime wiring, and a lightweight component foundation to enable safe, incremental UI iteration.  
- Add agent- and CI-friendly guardrails to prevent visual drift and accidental hardcoded styling.

### Description

- Added a layered token repo under `packages/dbt-tools/web/tokens/` with `primitives/`, `semantics/`, `components/`, and `themes/` (light + dark) to model primitive, semantic, component, and theme overrides.  
- Implemented a Style Dictionary-based build pipeline (`scripts/build-tokens.mjs`) that generates `packages/dbt-tools/web/src/styles/tokens.css`, `src/styles/theme.css`, `src/lib/tokens.ts`, and `src/lib/tailwind-theme-bridge.ts`.  
- Wired runtime token contract via `src/styles/app.css` and updated `src/index.css` import order so generated token files load first and feature code consumes semantic CSS variables (mapped aliases like `--bg`, `--text` remain available).  
- Introduced a small shared design-system (`src/design-system/`) with `Button`, `Input`, `Card`, state patterns (`LoadingStatePattern`, `EmptyStatePattern`) and `design-system.css` where all visual decisions map to token variables.  
- Added agent/authoring artifacts and guardrails: `.agent/ui-rules.md`, `.agent/prompts/implement-component.md`, a PR checklist (`.github/pull_request_template.md`), and `scripts/validate-tokens.mjs` to validate token schema and detect forbidden hardcoded literals in guarded UI paths.  
- Added package scripts `tokens:build`, `tokens:validate`, and `tokens:check` and added `style-dictionary` as a devDependency; created a Tailwind bridge artifact instead of requiring a Tailwind migration.

### Testing

- Ran `pnpm tokens:build` which successfully generated `src/styles/tokens.css`, `src/styles/theme.css`, `src/lib/tokens.ts`, and `src/lib/tailwind-theme-bridge.ts` (success).  
- Ran `pnpm tokens:validate` which passed schema checks and guarded-path hardcoded-literal checks (success).  
- Ran `pnpm --filter @dbt-tools/web lint:stylelint` to verify CSS slices (success).  
- Attempted full package build `pnpm --filter @dbt-tools/web build` but it failed in this environment during the `@dbt-tools/core` prebuild step due to unresolved `dbt-artifacts-parser/*` subpath type/module declarations (this is unrelated to the token system and blocks the monorepo build in this sandbox).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d16a014c832ca13504c988cf5d12)