### PR TITLE
feat(web): add coherent cross-view pivots for investigation flows

### DIFF
--- a/packages/dbt-tools/web/e2e/cross-view.spec.ts
+++ b/packages/dbt-tools/web/e2e/cross-view.spec.ts
@@ -115,7 +115,9 @@ test.describe("timeline pivot actions", () => {
 
     await page.goto("/?view=timeline&selected=model.jaffle_shop.orders");
     await page.getByRole("button", { name: "Run", exact: true }).click();
-    await expect(page.getByRole("heading", { name: "Runs" }).first()).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Runs" }).first(),
+    ).toBeVisible();
     await expect(page).toHaveURL(/[?&]view=runs/);
     await expect(page).toHaveURL(/[?&]selected=model\.jaffle_shop\.orders/);
   });

--- a/packages/dbt-tools/web/e2e/cross-view.spec.ts
+++ b/packages/dbt-tools/web/e2e/cross-view.spec.ts
@@ -94,3 +94,29 @@ test.describe("inventory to timeline cross-view", () => {
     await expect(page).toHaveURL(/[?&]selected=/);
   });
 });
+
+test.describe("timeline pivot actions", () => {
+  test("selected timeline item offers Inventory and Run pivots", async ({
+    page,
+  }) => {
+    await loadWorkspace(page);
+    await page.goto("/?view=timeline&selected=model.jaffle_shop.orders");
+    await expect(
+      page.getByRole("heading", { name: "Timeline" }).first(),
+    ).toBeVisible();
+    await expect(page.getByText("Focused timeline item:")).toBeVisible();
+
+    await page.getByRole("button", { name: "Inventory", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Inventory" }).first(),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/[?&]view=inventory/);
+    await expect(page).toHaveURL(/[?&]resource=model\.jaffle_shop\.orders/);
+
+    await page.goto("/?view=timeline&selected=model.jaffle_shop.orders");
+    await page.getByRole("button", { name: "Run", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Runs" }).first()).toBeVisible();
+    await expect(page).toHaveURL(/[?&]view=runs/);
+    await expect(page).toHaveURL(/[?&]selected=model\.jaffle_shop\.orders/);
+  });
+});

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/AnalysisWorkspace.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/AnalysisWorkspace.tsx
@@ -56,6 +56,7 @@ export function AnalysisWorkspace({
             filters={overviewFilters}
             setFilters={onOverviewFiltersChange}
             workspaceSignals={workspaceSignals}
+            onNavigateTo={onNavigateTo}
           />
         )}
         {activeView === "inventory" && (
@@ -94,6 +95,7 @@ export function AnalysisWorkspace({
             filters={timelineFilters}
             setFilters={onTimelineFiltersChange}
             onInvestigationSelectionChange={onInvestigationSelectionChange}
+            onNavigateTo={onNavigateTo}
           />
         )}
       </div>

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/shared.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/shared.tsx
@@ -197,6 +197,22 @@ export function QuickJumpActions({
   );
 }
 
+export function RelatedViewsActions({
+  label = "Related views",
+  actions,
+}: {
+  label?: string;
+  actions: { label: string; onClick: () => void; disabled?: boolean }[];
+}) {
+  if (actions.length === 0) return null;
+  return (
+    <div className="related-views-actions" role="group" aria-label={label}>
+      <span className="related-views-actions__label">{label}</span>
+      <QuickJumpActions actions={actions} />
+    </div>
+  );
+}
+
 export function EntityInspector({
   eyebrow,
   title,

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
@@ -15,8 +15,10 @@ import {
 } from "./useTimelineNeighborhoodRows";
 import type { AnalysisState, GanttItem, ResourceNode } from "@web/types";
 import type {
+  AssetViewState,
   InvestigationSelectionState,
   TimelineFilterState,
+  WorkspaceView,
 } from "@web/lib/analysis-workspace/types";
 import { TEST_RESOURCE_TYPES } from "@web/lib/analysis-workspace/constants";
 import {
@@ -27,7 +29,12 @@ import {
   timelineGanttHasCompileExecutePhases,
 } from "@web/lib/analysis-workspace/utils";
 import { buildResourceTestStats } from "@web/lib/analysis-workspace/explorerTree";
-import { SectionCard, WorkspaceScaffold } from "../shared";
+import { buildCrossViewNavigationTargets } from "@web/lib/analysis-workspace/crossViewNavigation";
+import {
+  RelatedViewsActions,
+  SectionCard,
+  WorkspaceScaffold,
+} from "../shared";
 import {
   TimelineSearchControls,
   type TimelineTypeFilterHint,
@@ -246,11 +253,77 @@ function TimelineSurface({
   );
 }
 
+function TimelineRelatedViewsBar({
+  selectedTimelineItem,
+  onNavigateTo,
+}: {
+  selectedTimelineItem: GanttItem;
+  onNavigateTo: (
+    view: WorkspaceView,
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: AssetViewState["activeTab"];
+      rootResourceId?: string;
+    },
+  ) => void;
+}) {
+  const selectedTimelineTargets = buildCrossViewNavigationTargets({
+    resourceId: selectedTimelineItem.unique_id,
+    executionId: selectedTimelineItem.unique_id,
+  });
+  return (
+    <div className="timeline-selection-context">
+      <p className="timeline-selection-context__label">
+        Focused timeline item: <strong>{selectedTimelineItem.name}</strong>
+      </p>
+      <RelatedViewsActions
+        label="Related views for selected timeline item"
+        actions={[
+          ...(selectedTimelineTargets.inventory
+            ? [
+                {
+                  label: "Inventory",
+                  onClick: () =>
+                    onNavigateTo(
+                      selectedTimelineTargets.inventory.view,
+                      selectedTimelineTargets.inventory.options,
+                    ),
+                },
+              ]
+            : []),
+          ...(selectedTimelineTargets.runs
+            ? [
+                {
+                  label: "Run",
+                  onClick: () =>
+                    onNavigateTo(
+                      selectedTimelineTargets.runs.view,
+                      selectedTimelineTargets.runs.options,
+                    ),
+                },
+              ]
+            : []),
+          {
+            label: "Health",
+            onClick: () =>
+              onNavigateTo(
+                selectedTimelineTargets.health.view,
+                selectedTimelineTargets.health.options,
+              ),
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
 export function TimelineView({
   analysis,
   filters,
   setFilters,
   onInvestigationSelectionChange,
+  onNavigateTo,
 }: {
   analysis: AnalysisState;
   filters: TimelineFilterState;
@@ -258,6 +331,15 @@ export function TimelineView({
   onInvestigationSelectionChange: Dispatch<
     SetStateAction<InvestigationSelectionState>
   >;
+  onNavigateTo: (
+    view: WorkspaceView,
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: AssetViewState["activeTab"];
+      rootResourceId?: string;
+    },
+  ) => void;
 }) {
   const deferredQuery = useDeferredValue(filters.query);
   const projectName =
@@ -327,6 +409,16 @@ export function TimelineView({
     }
     return m;
   }, [analysis.ganttData]);
+
+  const selectedTimelineItem = useMemo(
+    () =>
+      filters.selectedExecutionId == null
+        ? null
+        : (analysis.ganttData.find(
+            (item) => item.unique_id === filters.selectedExecutionId,
+          ) ?? null),
+    [analysis.ganttData, filters.selectedExecutionId],
+  );
 
   const filteredParents: GanttItem[] = useMemo(
     () =>
@@ -488,6 +580,12 @@ export function TimelineView({
         toggleType={toggleType}
         onInvestigationSelectionChange={onInvestigationSelectionChange}
       />
+      {selectedTimelineItem != null ? (
+        <TimelineRelatedViewsBar
+          selectedTimelineItem={selectedTimelineItem}
+          onNavigateTo={onNavigateTo}
+        />
+      ) : null}
     </WorkspaceScaffold>
   );
 }

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
@@ -30,11 +30,7 @@ import {
 } from "@web/lib/analysis-workspace/utils";
 import { buildResourceTestStats } from "@web/lib/analysis-workspace/explorerTree";
 import { buildCrossViewNavigationTargets } from "@web/lib/analysis-workspace/crossViewNavigation";
-import {
-  RelatedViewsActions,
-  SectionCard,
-  WorkspaceScaffold,
-} from "../shared";
+import { RelatedViewsActions, SectionCard, WorkspaceScaffold } from "../shared";
 import {
   TimelineSearchControls,
   type TimelineTypeFilterHint,
@@ -272,6 +268,8 @@ function TimelineRelatedViewsBar({
     resourceId: selectedTimelineItem.unique_id,
     executionId: selectedTimelineItem.unique_id,
   });
+  const inventoryTarget = selectedTimelineTargets.inventory;
+  const runsTarget = selectedTimelineTargets.runs;
   return (
     <div className="timeline-selection-context">
       <p className="timeline-selection-context__label">
@@ -280,27 +278,21 @@ function TimelineRelatedViewsBar({
       <RelatedViewsActions
         label="Related views for selected timeline item"
         actions={[
-          ...(selectedTimelineTargets.inventory
+          ...(inventoryTarget
             ? [
                 {
                   label: "Inventory",
                   onClick: () =>
-                    onNavigateTo(
-                      selectedTimelineTargets.inventory.view,
-                      selectedTimelineTargets.inventory.options,
-                    ),
+                    onNavigateTo(inventoryTarget.view, inventoryTarget.options),
                 },
               ]
             : []),
-          ...(selectedTimelineTargets.runs
+          ...(runsTarget
             ? [
                 {
                   label: "Run",
                   onClick: () =>
-                    onNavigateTo(
-                      selectedTimelineTargets.runs.view,
-                      selectedTimelineTargets.runs.options,
-                    ),
+                    onNavigateTo(runsTarget.view, runsTarget.options),
                 },
               ]
             : []),

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.test.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.test.tsx
@@ -269,6 +269,45 @@ describe("AssetsView", () => {
     cleanupRoot(root, container);
   });
 
+  it("renders related view pivots for the selected asset", () => {
+    const resource = makeResource();
+    const executionRow = {
+      uniqueId: resource.uniqueId,
+      name: resource.name,
+      resourceType: "model",
+      packageName: "jaffle_shop",
+      path: resource.path,
+      status: "success",
+      statusTone: "positive",
+      executionTime: 3.63,
+      threadId: "Thread-1",
+      start: null,
+      end: null,
+    } as ExecutionRow;
+    const { container, root, onNavigateTo } = renderAssetsView({
+      resource,
+      analysis: makeAnalysis([resource], [executionRow]),
+    });
+
+    expect(container.textContent).toContain("Timeline");
+    expect(container.textContent).toContain("Run");
+    expect(container.textContent).toContain("Health");
+
+    const runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Run"),
+    ) as HTMLButtonElement;
+    expect(runButton).toBeTruthy();
+    act(() => {
+      runButton.click();
+    });
+    expect(onNavigateTo).toHaveBeenCalledWith("runs", {
+      executionId: resource.uniqueId,
+      resourceId: resource.uniqueId,
+    });
+
+    cleanupRoot(root, container);
+  });
+
   it("shows adapter response on the asset summary when snapshot includes it", () => {
     const resource = makeResource({
       adapterMetrics: {

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.tsx
@@ -20,6 +20,8 @@ import { AssetTestsSection } from "./AssetTestsSection";
 import { useResourceCode } from "@web/hooks/useResourceCode";
 import { AssetSummarySection } from "./AssetSummarySection";
 import { AssetSqlOrDefinitionCard } from "./AssetsViewSqlDefinitionCard";
+import { buildCrossViewNavigationTargets } from "@web/lib/analysis-workspace/crossViewNavigation";
+import { RelatedViewsActions } from "../shared";
 
 type AssetSectionId = Exclude<AssetViewState["activeTab"], "runtime">;
 
@@ -188,6 +190,10 @@ export function AssetsView({
       }));
     },
   } as const;
+  const relatedTargets = buildCrossViewNavigationTargets({
+    resourceId: resource.uniqueId,
+    executionId: executionRowForSummary?.uniqueId ?? null,
+  });
 
   return (
     <div className="workspace-view asset-workspace">
@@ -198,18 +204,43 @@ export function AssetsView({
           {detailSubtitle}
         </div>
         <div className="asset-hero__actions" aria-label="Asset actions">
-          <button
-            type="button"
-            className="workspace-pill"
-            onClick={() =>
-              onNavigateTo("timeline", {
-                resourceId: resource.uniqueId,
-                executionId: resource.uniqueId,
-              })
-            }
-          >
-            Open in Timeline
-          </button>
+          <RelatedViewsActions
+            label={`Related views for ${resource.name}`}
+            actions={[
+              ...(relatedTargets.timeline
+                ? [
+                    {
+                      label: "Timeline",
+                      onClick: () =>
+                        onNavigateTo(
+                          relatedTargets.timeline.view,
+                          relatedTargets.timeline.options,
+                        ),
+                    },
+                  ]
+                : []),
+              ...(relatedTargets.runs
+                ? [
+                    {
+                      label: "Run",
+                      onClick: () =>
+                        onNavigateTo(
+                          relatedTargets.runs.view,
+                          relatedTargets.runs.options,
+                        ),
+                    },
+                  ]
+                : []),
+              {
+                label: "Health",
+                onClick: () =>
+                  onNavigateTo(
+                    relatedTargets.health.view,
+                    relatedTargets.health.options,
+                  ),
+              },
+            ]}
+          />
         </div>
       </section>
       <div className="asset-workspace__body">

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.tsx
@@ -194,6 +194,8 @@ export function AssetsView({
     resourceId: resource.uniqueId,
     executionId: executionRowForSummary?.uniqueId ?? null,
   });
+  const timelineTarget = relatedTargets.timeline;
+  const runsTarget = relatedTargets.runs;
 
   return (
     <div className="workspace-view asset-workspace">
@@ -207,27 +209,21 @@ export function AssetsView({
           <RelatedViewsActions
             label={`Related views for ${resource.name}`}
             actions={[
-              ...(relatedTargets.timeline
+              ...(timelineTarget
                 ? [
                     {
                       label: "Timeline",
                       onClick: () =>
-                        onNavigateTo(
-                          relatedTargets.timeline.view,
-                          relatedTargets.timeline.options,
-                        ),
+                        onNavigateTo(timelineTarget.view, timelineTarget.options),
                     },
                   ]
                 : []),
-              ...(relatedTargets.runs
+              ...(runsTarget
                 ? [
                     {
                       label: "Run",
                       onClick: () =>
-                        onNavigateTo(
-                          relatedTargets.runs.view,
-                          relatedTargets.runs.options,
-                        ),
+                        onNavigateTo(runsTarget.view, runsTarget.options),
                     },
                   ]
                 : []),

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/health/HealthView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/health/HealthView.tsx
@@ -104,7 +104,10 @@ export function HealthView({
         />
         <HealthMetricRow analysis={analysis} projectName={projectName} />
         <section className="health-fold__bottlenecks" aria-label="Bottlenecks">
-          <OverviewActionListCard derived={derived} onNavigateTo={onNavigateTo} />
+          <OverviewActionListCard
+            derived={derived}
+            onNavigateTo={onNavigateTo}
+          />
         </section>
       </div>
 

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/health/HealthView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/health/HealthView.tsx
@@ -4,7 +4,9 @@ import type { AnalysisState } from "@web/types";
 import { TEST_RESOURCE_TYPES } from "@web/lib/analysis-workspace/constants";
 import type { WorkspaceArtifactSource } from "@web/services/artifactSourceApi";
 import type {
+  AssetViewState,
   OverviewFilterState,
+  WorkspaceView,
   WorkspaceSignal,
 } from "@web/lib/analysis-workspace/types";
 import { buildOverviewDerivedState } from "@web/lib/analysis-workspace/overviewState";
@@ -38,6 +40,7 @@ export function HealthView({
   filters,
   setFilters,
   workspaceSignals,
+  onNavigateTo,
 }: {
   analysis: AnalysisState;
   projectName: string | null;
@@ -45,6 +48,15 @@ export function HealthView({
   filters: OverviewFilterState;
   setFilters: Dispatch<SetStateAction<OverviewFilterState>>;
   workspaceSignals: WorkspaceSignal[];
+  onNavigateTo: (
+    view: WorkspaceView,
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: AssetViewState["activeTab"];
+      rootResourceId?: string;
+    },
+  ) => void;
 }) {
   const healthExecutionFilters = useMemo(
     () => ({
@@ -92,7 +104,7 @@ export function HealthView({
         />
         <HealthMetricRow analysis={analysis} projectName={projectName} />
         <section className="health-fold__bottlenecks" aria-label="Bottlenecks">
-          <OverviewActionListCard derived={derived} />
+          <OverviewActionListCard derived={derived} onNavigateTo={onNavigateTo} />
         </section>
       </div>
 

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/overview/OverviewCards.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/overview/OverviewCards.tsx
@@ -1,19 +1,32 @@
 import type { AnalysisState } from "@web/types";
+import type { AssetViewState, WorkspaceView } from "@web/lib/analysis-workspace/types";
 import type { OverviewDerivedState } from "@web/lib/analysis-workspace/overviewState";
 import { formatSeconds } from "@web/lib/analysis-workspace/utils";
+import { buildCrossViewNavigationTargets } from "@web/lib/analysis-workspace/crossViewNavigation";
 import { EmptyState } from "../../../EmptyState";
 import { OverviewScopeBadge } from "./OverviewPanel";
+import { RelatedViewsActions } from "../../shared";
 
 export function OverviewActionListCard({
   derived,
   title = "Bottlenecks",
   subtitle = "Longest-running nodes in the filtered execution slice.",
   embedded = false,
+  onNavigateTo,
 }: {
   derived: OverviewDerivedState;
   title?: string;
   subtitle?: string;
   embedded?: boolean;
+  onNavigateTo?: (
+    view: WorkspaceView,
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: AssetViewState["activeTab"];
+      rootResourceId?: string;
+    },
+  ) => void;
 }) {
   const topRows = derived.topBottlenecks;
 
@@ -30,21 +43,72 @@ export function OverviewActionListCard({
       {topRows.length > 0 ? (
         <div className="action-list">
           {topRows.map((row, index) => (
-            <div key={row.uniqueId} className="action-list__row">
-              <div className="action-list__body">
-                <strong>{`${index + 1}. ${row.name}`}</strong>
-                <span>
-                  {`${(
-                    (row.executionTime /
-                      Math.max(derived.filteredExecutionTime, 0.0001)) *
-                    100
-                  ).toFixed(1)}% of filtered run`}
-                </span>
-              </div>
-              <div className="action-list__metric">
-                <strong>{formatSeconds(row.executionTime)}</strong>
-              </div>
-            </div>
+            (() => {
+              const targets = buildCrossViewNavigationTargets({
+                resourceId: row.uniqueId,
+                executionId: row.uniqueId,
+              });
+              return (
+                <div key={row.uniqueId} className="action-list__row">
+                  <div className="action-list__body">
+                    <strong>{`${index + 1}. ${row.name}`}</strong>
+                    <span>
+                      {`${(
+                        (row.executionTime /
+                          Math.max(derived.filteredExecutionTime, 0.0001)) *
+                        100
+                      ).toFixed(1)}% of filtered run`}
+                    </span>
+                  </div>
+                  <div className="action-list__metric">
+                    <strong>{formatSeconds(row.executionTime)}</strong>
+                  </div>
+                  {onNavigateTo ? (
+                    <RelatedViewsActions
+                      label={`Related views for ${row.name}`}
+                      actions={[
+                        ...(targets.inventory
+                          ? [
+                              {
+                                label: "Inventory",
+                                onClick: () =>
+                                  onNavigateTo(
+                                    targets.inventory.view,
+                                    targets.inventory.options,
+                                  ),
+                              },
+                            ]
+                          : []),
+                        ...(targets.timeline
+                          ? [
+                              {
+                                label: "Timeline",
+                                onClick: () =>
+                                  onNavigateTo(
+                                    targets.timeline.view,
+                                    targets.timeline.options,
+                                  ),
+                              },
+                            ]
+                          : []),
+                        ...(targets.runs
+                          ? [
+                              {
+                                label: "Run",
+                                onClick: () =>
+                                  onNavigateTo(
+                                    targets.runs.view,
+                                    targets.runs.options,
+                                  ),
+                              },
+                            ]
+                          : []),
+                      ]}
+                    />
+                  ) : null}
+                </div>
+              );
+            })()
           ))}
         </div>
       ) : (

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/overview/OverviewCards.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/overview/OverviewCards.tsx
@@ -1,5 +1,8 @@
 import type { AnalysisState } from "@web/types";
-import type { AssetViewState, WorkspaceView } from "@web/lib/analysis-workspace/types";
+import type {
+  AssetViewState,
+  WorkspaceView,
+} from "@web/lib/analysis-workspace/types";
 import type { OverviewDerivedState } from "@web/lib/analysis-workspace/overviewState";
 import { formatSeconds } from "@web/lib/analysis-workspace/utils";
 import { buildCrossViewNavigationTargets } from "@web/lib/analysis-workspace/crossViewNavigation";
@@ -42,12 +45,15 @@ export function OverviewActionListCard({
       )}
       {topRows.length > 0 ? (
         <div className="action-list">
-          {topRows.map((row, index) => (
+          {topRows.map((row, index) =>
             (() => {
               const targets = buildCrossViewNavigationTargets({
                 resourceId: row.uniqueId,
                 executionId: row.uniqueId,
               });
+              const inventoryTarget = targets.inventory;
+              const timelineTarget = targets.timeline;
+              const runsTarget = targets.runs;
               return (
                 <div key={row.uniqueId} className="action-list__row">
                   <div className="action-list__body">
@@ -67,38 +73,38 @@ export function OverviewActionListCard({
                     <RelatedViewsActions
                       label={`Related views for ${row.name}`}
                       actions={[
-                        ...(targets.inventory
+                        ...(inventoryTarget
                           ? [
                               {
                                 label: "Inventory",
                                 onClick: () =>
                                   onNavigateTo(
-                                    targets.inventory.view,
-                                    targets.inventory.options,
+                                    inventoryTarget.view,
+                                    inventoryTarget.options,
                                   ),
                               },
                             ]
                           : []),
-                        ...(targets.timeline
+                        ...(timelineTarget
                           ? [
                               {
                                 label: "Timeline",
                                 onClick: () =>
                                   onNavigateTo(
-                                    targets.timeline.view,
-                                    targets.timeline.options,
+                                    timelineTarget.view,
+                                    timelineTarget.options,
                                   ),
                               },
                             ]
                           : []),
-                        ...(targets.runs
+                        ...(runsTarget
                           ? [
                               {
                                 label: "Run",
                                 onClick: () =>
                                   onNavigateTo(
-                                    targets.runs.view,
-                                    targets.runs.options,
+                                    runsTarget.view,
+                                    runsTarget.options,
                                   ),
                               },
                             ]
@@ -108,8 +114,8 @@ export function OverviewActionListCard({
                   ) : null}
                 </div>
               );
-            })()
-          ))}
+            })(),
+          )}
         </div>
       ) : (
         <EmptyState

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.test.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.test.tsx
@@ -304,6 +304,7 @@ describe("RunsView", () => {
     expect(container.textContent).toContain("Open in Timeline");
     expect(container.textContent).toContain("Open in Inventory");
     expect(container.textContent).toContain("Open in Lineage");
+    expect(container.textContent).toContain("Open in Health");
   });
 
   it("wires the Open in Lineage action to inventory lineage navigation", () => {

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.tsx
@@ -1,8 +1,10 @@
 import { type Dispatch, type SetStateAction, useEffect, useMemo } from "react";
 import type { AnalysisState } from "@web/types";
 import type {
+  AssetViewState,
   InvestigationSelectionState,
   RunsViewState,
+  WorkspaceView,
 } from "@web/lib/analysis-workspace/types";
 import { useRunsResultsSource } from "@web/hooks/useRunsResultsSource";
 import {
@@ -29,11 +31,11 @@ export function RunsView({
     SetStateAction<InvestigationSelectionState>
   >;
   onNavigateTo: (
-    view: "inventory" | "timeline",
+    view: WorkspaceView,
     options?: {
       resourceId?: string;
       executionId?: string;
-      assetTab?: "summary" | "lineage";
+      assetTab?: AssetViewState["activeTab"];
       rootResourceId?: string;
     },
   ) => void;

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsViewAdapterInspector.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsViewAdapterInspector.tsx
@@ -1,4 +1,8 @@
 import type { ExecutionRow } from "@web/types";
+import type {
+  AssetViewState,
+  WorkspaceView,
+} from "@web/lib/analysis-workspace/types";
 import { getAdapterResponseFieldsBeyondNormalized } from "@dbt-tools/core/browser";
 import {
   getRunsAdapterField,
@@ -32,11 +36,11 @@ export function RunsAdapterInspector({
   visibleColumns: RunsAdapterColumn[];
   overflowColumns: RunsAdapterColumn[];
   onNavigateTo: (
-    view: "inventory" | "timeline",
+    view: WorkspaceView,
     options?: {
       resourceId?: string;
       executionId?: string;
-      assetTab?: "summary" | "lineage";
+      assetTab?: AssetViewState["activeTab"];
       rootResourceId?: string;
     },
   ) => void;
@@ -100,6 +104,9 @@ export function RunsAdapterInspector({
     resourceId: row.uniqueId,
     executionId: row.uniqueId,
   });
+  const timelineTarget = relatedTargets.timeline;
+  const inventoryTarget = relatedTargets.inventory;
+  const lineageTarget = relatedTargets.lineage;
 
   return (
     <EntityInspector
@@ -121,46 +128,40 @@ export function RunsAdapterInspector({
       ]}
       sections={sections}
       actions={[
-        ...(relatedTargets.timeline
+        ...(timelineTarget
           ? [
               {
                 label: "Open in Timeline",
                 onClick: () =>
-                  onNavigateTo(
-                    relatedTargets.timeline.view,
-                    relatedTargets.timeline.options,
-                  ),
+                  onNavigateTo(timelineTarget.view, timelineTarget.options),
               },
             ]
           : []),
-        ...(relatedTargets.inventory
+        ...(inventoryTarget
           ? [
               {
                 label: "Open in Inventory",
                 onClick: () =>
-                  onNavigateTo(
-                    relatedTargets.inventory.view,
-                    relatedTargets.inventory.options,
-                  ),
+                  onNavigateTo(inventoryTarget.view, inventoryTarget.options),
               },
             ]
           : []),
-        ...(relatedTargets.lineage
+        ...(lineageTarget
           ? [
               {
                 label: "Open in Lineage",
                 onClick: () =>
-                  onNavigateTo(
-                    relatedTargets.lineage.view,
-                    relatedTargets.lineage.options,
-                  ),
+                  onNavigateTo(lineageTarget.view, lineageTarget.options),
               },
             ]
           : []),
         {
           label: "Open in Health",
           onClick: () =>
-            onNavigateTo(relatedTargets.health.view, relatedTargets.health.options),
+            onNavigateTo(
+              relatedTargets.health.view,
+              relatedTargets.health.options,
+            ),
         },
       ]}
     />

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsViewAdapterInspector.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsViewAdapterInspector.tsx
@@ -6,6 +6,7 @@ import {
 } from "@web/lib/analysis-workspace/runsAdapterColumns";
 import { EntityInspector, formatResourceTypeLabel } from "../../shared";
 import { formatSeconds } from "@web/lib/analysis-workspace/utils";
+import { buildCrossViewNavigationTargets } from "@web/lib/analysis-workspace/crossViewNavigation";
 
 function formatInspectorFields(
   row: ExecutionRow,
@@ -95,6 +96,10 @@ export function RunsAdapterInspector({
           ]
         : [];
   const sections = [...normalizedSections, ...rawFieldSection];
+  const relatedTargets = buildCrossViewNavigationTargets({
+    resourceId: row.uniqueId,
+    executionId: row.uniqueId,
+  });
 
   return (
     <EntityInspector
@@ -116,30 +121,46 @@ export function RunsAdapterInspector({
       ]}
       sections={sections}
       actions={[
+        ...(relatedTargets.timeline
+          ? [
+              {
+                label: "Open in Timeline",
+                onClick: () =>
+                  onNavigateTo(
+                    relatedTargets.timeline.view,
+                    relatedTargets.timeline.options,
+                  ),
+              },
+            ]
+          : []),
+        ...(relatedTargets.inventory
+          ? [
+              {
+                label: "Open in Inventory",
+                onClick: () =>
+                  onNavigateTo(
+                    relatedTargets.inventory.view,
+                    relatedTargets.inventory.options,
+                  ),
+              },
+            ]
+          : []),
+        ...(relatedTargets.lineage
+          ? [
+              {
+                label: "Open in Lineage",
+                onClick: () =>
+                  onNavigateTo(
+                    relatedTargets.lineage.view,
+                    relatedTargets.lineage.options,
+                  ),
+              },
+            ]
+          : []),
         {
-          label: "Open in Timeline",
+          label: "Open in Health",
           onClick: () =>
-            onNavigateTo("timeline", {
-              resourceId: row.uniqueId,
-              executionId: row.uniqueId,
-            }),
-        },
-        {
-          label: "Open in Inventory",
-          onClick: () =>
-            onNavigateTo("inventory", {
-              resourceId: row.uniqueId,
-              assetTab: "summary",
-            }),
-        },
-        {
-          label: "Open in Lineage",
-          onClick: () =>
-            onNavigateTo("inventory", {
-              resourceId: row.uniqueId,
-              assetTab: "lineage",
-              rootResourceId: row.uniqueId,
-            }),
+            onNavigateTo(relatedTargets.health.view, relatedTargets.health.options),
         },
       ]}
     />

--- a/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.test.ts
+++ b/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildCrossViewNavigationTargets } from "./crossViewNavigation";
+
+describe("buildCrossViewNavigationTargets", () => {
+  it("builds all pivots when both resource and execution ids exist", () => {
+    const targets = buildCrossViewNavigationTargets({
+      resourceId: "model.pkg.orders",
+      executionId: "model.pkg.orders",
+    });
+    expect(targets.inventory?.view).toBe("inventory");
+    expect(targets.inventory?.options?.assetTab).toBe("summary");
+    expect(targets.lineage?.options?.assetTab).toBe("lineage");
+    expect(targets.timeline?.view).toBe("timeline");
+    expect(targets.runs?.view).toBe("runs");
+    expect(targets.health.view).toBe("health");
+  });
+
+  it("omits unavailable pivots when ids are missing", () => {
+    const targets = buildCrossViewNavigationTargets({});
+    expect(targets.inventory).toBeNull();
+    expect(targets.lineage).toBeNull();
+    expect(targets.runs).toBeNull();
+    expect(targets.timeline).toBeNull();
+    expect(targets.health.view).toBe("health");
+  });
+});

--- a/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.ts
+++ b/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.ts
@@ -1,0 +1,84 @@
+import type {
+  AssetTab,
+  WorkspaceView,
+} from "@web/lib/analysis-workspace/types";
+
+export interface NavigationTarget {
+  view: WorkspaceView;
+  options?: {
+    resourceId?: string;
+    executionId?: string;
+    assetTab?: AssetTab;
+    rootResourceId?: string;
+  };
+}
+
+export interface CrossViewNavigationContext {
+  resourceId?: string | null;
+  executionId?: string | null;
+}
+
+export interface CrossViewNavigationTargets {
+  inventory: NavigationTarget | null;
+  lineage: NavigationTarget | null;
+  runs: NavigationTarget | null;
+  timeline: NavigationTarget | null;
+  health: NavigationTarget;
+}
+
+export function buildCrossViewNavigationTargets(
+  context: CrossViewNavigationContext,
+): CrossViewNavigationTargets {
+  const resourceId = context.resourceId ?? null;
+  const executionId = context.executionId ?? null;
+  const timelineExecutionId = executionId ?? resourceId;
+  return {
+    inventory: resourceId
+      ? {
+          view: "inventory",
+          options: {
+            resourceId,
+            assetTab: "summary",
+          },
+        }
+      : null,
+    lineage: resourceId
+      ? {
+          view: "inventory",
+          options: {
+            resourceId,
+            assetTab: "lineage",
+            rootResourceId: resourceId,
+          },
+        }
+      : null,
+    runs: executionId
+      ? {
+          view: "runs",
+          options: {
+            executionId,
+            resourceId: resourceId ?? executionId,
+          },
+        }
+      : null,
+    timeline: timelineExecutionId
+      ? {
+          view: "timeline",
+          options: {
+            executionId: timelineExecutionId,
+            resourceId: resourceId ?? timelineExecutionId,
+          },
+        }
+      : null,
+    health: {
+      view: "health",
+      options:
+        resourceId || executionId
+          ? {
+              resourceId: resourceId ?? undefined,
+              executionId: executionId ?? undefined,
+            }
+          : undefined,
+    },
+  };
+}

--- a/packages/dbt-tools/web/src/styles/workspace.css
+++ b/packages/dbt-tools/web/src/styles/workspace.css
@@ -274,8 +274,9 @@
 
 .action-list__row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 0.75rem;
   padding: 0.6rem 0.8rem;
   border-radius: calc(var(--radius-sm) - 4px);
@@ -314,6 +315,36 @@
   font-size: 0.88rem;
   font-weight: 700;
   color: var(--accent-primary);
+}
+
+.related-views-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.related-views-actions__label {
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+}
+
+.timeline-selection-context {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+}
+
+.timeline-selection-context__label {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
 }
 
 /* Critical path card */


### PR DESCRIPTION
### Motivation
- Views (Health, Timeline, Inventory, Runs) exposed related objects but lacked a consistent, context-preserving pivot model, making cross-view investigation fragile.  
- Provide a single, reusable contract so any lens can pivot to Inventory / Lineage / Runs / Timeline / Health while preserving selected resource/run context and URL-backed state.  

### Description
- Add a centralized navigation helper `buildCrossViewNavigationTargets` to map a small investigation context (`resourceId`, `executionId`) into consistent targets for `inventory`, `lineage`, `runs`, `timeline`, and `health` (`packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.ts`).  
- Introduce `RelatedViewsActions` (a compact action cluster) and reuse existing quick-jump styling to present related-view pivots in a consistent, unobtrusive way (`shared.tsx`, CSS).  
- Wire the helper + UI into the four lenses: Timeline (selected-item context bar with Inventory/Run/Health pivots), Health (bottleneck rows expose related pivots), Inventory (asset hero shows Timeline/Run/Health pivots), and Runs (inspector actions use shared targets and include Health pivot).  
- Thread the existing `onNavigateTo` contract through workspace entry points so all pivots use the same URL/state machinery (no ad-hoc route construction).  
- Add small CSS adjustments to place the related-actions cluster without disrupting the dense operational layout.  
- Tests: add unit tests for the helper and update component tests; add a Playwright E2E spec to cover timeline-selected-item pivots.  

### Testing
- Ran targeted unit tests: `pnpm test packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.test.ts packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.test.tsx packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.test.tsx packages/dbt-tools/web/src/components/AppShell/workspaceUrlSync.test.ts` — all tests passed.  
- Ran ESLint checks on changed TS/TSX and e2e spec files — passed for the updated TS/TSX/e2e files in this environment.  
- Attempted full web build: `pnpm --filter @dbt-tools/web build` — failed in this sandbox due to unresolved external module paths required by `@dbt-tools/core` (local dependency `dbt-artifacts-parser/*` not available in the environment), so full production build was not completed here.  
- Stylelint (`pnpm --filter @dbt-tools/web lint:stylelint`) failed in this environment due to missing stylelint plugin resolution (`stylelint-declaration-strict-value`) in the sandbox; this is an environmental tooling issue, not a code regression.  

If helpful I can follow up with a small PR to further surface additional context (time range / status / search) into URL params, or run the full E2E suite once the monorepo build environment (parser/core artifacts and stylelint plugin) is available in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96c2a8950832c83779ac7748c477c)