### PR TITLE
feat(web): shared cross-view pivots for Timeline / Inventory / Health / Runs

### DIFF
--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/AnalysisWorkspace.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/AnalysisWorkspace.tsx
@@ -56,6 +56,7 @@ export function AnalysisWorkspace({
             filters={overviewFilters}
             setFilters={onOverviewFiltersChange}
             workspaceSignals={workspaceSignals}
+            onNavigateTo={onNavigateTo}
           />
         )}
         {activeView === "inventory" && (
@@ -94,6 +95,7 @@ export function AnalysisWorkspace({
             filters={timelineFilters}
             setFilters={onTimelineFiltersChange}
             onInvestigationSelectionChange={onInvestigationSelectionChange}
+            onNavigateTo={onNavigateTo}
           />
         )}
       </div>

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/shared.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/shared.tsx
@@ -175,6 +175,37 @@ export function WorkspaceScaffold({
   );
 }
 
+export function RelatedViewPivots({
+  actions,
+  label = "Related views",
+}: {
+  actions: {
+    key: string;
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+  }[];
+  label?: string;
+}) {
+  return (
+    <div className="related-view-pivots" role="group" aria-label={label}>
+      <span className="related-view-pivots__label">{label}</span>
+      <div className="entity-inspector__actions">
+        {actions.map((action) => (
+          <button
+            key={action.key}
+            type="button"
+            className="workspace-pill"
+            onClick={action.onClick}
+            disabled={action.disabled}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
 export function QuickJumpActions({
   actions,
 }: {

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
@@ -27,7 +27,13 @@ import {
   timelineGanttHasCompileExecutePhases,
 } from "@web/lib/analysis-workspace/utils";
 import { buildResourceTestStats } from "@web/lib/analysis-workspace/explorerTree";
-import { SectionCard, WorkspaceScaffold } from "../shared";
+import { buildCrossViewPivotActions } from "@web/lib/analysis-workspace/crossViewNavigation";
+import {
+  EntityInspector,
+  RelatedViewPivots,
+  SectionCard,
+  WorkspaceScaffold,
+} from "../shared";
 import {
   TimelineSearchControls,
   type TimelineTypeFilterHint,
@@ -251,6 +257,7 @@ export function TimelineView({
   filters,
   setFilters,
   onInvestigationSelectionChange,
+  onNavigateTo,
 }: {
   analysis: AnalysisState;
   filters: TimelineFilterState;
@@ -258,6 +265,15 @@ export function TimelineView({
   onInvestigationSelectionChange: Dispatch<
     SetStateAction<InvestigationSelectionState>
   >;
+  onNavigateTo: (
+    view: "health" | "inventory" | "runs" | "timeline",
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: "summary" | "lineage" | "sql" | "runtime" | "tests";
+      rootResourceId?: string;
+    },
+  ) => void;
 }) {
   const deferredQuery = useDeferredValue(filters.query);
   const projectName =
@@ -461,13 +477,69 @@ export function TimelineView({
     filters.activeStatuses.size > 0 ||
     hasTypeOverride ||
     filters.query.length > 0;
+  const selectedTimelineItem =
+    filters.selectedExecutionId == null
+      ? null
+      : (analysis.ganttData.find(
+          (item) => item.unique_id === filters.selectedExecutionId,
+        ) ?? null);
 
   return (
     <WorkspaceScaffold
       title="Timeline"
       description="Runtime timing, concurrency, bottlenecks, and execution order."
       className="timeline-view"
+      inspector={
+        selectedTimelineItem ? (
+          <EntityInspector
+            eyebrow="Selected timeline item"
+            title={selectedTimelineItem.name}
+            typeLabel={selectedTimelineItem.resourceType ?? null}
+            stats={[
+              { label: "Status", value: selectedTimelineItem.status },
+              {
+                label: "Duration",
+                value: formatMs(selectedTimelineItem.duration),
+              },
+              {
+                label: "Selected id",
+                value: selectedTimelineItem.unique_id,
+              },
+            ]}
+            sections={[
+              {
+                label: "Context",
+                value:
+                  "Timeline focus is preserved while you pivot to other lenses.",
+              },
+            ]}
+            actions={[
+              {
+                label: "Focus in Timeline",
+                onClick: () =>
+                  setFilters((current) => ({
+                    ...current,
+                    query: selectedTimelineItem.name,
+                    selectedExecutionId: selectedTimelineItem.unique_id,
+                  })),
+              },
+            ]}
+          />
+        ) : null
+      }
     >
+      {selectedTimelineItem ? (
+        <RelatedViewPivots
+          label={`Related views for ${selectedTimelineItem.name}`}
+          actions={buildCrossViewPivotActions({
+            context: {
+              resourceId: selectedTimelineItem.unique_id,
+              executionId: selectedTimelineItem.unique_id,
+            },
+            onNavigateTo,
+          })}
+        />
+      ) : null}
       <TimelineSurface
         analysis={analysis}
         filters={filters}

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx
@@ -101,6 +101,73 @@ function parentHasFailureSignal(
   return !isPositiveStatus(item.status) || hasTestFail;
 }
 
+function TimelineSelectionInspector({
+  selectedTimelineItem,
+  setFilters,
+  onNavigateTo,
+}: {
+  selectedTimelineItem: GanttItem;
+  setFilters: Dispatch<SetStateAction<TimelineFilterState>>;
+  onNavigateTo: (
+    view: "health" | "inventory" | "runs" | "timeline",
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: "summary" | "lineage" | "sql" | "runtime" | "tests";
+      rootResourceId?: string;
+    },
+  ) => void;
+}) {
+  return (
+    <>
+      <RelatedViewPivots
+        label={`Related views for ${selectedTimelineItem.name}`}
+        actions={buildCrossViewPivotActions({
+          context: {
+            resourceId: selectedTimelineItem.unique_id,
+            executionId: selectedTimelineItem.unique_id,
+          },
+          onNavigateTo,
+        })}
+      />
+      <EntityInspector
+        eyebrow="Selected timeline item"
+        title={selectedTimelineItem.name}
+        typeLabel={selectedTimelineItem.resourceType ?? null}
+        stats={[
+          { label: "Status", value: selectedTimelineItem.status },
+          {
+            label: "Duration",
+            value: formatMs(selectedTimelineItem.duration),
+          },
+          {
+            label: "Selected id",
+            value: selectedTimelineItem.unique_id,
+          },
+        ]}
+        sections={[
+          {
+            label: "Context",
+            value:
+              "Timeline focus is preserved while you pivot to other lenses.",
+          },
+        ]}
+        actions={[
+          {
+            label: "Focus in Timeline",
+            onClick: () =>
+              setFilters((current) => ({
+                ...current,
+                query: selectedTimelineItem.name,
+                selectedExecutionId: selectedTimelineItem.unique_id,
+              })),
+          },
+        ]}
+      />
+    </>
+  );
+}
+
 function TimelineSurface({
   analysis,
   filters,
@@ -491,55 +558,14 @@ export function TimelineView({
       className="timeline-view"
       inspector={
         selectedTimelineItem ? (
-          <EntityInspector
-            eyebrow="Selected timeline item"
-            title={selectedTimelineItem.name}
-            typeLabel={selectedTimelineItem.resourceType ?? null}
-            stats={[
-              { label: "Status", value: selectedTimelineItem.status },
-              {
-                label: "Duration",
-                value: formatMs(selectedTimelineItem.duration),
-              },
-              {
-                label: "Selected id",
-                value: selectedTimelineItem.unique_id,
-              },
-            ]}
-            sections={[
-              {
-                label: "Context",
-                value:
-                  "Timeline focus is preserved while you pivot to other lenses.",
-              },
-            ]}
-            actions={[
-              {
-                label: "Focus in Timeline",
-                onClick: () =>
-                  setFilters((current) => ({
-                    ...current,
-                    query: selectedTimelineItem.name,
-                    selectedExecutionId: selectedTimelineItem.unique_id,
-                  })),
-              },
-            ]}
+          <TimelineSelectionInspector
+            selectedTimelineItem={selectedTimelineItem}
+            setFilters={setFilters}
+            onNavigateTo={onNavigateTo}
           />
         ) : null
       }
     >
-      {selectedTimelineItem ? (
-        <RelatedViewPivots
-          label={`Related views for ${selectedTimelineItem.name}`}
-          actions={buildCrossViewPivotActions({
-            context: {
-              resourceId: selectedTimelineItem.unique_id,
-              executionId: selectedTimelineItem.unique_id,
-            },
-            onNavigateTo,
-          })}
-        />
-      ) : null}
       <TimelineSurface
         analysis={analysis}
         filters={filters}

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/AssetsView.tsx
@@ -13,7 +13,8 @@ import type {
   LineageViewState,
   WorkspaceView,
 } from "@web/lib/analysis-workspace/types";
-import { ResourceTypeBadge } from "../shared";
+import { buildCrossViewPivotActions } from "@web/lib/analysis-workspace/crossViewNavigation";
+import { RelatedViewPivots, ResourceTypeBadge } from "../shared";
 import { MaterializationSemanticsBadge } from "../MaterializationSemanticsBadge";
 import { LineagePanel } from "../lineage/LineagePanel";
 import { AssetTestsSection } from "./AssetTestsSection";
@@ -198,18 +199,19 @@ export function AssetsView({
           {detailSubtitle}
         </div>
         <div className="asset-hero__actions" aria-label="Asset actions">
-          <button
-            type="button"
-            className="workspace-pill"
-            onClick={() =>
-              onNavigateTo("timeline", {
+          <RelatedViewPivots
+            label={`Related views for ${resource.name}`}
+            actions={buildCrossViewPivotActions({
+              context: {
                 resourceId: resource.uniqueId,
-                executionId: resource.uniqueId,
-              })
-            }
-          >
-            Open in Timeline
-          </button>
+                executionId: executionRowForSummary?.uniqueId ?? null,
+              },
+              onNavigateTo,
+            }).map((action) => ({
+              ...action,
+              label: `Open in ${action.label}`,
+            }))}
+          />
         </div>
       </section>
       <div className="asset-workspace__body">

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/health/HealthView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/health/HealthView.tsx
@@ -4,7 +4,9 @@ import type { AnalysisState } from "@web/types";
 import { TEST_RESOURCE_TYPES } from "@web/lib/analysis-workspace/constants";
 import type { WorkspaceArtifactSource } from "@web/services/artifactSourceApi";
 import type {
+  AssetViewState,
   OverviewFilterState,
+  WorkspaceView,
   WorkspaceSignal,
 } from "@web/lib/analysis-workspace/types";
 import { buildOverviewDerivedState } from "@web/lib/analysis-workspace/overviewState";
@@ -38,6 +40,7 @@ export function HealthView({
   filters,
   setFilters,
   workspaceSignals,
+  onNavigateTo,
 }: {
   analysis: AnalysisState;
   projectName: string | null;
@@ -45,6 +48,15 @@ export function HealthView({
   filters: OverviewFilterState;
   setFilters: Dispatch<SetStateAction<OverviewFilterState>>;
   workspaceSignals: WorkspaceSignal[];
+  onNavigateTo: (
+    view: WorkspaceView,
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: AssetViewState["activeTab"];
+      rootResourceId?: string;
+    },
+  ) => void;
 }) {
   const healthExecutionFilters = useMemo(
     () => ({
@@ -92,7 +104,10 @@ export function HealthView({
         />
         <HealthMetricRow analysis={analysis} projectName={projectName} />
         <section className="health-fold__bottlenecks" aria-label="Bottlenecks">
-          <OverviewActionListCard derived={derived} />
+          <OverviewActionListCard
+            derived={derived}
+            onNavigateTo={onNavigateTo}
+          />
         </section>
       </div>
 

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/overview/OverviewCards.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/overview/OverviewCards.tsx
@@ -1,7 +1,9 @@
 import type { AnalysisState } from "@web/types";
 import type { OverviewDerivedState } from "@web/lib/analysis-workspace/overviewState";
 import { formatSeconds } from "@web/lib/analysis-workspace/utils";
+import { buildCrossViewPivotActions } from "@web/lib/analysis-workspace/crossViewNavigation";
 import { EmptyState } from "../../../EmptyState";
+import { RelatedViewPivots } from "../../shared";
 import { OverviewScopeBadge } from "./OverviewPanel";
 
 export function OverviewActionListCard({
@@ -9,11 +11,21 @@ export function OverviewActionListCard({
   title = "Bottlenecks",
   subtitle = "Longest-running nodes in the filtered execution slice.",
   embedded = false,
+  onNavigateTo,
 }: {
   derived: OverviewDerivedState;
   title?: string;
   subtitle?: string;
   embedded?: boolean;
+  onNavigateTo?: (
+    view: "health" | "inventory" | "runs" | "timeline",
+    options?: {
+      resourceId?: string;
+      executionId?: string;
+      assetTab?: "summary" | "lineage" | "sql" | "runtime" | "tests";
+      rootResourceId?: string;
+    },
+  ) => void;
 }) {
   const topRows = derived.topBottlenecks;
 
@@ -44,6 +56,18 @@ export function OverviewActionListCard({
               <div className="action-list__metric">
                 <strong>{formatSeconds(row.executionTime)}</strong>
               </div>
+              {onNavigateTo ? (
+                <RelatedViewPivots
+                  label={`Related views for ${row.name}`}
+                  actions={buildCrossViewPivotActions({
+                    context: {
+                      resourceId: row.uniqueId,
+                      executionId: row.uniqueId,
+                    },
+                    onNavigateTo,
+                  })}
+                />
+              ) : null}
             </div>
           ))}
         </div>

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.test.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.test.tsx
@@ -303,10 +303,11 @@ describe("RunsView", () => {
     expect(container.textContent).toContain("Selected run item");
     expect(container.textContent).toContain("Open in Timeline");
     expect(container.textContent).toContain("Open in Inventory");
-    expect(container.textContent).toContain("Open in Lineage");
+    expect(container.textContent).toContain("Open in Run");
+    expect(container.textContent).toContain("Open in Health");
   });
 
-  it("wires the Open in Lineage action to inventory lineage navigation", () => {
+  it("wires the Open in Run action to runs navigation", () => {
     const row = makeRow({
       uniqueId: "model.pkg.orders",
       name: "orders",
@@ -329,21 +330,20 @@ describe("RunsView", () => {
       );
     });
 
-    const lineageButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "Open in Lineage",
+    const runButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Open in Run",
     );
-    expect(lineageButton).toBeTruthy();
+    expect(runButton).toBeTruthy();
 
     act(() => {
-      lineageButton?.dispatchEvent(
+      runButton?.dispatchEvent(
         new MouseEvent("click", { bubbles: true, cancelable: true }),
       );
     });
 
-    expect(onNavigateTo).toHaveBeenCalledWith("inventory", {
+    expect(onNavigateTo).toHaveBeenCalledWith("runs", {
+      executionId: row.uniqueId,
       resourceId: row.uniqueId,
-      assetTab: "lineage",
-      rootResourceId: row.uniqueId,
     });
   });
 });

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.tsx
@@ -29,11 +29,11 @@ export function RunsView({
     SetStateAction<InvestigationSelectionState>
   >;
   onNavigateTo: (
-    view: "inventory" | "timeline",
+    view: "health" | "inventory" | "runs" | "timeline",
     options?: {
       resourceId?: string;
       executionId?: string;
-      assetTab?: "summary" | "lineage";
+      assetTab?: "summary" | "lineage" | "sql" | "runtime" | "tests";
       rootResourceId?: string;
     },
   ) => void;

--- a/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsViewAdapterInspector.tsx
+++ b/packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsViewAdapterInspector.tsx
@@ -4,6 +4,7 @@ import {
   getRunsAdapterField,
   type RunsAdapterColumn,
 } from "@web/lib/analysis-workspace/runsAdapterColumns";
+import { buildCrossViewPivotActions } from "@web/lib/analysis-workspace/crossViewNavigation";
 import { EntityInspector, formatResourceTypeLabel } from "../../shared";
 import { formatSeconds } from "@web/lib/analysis-workspace/utils";
 
@@ -31,11 +32,11 @@ export function RunsAdapterInspector({
   visibleColumns: RunsAdapterColumn[];
   overflowColumns: RunsAdapterColumn[];
   onNavigateTo: (
-    view: "inventory" | "timeline",
+    view: "health" | "inventory" | "runs" | "timeline",
     options?: {
       resourceId?: string;
       executionId?: string;
-      assetTab?: "summary" | "lineage";
+      assetTab?: "summary" | "lineage" | "sql" | "runtime" | "tests";
       rootResourceId?: string;
     },
   ) => void;
@@ -115,33 +116,14 @@ export function RunsAdapterInspector({
         },
       ]}
       sections={sections}
-      actions={[
-        {
-          label: "Open in Timeline",
-          onClick: () =>
-            onNavigateTo("timeline", {
-              resourceId: row.uniqueId,
-              executionId: row.uniqueId,
-            }),
-        },
-        {
-          label: "Open in Inventory",
-          onClick: () =>
-            onNavigateTo("inventory", {
-              resourceId: row.uniqueId,
-              assetTab: "summary",
-            }),
-        },
-        {
-          label: "Open in Lineage",
-          onClick: () =>
-            onNavigateTo("inventory", {
-              resourceId: row.uniqueId,
-              assetTab: "lineage",
-              rootResourceId: row.uniqueId,
-            }),
-        },
-      ]}
+      actions={buildCrossViewPivotActions({
+        context: { resourceId: row.uniqueId, executionId: row.uniqueId },
+        onNavigateTo,
+      }).map((action) => ({
+        label: `Open in ${action.label}`,
+        onClick: action.onClick,
+        disabled: action.disabled,
+      }))}
     />
   );
 }

--- a/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.test.ts
+++ b/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildCrossViewPivotActions } from "./crossViewNavigation";
+
+describe("buildCrossViewPivotActions", () => {
+  it("builds enabled actions when resource and execution are available", () => {
+    const onNavigateTo = vi.fn();
+    const actions = buildCrossViewPivotActions({
+      context: {
+        resourceId: "model.jaffle_shop.orders",
+        executionId: "model.jaffle_shop.orders",
+      },
+      onNavigateTo,
+    });
+
+    expect(actions.map((action) => action.key)).toEqual([
+      "inventory",
+      "timeline",
+      "runs",
+      "health",
+    ]);
+    expect(actions.some((action) => action.disabled)).toBe(false);
+
+    actions[0]?.onClick();
+    actions[1]?.onClick();
+    actions[2]?.onClick();
+    actions[3]?.onClick();
+
+    expect(onNavigateTo).toHaveBeenNthCalledWith(1, "inventory", {
+      resourceId: "model.jaffle_shop.orders",
+      assetTab: "summary",
+      rootResourceId: "model.jaffle_shop.orders",
+    });
+    expect(onNavigateTo).toHaveBeenNthCalledWith(2, "timeline", {
+      resourceId: "model.jaffle_shop.orders",
+      executionId: "model.jaffle_shop.orders",
+    });
+    expect(onNavigateTo).toHaveBeenNthCalledWith(3, "runs", {
+      executionId: "model.jaffle_shop.orders",
+      resourceId: "model.jaffle_shop.orders",
+    });
+    expect(onNavigateTo).toHaveBeenNthCalledWith(4, "health");
+  });
+
+  it("disables unavailable pivots when context is partial", () => {
+    const onNavigateTo = vi.fn();
+    const actions = buildCrossViewPivotActions({
+      context: {
+        resourceId: "source.jaffle_shop.raw_customers",
+        executionId: null,
+      },
+      onNavigateTo,
+      includeHealth: false,
+      includeInventoryTab: "lineage",
+    });
+
+    expect(actions.map((action) => [action.key, action.disabled])).toEqual([
+      ["inventory", false],
+      ["timeline", false],
+      ["runs", true],
+    ]);
+
+    actions[0]?.onClick();
+    actions[1]?.onClick();
+    actions[2]?.onClick();
+
+    expect(onNavigateTo).toHaveBeenNthCalledWith(1, "inventory", {
+      resourceId: "source.jaffle_shop.raw_customers",
+      assetTab: "lineage",
+      rootResourceId: "source.jaffle_shop.raw_customers",
+    });
+    expect(onNavigateTo).toHaveBeenNthCalledWith(2, "timeline", {
+      resourceId: "source.jaffle_shop.raw_customers",
+    });
+    expect(onNavigateTo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.ts
+++ b/packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.ts
@@ -1,0 +1,90 @@
+import type { AssetTab } from "@web/lib/analysis-workspace/types";
+
+export interface CrossViewContext {
+  resourceId?: string | null;
+  executionId?: string | null;
+}
+
+export interface CrossViewPivotAction {
+  key: string;
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export type CrossViewTargetView = "health" | "inventory" | "runs" | "timeline";
+
+export type CrossViewNavigate = (
+  view: CrossViewTargetView,
+  options?: {
+    resourceId?: string;
+    executionId?: string;
+    assetTab?: AssetTab;
+    rootResourceId?: string;
+  },
+) => void;
+
+export function buildCrossViewPivotActions({
+  context,
+  onNavigateTo,
+  includeInventoryTab = "summary",
+  includeHealth = true,
+}: {
+  context: CrossViewContext;
+  onNavigateTo: CrossViewNavigate;
+  includeInventoryTab?: AssetTab;
+  includeHealth?: boolean;
+}): CrossViewPivotAction[] {
+  const resourceId = context.resourceId ?? null;
+  const executionId = context.executionId ?? null;
+
+  const actions: CrossViewPivotAction[] = [
+    {
+      key: "inventory",
+      label: "Inventory",
+      disabled: !resourceId,
+      onClick: () => {
+        if (!resourceId) return;
+        onNavigateTo("inventory", {
+          resourceId,
+          assetTab: includeInventoryTab,
+          rootResourceId: resourceId,
+        });
+      },
+    },
+    {
+      key: "timeline",
+      label: "Timeline",
+      disabled: !resourceId && !executionId,
+      onClick: () => {
+        if (!resourceId && !executionId) return;
+        onNavigateTo("timeline", {
+          ...(resourceId ? { resourceId } : {}),
+          ...(executionId ? { executionId } : {}),
+        });
+      },
+    },
+    {
+      key: "runs",
+      label: "Run",
+      disabled: !executionId,
+      onClick: () => {
+        if (!executionId) return;
+        onNavigateTo("runs", {
+          executionId,
+          ...(resourceId ? { resourceId } : {}),
+        });
+      },
+    },
+  ];
+
+  if (includeHealth) {
+    actions.push({
+      key: "health",
+      label: "Health",
+      onClick: () => onNavigateTo("health"),
+    });
+  }
+
+  return actions;
+}

--- a/packages/dbt-tools/web/src/styles/workspace.css
+++ b/packages/dbt-tools/web/src/styles/workspace.css
@@ -275,6 +275,7 @@
 .action-list__row {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   justify-content: space-between;
   gap: 0.75rem;
   padding: 0.6rem 0.8rem;
@@ -2180,6 +2181,22 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 1rem;
+}
+
+.related-view-pivots {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.related-view-pivots__label {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.related-view-pivots .entity-inspector__actions {
+  margin-top: 0;
 }
 
 .asset-workspace {


### PR DESCRIPTION
### Motivation

- The four workspace lenses (Health, Timeline, Inventory, Runs) felt fragmented and lacked a coherent pivot model for investigators to move between entity/run/time contexts. 
- Timeline and Health lacked consistent, context-preserving links into Inventory and Runs, which disrupted common investigation flows. 
- Implement a small, reusable navigation contract so pivots are consistent, deeplinkable, and resilient when data is missing.

### Description

- Add a centralized cross-view helper `buildCrossViewPivotActions` to produce context-aware pivot actions (`inventory`, `timeline`, `runs`, `health`) that disable when data is unavailable and invoke the existing `onNavigateTo` contract (`packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.ts`).
- Introduce a compact reusable UI cluster `RelatedViewPivots` in the Analysis Workspace shared components and lightweight CSS rules to present action clusters without visual noise (`packages/dbt-tools/web/src/components/AnalysisWorkspace/shared.tsx`, `packages/dbt-tools/web/src/styles/workspace.css`).
- Wire the shared pivots into the workspace lenses so investigation context is preserved where possible: Timeline (selected-item inspector + pivots), Health (bottlenecks rows), Inventory (asset hero), and Runs (selected-run inspector) (`packages/dbt-tools/web/src/components/AnalysisWorkspace/timeline/TimelineView.tsx`, `.../views/health/HealthView.tsx`, `.../views/AssetsView.tsx`, `.../views/runs/RunsViewAdapterInspector.tsx`, plus glue in `AnalysisWorkspace.tsx`).
- Replace one-off link actions with the shared pivot model and format pivot labels (for UI clarity) where appropriate, and ensure pivots degrade gracefully (disabled) when a run or resource id is missing.
- Add a unit test for the helper (`crossViewNavigation.test.ts`) and update an existing runs test to reflect the new inspector actions (`RunsView.test.tsx`).

### Testing

- Ran focused unit tests: `pnpm vitest run packages/dbt-tools/web/src/lib/analysis-workspace/crossViewNavigation.test.ts packages/dbt-tools/web/src/components/AnalysisWorkspace/views/runs/RunsView.test.tsx` and observed all tests passing (2 files, 8 tests passed). 
- Built parser package required by core with `pnpm --filter dbt-artifacts-parser build` which succeeded and resolved earlier type-resolution failures. 
- Built the web package with `pnpm --filter @dbt-tools/web build`; initial build failed due to missing parser subpath types until the parser was built, then the build completed successfully after building `dbt-artifacts-parser` first. 
- The changes are limited, covered by unit tests for the helper, and the build succeeds for the touched packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96c2e6b30832c95fbaee340e3fe23)