### PR TITLE
Add ui-feature-verify skill and session prerequisites

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -25,6 +25,10 @@ Optimize for fast failure. Run the cheapest high-signal checks first, then the s
 - **Step 6 — never parallel with build or pack on the same workspace:** `pnpm codeql` runs `codeql:db`, which invokes `codeql:clean` and **deletes** `packages/dbt-tools/web/dist`, `dist-serve`, and CodeQL artifacts. Run CodeQL only **after** step 5 completes (or accept that web build outputs under `packages/dbt-tools/web` are removed afterward).
 - **Step 7 — sequential, mutating:** Run **normalization** only **after** step 6. Do **not** parallelize step 7 with Batch A or with step 3. `pnpm format` rewrites files; if the working tree is still dirty after step 7’s stability loop, do **not** claim full completion—report the remaining diff (or `git status --short`).
 
+## Working-tree check (before steps 1–7)
+
+Before running any step, run `git status --short`. If any paths appear, warn the caller and ask them to commit or stash before proceeding. Do not start verification while a foreground agent is still editing the same files—a write conflict at step 7 normalization wastes tokens resolving merge artifacts.
+
 ## Steps (canonical order)
 
 1. Run `pnpm lint:report` from the repository root. This catches policy violations quickly, including file-size and complexity regressions. If it fails, use `lint-fix` until it passes, then rerun `pnpm lint:report`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,18 @@
     }
   },
   "_comment": "Project defaults (committed). Personal overrides: .claude/settings.local.json (gitignored). Verify layers with /status in Claude Code. Sandbox: /sandbox in REPL; autoAllowBashIfSandboxed trades fewer prompts for less review of sandboxed commands.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -d node_modules && test -x node_modules/.bin/pnpm || pnpm install --frozen-lockfile"
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,

--- a/.claude/skills/dbt-tools-web-e2e/SKILL.md
+++ b/.claude/skills/dbt-tools-web-e2e/SKILL.md
@@ -38,11 +38,15 @@ This skill covers **deterministic** automation (specs + CI-style runs). It does 
 
 ## Preview build constraint
 
-Playwright starts **`vite preview`** on `http://localhost:4173` (see `playwright.config.ts`). **`dist/` must already exist**—run `pnpm build` / `pnpm --filter @dbt-tools/web build` first, or rely on the **Test** workflow which builds before E2E. Tests exercise the **production preview** bundle, not `pnpm dev`.
+Playwright starts **`vite preview`** on `http://localhost:4173` (see `playwright.config.ts`). Always run **`pnpm --filter @dbt-tools/web build`** before running tests—do not assume `dist/` is current. The **Test** workflow always builds before E2E shards; in any other context (skill invocation, local run, `ui-feature-verify`) rebuild explicitly. Tests exercise the **production preview** bundle, not `pnpm dev`.
 
 Some flows may **fail or be skipped** in preview while they work in dev—for example, code paths that assume Node `require` or dev-only bundling. Do **not** remove `test.skip` or weaken assertions without **fixing the underlying preview/bundle issue**. Document new skips with a short comment pointing to the root cause.
 
 Details: [Playwright conventions](references/playwright-conventions.md).
+
+## Coverage contract
+
+For every new button, tab, pivot, or navigation element added to a view, the spec for that view must include at least one assertion that the element exists and is visible (e.g. `expect(page.getByRole('button', { name: '...' })).toBeVisible()`). The `ui-feature-verify` skill's step 8 gap report flags missing assertions before the session ends. Do not ship a UI feature without that assertion.
 
 ## Further reading
 

--- a/.claude/skills/dbt-tools-web-e2e/references/playwright-conventions.md
+++ b/.claude/skills/dbt-tools-web-e2e/references/playwright-conventions.md
@@ -5,7 +5,7 @@ Source of truth: [`packages/dbt-tools/web/playwright.config.ts`](../../../../pac
 ## Server and base URL
 
 - **`baseURL`:** `http://localhost:4173`
-- **`webServer`:** `vite preview` on port `4173` only (see config). **`dist/` must exist** before preview starts—run `pnpm build` (or `pnpm --filter @dbt-tools/web build`) first. The GitHub **Test** workflow builds the monorepo before the sharded E2E jobs.
+- **`webServer`:** `vite preview` on port `4173` only (see config). Always run `pnpm --filter @dbt-tools/web build` before preview starts—do not assume `dist/` is current. The GitHub **Test** workflow always builds before the sharded E2E jobs.
 - Tests always hit the **preview** server. Do not assume HMR, dev-only env, or behaviors that differ between `pnpm dev` and `vite preview` unless you explicitly verify both.
 
 ## Projects and reporting

--- a/.claude/skills/ui-feature-verify/SKILL.md
+++ b/.claude/skills/ui-feature-verify/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: ui-feature-verify
+description: Lightweight verification for UI-only changes to @dbt-tools/web. Runs lint, unit tests, coverage, a fresh build, Playwright E2E, and a coverage gap report. Use instead of the full verifier when changes are confined to packages/dbt-tools/web/src/. Skips CodeQL and pack+npx smoke.
+compatibility: Requires pnpm and Node as in repo .node-version; Playwright Chromium via @dbt-tools/web devDependencies. Run from repository root unless noted.
+---
+
+# UI feature verify
+
+## Trigger scenarios
+
+Use this skill when:
+
+- A change is **confined to `packages/dbt-tools/web/src/`** (components, styles, types, lib, helpers).
+- The user asks to verify, green-check, or ship a UI feature without a full verifier run.
+- The task involves new nav pills, view tabs, timeline inspector changes, or other interactive UI elements.
+
+Do **not** use this skill when changes touch published packages (`dbt-artifacts-parser`, `@dbt-tools/core`), scripts under `scripts/`, CI workflows, or `package.json` files. Use the full **verifier** agent for those.
+
+## Steps (canonical order)
+
+1. **Working-tree check.** Run `git status --short`. If files outside `packages/dbt-tools/web/` are modified, warn the user and ask whether to proceed. If another agent may still be writing files, wait for it to finish before continuing.
+
+2. **Lint.** Run `pnpm lint:report` from the repository root. Must exit 0. If it fails, apply `lint-fix` until it passes, then rerun.
+
+3. **Unit tests.** Run `pnpm --filter @dbt-tools/web test`. If tests fail, apply `test-fix` and rerun until green.
+
+4. **Coverage.** Run `pnpm coverage:report` from the repository root. Must exit 0. If below thresholds, add unit tests and rerun. Thresholds: lines 60%, branches 50%, functions 60%, statements 60% (see `CLAUDE.md`).
+
+5. **Build (always rebuild).** Run `pnpm --filter @dbt-tools/web build`. Do not skip even if `dist/` appears current—a stale build causes silent E2E failures. If it fails, apply `build-fix` and rerun.
+
+6. **Playwright browser check.** Run `pnpm --filter @dbt-tools/web exec playwright install chromium --with-deps`. Idempotent when browsers are present; fast. Do not skip.
+
+7. **E2E.** Run `pnpm --filter @dbt-tools/web test:e2e`. If E2E fails, apply `dbt-tools-web-e2e-fix` and rerun until green.
+
+8. **Coverage gap report.** Review the diff for this session (`git diff --name-only HEAD~1..HEAD` or the user's stated scope). List every new interactive UI element (button, tab, pivot, navigation link) added. For each, confirm a `toBeVisible` or equivalent assertion exists in the corresponding spec under `packages/dbt-tools/web/e2e/`. Report any element without a spec assertion as a gap. Do not claim the feature is shipped until each gap is covered or explicitly accepted by the user with a reason.
+
+## Parallel batches
+
+- **Steps 2 and 3** are safe to run in parallel (lint and unit tests are independent).
+- **Step 4** must run after step 3 (Vitest contention if concurrent).
+- **Steps 5–8** are sequential: build → browser check → E2E → gap report.
+
+## What this skill skips
+
+Intentionally omits `pnpm codeql` and `dbt-tools-web-pack-npx-smoke`. Both are expensive and irrelevant for source-only UI changes. Use the full **verifier** agent when those gates are needed.
+
+## Related
+
+- [dbt-tools-web-e2e skill](../dbt-tools-web-e2e/SKILL.md) — authoring E2E specs
+- [dbt-tools-web-e2e-fix skill](../dbt-tools-web-e2e-fix/SKILL.md) — fixing E2E failures
+- [verifier agent](../../agents/verifier.md) — full verification including CodeQL
+- [Coverage contract](../dbt-tools-web-e2e/SKILL.md#coverage-contract) — assertion requirement for new UI elements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,21 @@ Run **`/status`** in Claude Code to see which settings layers are active and to 
 ## Plugins
 
 Official plugins enabled for this project are listed in `.claude/settings.json` under `enabledPlugins` and summarized in [AGENTS.md](AGENTS.md).
+
+## Session prerequisites
+
+Before running any quality gate or invoking the verifier, confirm:
+
+1. `node_modules/` is present at the repo root. If absent, run `pnpm install --frozen-lockfile` before anything else. Many tools (Trunk, ESLint, Vitest, Playwright) silently fail without it.
+2. Playwright browsers are installed for `@dbt-tools/web` E2E. If `pnpm test:e2e` or the `ui-feature-verify` skill reports missing browsers, run `pnpm --filter @dbt-tools/web exec playwright install chromium --with-deps` once. CI caches `~/.cache/ms-playwright`; local machines must install once per Playwright major.
+
+The session-start hook in `.claude/settings.json` covers the `node_modules` case automatically; browser binaries require the one-time manual step above.
+
+## Agent coordination
+
+When more than one agent runs concurrently, file-write conflicts waste tokens and produce incorrect commits. Follow these rules:
+
+- **Before spawning a background agent**, note which files it may write. Do not spawn a second agent that writes the same files as the foreground agent until the first write batch is committed.
+- **Explore agents** must read only. When dispatching two Explore agents, scope each to a disjoint directory set and merge their summaries before the main agent reads those files—this avoids double-reading.
+- **The verifier agent** is write-capable (step 7 runs `pnpm format`). Do not start the verifier while the foreground agent has uncommitted edits. Commit or stash first.
+- **Scope verification to the change.** For a UI-only change (`packages/dbt-tools/web/src/` only), use the `ui-feature-verify` skill instead of the full verifier. Reserve the full verifier (CodeQL, pack+npx smoke) for changes that touch published packages, scripts, or CI configuration.


### PR DESCRIPTION
## Summary

This PR introduces a lightweight verification workflow for UI-only changes to `@dbt-tools/web` and establishes session prerequisites and agent coordination guidelines to prevent file-write conflicts and silent failures.

## Key Changes

- **New `ui-feature-verify` skill** (`.claude/skills/ui-feature-verify/SKILL.md`):
  - Lightweight alternative to the full verifier for changes confined to `packages/dbt-tools/web/src/`
  - Runs lint, unit tests, coverage, build, Playwright E2E, and a coverage gap report
  - Intentionally skips expensive CodeQL and pack+npx smoke tests
  - Includes a coverage gap report step that flags new interactive UI elements without E2E assertions
  - Defines parallel-safe batch execution (lint+unit tests in parallel; build→browser→E2E→gap report sequential)

- **Session prerequisites in `CLAUDE.md`**:
  - Documents required `node_modules/` presence and Playwright browser installation
  - Notes that the session-start hook handles `node_modules` automatically
  - Clarifies that Playwright browsers require a one-time manual install per major version

- **Agent coordination guidelines in `CLAUDE.md`**:
  - Establishes rules to prevent file-write conflicts when multiple agents run concurrently
  - Specifies that the verifier agent is write-capable and should not run while foreground agent has uncommitted edits
  - Recommends using `ui-feature-verify` for UI-only changes instead of the full verifier

- **Session-start hook in `.claude/settings.json`**:
  - Automatically runs `pnpm install --frozen-lockfile` if `node_modules/` is missing
  - Ensures tools like Trunk, ESLint, Vitest, and Playwright don't silently fail due to missing dependencies

- **Coverage contract in `dbt-tools-web-e2e/SKILL.md`**:
  - Formalizes requirement that every new button, tab, pivot, or navigation element must have a corresponding E2E assertion
  - References the `ui-feature-verify` gap report as the enforcement mechanism

- **Updated Playwright conventions**:
  - Clarifies that `dist/` must always be rebuilt before E2E runs (not assumed to be current)
  - Applies to skill invocation, local runs, and `ui-feature-verify` contexts

- **Working-tree check in `verifier.md`**:
  - Adds pre-flight check to warn if uncommitted changes exist before verification begins
  - Prevents write conflicts at normalization step

## Notable Implementation Details

- The `ui-feature-verify` skill's step 8 (coverage gap report) uses `git diff --name-only HEAD~1..HEAD` to identify new UI elements and cross-references E2E specs to ensure assertions exist
- Parallel batches are carefully scoped: lint and unit tests can run together, but coverage must wait for unit tests to avoid Vitest contention
- The session-start hook uses a conditional test (`test -d node_modules && test -x node_modules/.bin/pnpm`) to avoid redundant installs
- All documentation emphasizes that `vite preview` requires an explicit rebuild—no assumptions about stale `dist/` directories

https://claude.ai/code/session_01GwriyD9guGZFvSRtFhG8go