### PR TITLE
Refactor CLI structure and enhance command schema for dbt-tools

### DIFF
--- a/docs/adr/0035-dbt-tools-operational-intelligence-and-positioning-boundaries.md
+++ b/docs/adr/0035-dbt-tools-operational-intelligence-and-positioning-boundaries.md
@@ -30,7 +30,7 @@ Earlier positioning (see ADR-0006) emphasized **artifact-only** operation and **
 | Package           | Role                                                                                                                                                                                                                                                                                      |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@dbt-tools/core` | Reusable **analysis engine**: graph construction, execution analysis, snapshots, exports, and shared logic for CLI and web. Intended as a **substrate** other systems can build on—not a private implementation detail.                                                                   |
-| `@dbt-tools/cli`  | **Structured interface** for operators, scripts, CI, and coding agents: machine-readable JSON, `schema` introspection, `--fields` to bound payloads, validated inputs, stable error codes.                                                                                                |
+| `@dbt-tools/cli`  | **Structured interface** for operators, scripts, CI, and coding agents: a task-oriented command hierarchy, machine-readable JSON, dual-surface discovery via help and `describe schema`, `--fields` to bound payloads, validated inputs, and stable error codes.                          |
 | `@dbt-tools/web`  | **Deterministic investigation UI**: dependency and lineage views, execution timelines, inventory, health-oriented summaries—**valuable without an LLM**. Remote artifact sources (S3/GCS) are **optional, configured infrastructure**, not a multi-tenant SaaS assumption (see ADR-0029). |
 
 ### Messaging pillars (use consistently in docs)
@@ -39,6 +39,15 @@ Earlier positioning (see ADR-0006) emphasized **artifact-only** operation and **
 2. **Human + agent interface** — Useful interactively for operators and programmatically for automation, CI, agent skills, and multi-tool workflows.
 3. **Actionable without AI** — The web app should answer questions such as what failed, what is slow, what is on the critical path, what depends on a node, and what to inspect next, using artifact-driven views alone.
 4. **Local-first / controlled environments** — Default paths assume local `target/` artifacts; remote access is explicit configuration in trusted environments.
+
+### CLI interaction model
+
+`@dbt-tools/cli` uses a **task-oriented hierarchy** rather than a flat verb list.
+
+- Top-level families should communicate user intent first: inspect, find, trace, export, check, and describe.
+- CLI discovery is **dual-surface**: people should be able to orient through `--help`, while agents and automation can query `describe schema` for the same command tree.
+- Command-family structure is a **forward-growth mechanism**. New capabilities should prefer joining an existing family before introducing a new top-level family.
+- Human guessability is prioritized, but never by weakening machine-readable discovery or structured outputs.
 
 ### Explicit non-goals (category boundaries)
 
@@ -55,12 +64,14 @@ ADR-0006 remains authoritative for **artifact-only** scope, **offline/CI** use, 
 
 - One place to point contributors and readers for “what dbt-tools is” vs “what it is not.”
 - Aligns READMEs and user guides with package boundaries (core / CLI / web).
+- Gives the CLI a stable, extensible interaction model that is easier to teach and easier for agents to discover.
 - Reduces mistaken comparisons to Cloud, observability vendors, or chat-only tools.
 
 **Negative / risks:**
 
 - Docs require occasional refresh when capabilities grow; positioning language should stay tied to shipped behavior.
 - Historical ADRs (e.g. UX benchmarks in ADR-0018) must be read with this ADR so “benchmark product” is not confused with “category clone.”
+- CLI taxonomy changes are breaking product-surface changes and should be treated as deliberate decisions, not opportunistic naming churn.
 
 ## Alternatives considered
 

--- a/docs/user-guide-dbt-tools-cli.md
+++ b/docs/user-guide-dbt-tools-cli.md
@@ -1,113 +1,119 @@
 # User guide: @dbt-tools/cli
 
-Extended notes for operators and automation using **`dbt-tools`**. The CLI is the **structured interface** to dbt artifact analysis: JSON-oriented defaults, `schema` for runtime discovery, and `--fields` to bound payloads—suited to CI, scripts, and coding-agent skills alike. For product positioning (operational intelligence layer, composable substrate), see [ADR-0035](./adr/0035-dbt-tools-operational-intelligence-and-positioning-boundaries.md). For the full command reference (`summary`, `graph`, `run-report`, `deps`, `schema`), see the [package README](../packages/dbt-tools/cli/README.md).
+Extended notes for operators and automation using **`dbt-tools`**. The CLI is the **structured interface** to dbt artifact analysis: JSON-oriented defaults, `describe schema` for runtime discovery, and `--fields` to bound payloads. The vNext CLI uses a task-oriented hierarchy so humans and coding agents can discover commands through both help and machine-readable schema output. For the full command reference, see the [package README](../packages/dbt-tools/cli/README.md).
 
----
+## Basics
 
-## Quick orientation
-
-- **Binary:** `dbt-tools` (from `@dbt-tools/cli`)
-- **Defaults:** artifact paths under **`./target`** (`manifest.json`, `run_results.json`)
-- **Output:** JSON when stdout is **not** a TTY; human text in an interactive terminal — override with `--json` / `--no-json`
-- **Discovery:** `dbt-tools schema` and `dbt-tools schema <command>` for machine-readable option metadata
+- **Package:** `@dbt-tools/cli`
+- **Binary:** `dbt-tools`
+- **Node.js:** 20+
+- **Default artifact location:** `./target`
+- **Discovery:** `dbt-tools --help` plus `dbt-tools describe schema ...`
 
 Install:
 
 ```bash
 npm install -g @dbt-tools/cli
-# or:
 npx @dbt-tools/cli --help
 ```
 
----
+## Command taxonomy
+
+```text
+dbt-tools inspect <summary|run|timeline|inventory>
+dbt-tools find <resources>
+dbt-tools trace <lineage>
+dbt-tools export <graph>
+dbt-tools check <artifacts>
+dbt-tools describe <schema>
+```
+
+Recommended mental model:
+
+- `inspect` = structured views over artifacts
+- `find` = locate likely matches
+- `trace` = traverse lineage
+- `export` = emit graph/materialized output
+- `check` = operational readiness
+- `describe` = discovery and introspection
+
+## Migration from the flat CLI
+
+This release removes the older flat verbs. Update automation and scripts as follows:
+
+| Before                 | After                         |
+| :--------------------- | :---------------------------- |
+| `dbt-tools summary`    | `dbt-tools inspect summary`   |
+| `dbt-tools run-report` | `dbt-tools inspect run`       |
+| `dbt-tools timeline`   | `dbt-tools inspect timeline`  |
+| `dbt-tools inventory`  | `dbt-tools inspect inventory` |
+| `dbt-tools search`     | `dbt-tools find resources`    |
+| `dbt-tools deps`       | `dbt-tools trace lineage`     |
+| `dbt-tools graph`      | `dbt-tools export graph`      |
+| `dbt-tools status`     | `dbt-tools check artifacts`   |
+| `dbt-tools freshness`  | `dbt-tools check artifacts`   |
+| `dbt-tools schema`     | `dbt-tools describe schema`   |
+
+If a removed command is invoked, the CLI fails with a targeted “use X instead” message.
 
 ## Schema introspection
 
-Discover commands and flags at runtime (useful for agents):
+Use `describe schema` for machine-readable discovery:
 
 ```bash
-dbt-tools schema
-dbt-tools schema deps
+dbt-tools describe schema
+dbt-tools describe schema inspect
+dbt-tools describe schema inspect run
+dbt-tools describe schema trace lineage
 ```
 
-Example: inspect an option with `jq`:
+Typical automation pattern:
 
 ```bash
-dbt-tools schema deps | jq '.options[] | select(.name == "--direction")'
+dbt-tools describe schema trace lineage \
+  | jq '.options[] | select(.name == "--direction")'
 ```
 
----
+The returned schema includes:
 
-## Field filtering
+- command path segments
+- descriptions
+- arguments
+- options
+- defaults
+- enum values where available
 
-Use **`--fields`** on `summary`, `deps`, `graph` (JSON), and `run-report` to shrink payloads:
+## Output-size control
+
+Use `--fields` to shrink payloads when feeding output into automation or LLM context:
 
 ```bash
-dbt-tools deps model.my_project.customers --fields "unique_id,name"
-dbt-tools deps model.my_project.customers --fields "unique_id,name,attributes.resource_type"
+dbt-tools trace lineage model.my_project.customers --fields "unique_id,name"
+dbt-tools inspect summary --fields "total_nodes,total_edges"
+dbt-tools inspect run --fields "total_execution_time,critical_path"
 ```
 
----
+## Recommended automation flow
 
-## Input validation
+1. Run `dbt-tools check artifacts` to see what is available locally.
+2. Use `dbt-tools find resources` if you do not know the exact `unique_id`.
+3. Use `dbt-tools trace lineage` for dependency traversal.
+4. Choose `dbt-tools inspect run` for aggregated execution health.
+5. Choose `dbt-tools inspect timeline` for row-level execution investigation.
+6. Use `dbt-tools describe schema ...` whenever argument or option shapes are unclear.
 
-The CLI rejects unsafe or ambiguous inputs:
+## Before/after examples
 
-- Path segments like **`../`** / **`..\`**
-- Control characters (below `0x20`, except newline / CR / tab)
-- Resource IDs containing **`?`**, **`#`**, or **`%`** (including encoded traversal like `%2e%2e`)
+```bash
+# Before
+dbt-tools status
+dbt-tools search orders --json | jq '.results[0].unique_id'
+dbt-tools deps model.my_project.customers --direction upstream
+dbt-tools run-report --bottlenecks
 
-**Valid example:** `model.my_project.customers`
-**Invalid examples:** `model.x?fields=name`, `model%2ex`, `../../.ssh`
-
----
-
-## Error handling (non-TTY / agents)
-
-Errors are JSON with a stable **`code`** field:
-
-```json
-{
-  "error": "ValidationError",
-  "code": "VALIDATION_ERROR",
-  "message": "Resource ID contains invalid characters",
-  "details": {
-    "field": "resource_id"
-  }
-}
+# After
+dbt-tools check artifacts
+dbt-tools find resources orders --json | jq '.results[0].unique_id'
+dbt-tools trace lineage model.my_project.customers --direction upstream
+dbt-tools inspect run --bottlenecks
 ```
-
-| Code                  | Meaning                        |
-| --------------------- | ------------------------------ |
-| `VALIDATION_ERROR`    | Input validation failed        |
-| `FILE_NOT_FOUND`      | Artifact file missing          |
-| `PARSE_ERROR`         | Invalid JSON                   |
-| `UNSUPPORTED_VERSION` | Artifact version not supported |
-| `UNKNOWN_ERROR`       | Other failure                  |
-
----
-
-## Best practices for AI agents
-
-1. Prefer **`--fields`** on large outputs.
-2. Use default **`./target`** unless paths must differ.
-3. Use **`dbt-tools schema`** when argument shapes are unclear.
-4. Branch on **`code`** in JSON error bodies in scripts.
-5. Keep resource IDs literal dbt **`unique_id`** strings — never URL-encode or append query parameters.
-
----
-
-## Environment variables
-
-| Variable               | Purpose                                                 |
-| ---------------------- | ------------------------------------------------------- |
-| `DBT_TOOLS_TARGET_DIR` | Default target directory (replaces `./target`)          |
-| Legacy                 | `DBT_TARGET_DIR`, `DBT_TARGET` (deprecated; still read) |
-
----
-
-## Related
-
-- [Package README](../packages/dbt-tools/cli/README.md) — full command reference
-- [CONTRIBUTING.md](../CONTRIBUTING.md) — building and testing from source
-- [@dbt-tools/core README](../packages/dbt-tools/core/README.md) — library API used by the CLI

--- a/packages/dbt-tools/cli/README.md
+++ b/packages/dbt-tools/cli/README.md
@@ -1,36 +1,29 @@
 # @dbt-tools/cli
 
-**Structured interface** for dbt artifact analysis: machine-readable JSON by default in non-interactive environments, runtime **`schema`** introspection, **`--fields`** to shrink payloads, and validated inputs with stable error codes—suited to **operators**, **CI**, **scripts**, and **coding agents** (skills, multi-step automation) without treating AI as the only consumer.
+**Structured interface** for dbt artifact analysis: machine-readable JSON by default in non-interactive environments, runtime **`describe schema`** introspection, **`--fields`** to shrink payloads, and validated inputs with stable error codes. The vNext CLI uses a **task-oriented hierarchy** so humans and coding agents can guess commands more reliably and still discover the full surface at runtime.
 
-**Quick start:** install Node.js **20+** (see the repo [`.node-version`](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/.node-version) for the version used in development; Node 18 is EOL — [releases](https://nodejs.org/en/about/previous-releases)), then `npm install -g @dbt-tools/cli` and run `dbt-tools summary` from a directory that contains `./target/manifest.json`. Extended topics (errors, validation, `schema` introspection, agent-oriented patterns) are in the [user guide](../../../docs/user-guide-dbt-tools-cli.md). Positioning: [ADR-0035](../../../docs/adr/0035-dbt-tools-operational-intelligence-and-positioning-boundaries.md).
+**Quick start:** install Node.js **20+** (see the repo [`.node-version`](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/.node-version) for the version used in development; Node 18 is EOL — [releases](https://nodejs.org/en/about/previous-releases)), then `npm install -g @dbt-tools/cli` and run `dbt-tools inspect summary` from a directory that contains `./target/manifest.json`. Extended notes, migration guidance, and agent-oriented patterns are in the [user guide](../../../docs/user-guide-dbt-tools-cli.md). Positioning: [ADR-0035](../../../docs/adr/0035-dbt-tools-operational-intelligence-and-positioning-boundaries.md).
 
-## Commands
+## Task Families
 
-```mermaid
-graph TD
-  CLI["dbt-tools"]
-  CLI --> summary["summary\nmanifest statistics"]
-  CLI --> graphCmd["graph\nexport dependency graph"]
-  CLI --> rr["run-report\nexecution report"]
-  CLI --> deps["deps\nupstream / downstream deps"]
-  CLI --> inventory["inventory\nlist / filter resources"]
-  CLI --> timeline["timeline\nper-node execution timeline"]
-  CLI --> search["search\ndiscover resources"]
-  CLI --> status["status / freshness\nartifact readiness"]
-  CLI --> schema["schema\nruntime introspection"]
-
-  summary -->|manifest.json| MG[ManifestGraph]
-  graphCmd -->|manifest.json| MG
-  rr -->|run_results.json\n+ manifest.json| EA[ExecutionAnalyzer]
-  deps -->|manifest.json| DS[DependencyService]
-  inventory -->|manifest.json| MG
-  timeline -->|run_results.json\n+ manifest.json| EA
-  search -->|manifest.json| MG
-  status -.->|filesystem| FS[File stats]
-  schema -.->|describes| CLI
+```text
+dbt-tools inspect <summary|run|timeline|inventory>
+dbt-tools find <resources>
+dbt-tools trace <lineage>
+dbt-tools export <graph>
+dbt-tools check <artifacts>
+dbt-tools describe <schema>
 ```
 
----
+- `inspect summary` - manifest-level summary statistics
+- `inspect run` - aggregated execution report from `run_results.json`
+- `inspect timeline` - row-level execution entries from `run_results.json`
+- `inspect inventory` - enumerate and filter manifest resources
+- `find resources` - discover likely matches from text and filters
+- `trace lineage` - upstream/downstream dependency traversal from a resource
+- `export graph` - graph export, focused subgraphs, and field-level lineage
+- `check artifacts` - artifact presence, recency, and readiness
+- `describe schema` - machine-readable schema for the full tree or a specific path
 
 ## Installation
 
@@ -38,45 +31,77 @@ graph TD
 pnpm add -g @dbt-tools/cli
 ```
 
----
+## Common Examples
 
-## Features
+```bash
+# Check local artifact readiness before analysis
+dbt-tools check artifacts
 
-- **Default `./target` directory**: Commands default to dbt's standard artifact location
-- **JSON-by-default**: Machine-readable JSON output in non-interactive environments (stable contract for pipes, CI, agents)
-- **Input validation**: Hardened against common mistakes (path traversals, control chars, ambiguous resource IDs)
-- **Field filtering**: Bound output size with `--fields` (also useful when piping into LLM context)
-- **Schema introspection**: Runtime command and option discovery via `schema` command
-- **Dependency analysis**: Find upstream/downstream dependencies with `deps` command
-- **Inventory**: Browse and filter all dbt resources in one view
-- **Timeline**: Inspect per-node execution timing (row-level, unlike `run-report`)
-- **Search**: Discover resources by name, tag, type, or free-text query
-- **Status / Freshness**: Check if artifacts are present and how recent they are
-- **Subgraph focus**: Export a focused subgraph for any node via `graph --focus`
+# Get a manifest-level summary
+dbt-tools inspect summary
 
----
+# Find likely matches before tracing lineage
+dbt-tools find resources orders --json
+
+# Enumerate structured inventory with filters
+dbt-tools inspect inventory --type model --tag finance
+
+# Trace downstream lineage from a resource
+dbt-tools trace lineage model.my_project.customers
+
+# Trace upstream lineage with a smaller JSON payload
+dbt-tools trace lineage model.my_project.customers \
+  --direction upstream --fields "unique_id"
+
+# Inspect an aggregated run report
+dbt-tools inspect run --bottlenecks
+
+# Inspect row-level execution entries
+dbt-tools inspect timeline --top 10
+dbt-tools inspect timeline --failed-only
+
+# Export a focused subgraph
+dbt-tools export graph \
+  --focus model.my_project.orders \
+  --focus-direction downstream \
+  --resource-types model,test
+```
+
+## Help And Schema Discovery
+
+Both humans and agents should treat CLI help and schema introspection as first-class discovery surfaces.
+
+```bash
+# Human-oriented discovery
+dbt-tools --help
+dbt-tools inspect --help
+dbt-tools trace lineage --help
+
+# Machine-readable discovery
+dbt-tools describe schema
+dbt-tools describe schema inspect
+dbt-tools describe schema inspect run
+dbt-tools describe schema trace lineage
+```
+
+Example:
+
+```bash
+dbt-tools describe schema trace lineage | jq '.options[] | select(.name == "--direction")'
+```
 
 ## Command Reference
 
-### summary
+### inspect summary
 
-Provide summary statistics for dbt manifest.
+Provide summary statistics for the dbt manifest.
 
 ```bash
-# Uses ./target/manifest.json by default
-dbt-tools summary
-
-# Custom target directory
-dbt-tools summary --target-dir ./custom-target
-
-# Explicit path
-dbt-tools summary path/to/manifest.json
-
-# Field filtering to reduce context window usage
-dbt-tools summary --fields "total_nodes,total_edges"
-
-# JSON output
-dbt-tools summary --json
+dbt-tools inspect summary
+dbt-tools inspect summary --target-dir ./custom-target
+dbt-tools inspect summary path/to/manifest.json
+dbt-tools inspect summary --fields "total_nodes,total_edges"
+dbt-tools inspect summary --json
 ```
 
 **Options:**
@@ -87,83 +112,18 @@ dbt-tools summary --json
 - `--json` - Force JSON output
 - `--no-json` - Force human-readable output
 
----
+### inspect run
 
-### graph
-
-Export dependency graph in various formats.
-
-Supports optional subgraph focus via `--focus` to export a node-centred slice of the graph.
+Generate an **aggregated** execution report from `run_results.json` (totals, critical path, bottlenecks). For **row-level** per-node timings, use [`inspect timeline`](#inspect-timeline) instead.
 
 ```bash
-# Full graph (uses ./target/manifest.json by default)
-dbt-tools graph
-
-# Export as DOT format
-dbt-tools graph --format dot --output graph.dot
-
-# Export as GEXF format
-dbt-tools graph --format gexf --output graph.gexf
-
-# With field filtering (only affects JSON format)
-dbt-tools graph --format json --fields "name,resource_type"
-
-# Subgraph: focus on one node, 2 hops in both directions
-dbt-tools graph --focus model.my_project.orders --focus-depth 2
-
-# Upstream subgraph only
-dbt-tools graph --focus model.my_project.orders --focus-direction upstream
-
-# Downstream subgraph filtered to models and tests
-dbt-tools graph --focus model.my_project.orders \
-  --focus-direction downstream --resource-types model,test
-
-# Custom target directory
-dbt-tools graph --target-dir ./custom-target
-```
-
-**Options:**
-
-- `[manifest-path]` - Path to manifest.json (defaults to `./target/manifest.json`)
-- `--format <format>` - Export format: `json`, `dot`, or `gexf` (default: `json`)
-- `--output <path>` - Output file path (default: stdout)
-- `--target-dir <dir>` - Custom target directory
-- `--fields <fields>` - Comma-separated list of fields to include (affects JSON nodes)
-- `--focus <resource-id>` - Focus the export on a single node; produces a subgraph only
-- `--focus-depth <n>` - Max traversal hops when `--focus` is set (default: unlimited)
-- `--focus-direction <direction>` - Traversal direction: `upstream`, `downstream`, or `both` (default: `both`)
-- `--resource-types <types>` - Comma-separated resource types to keep (e.g. `model,test`)
-- `--field-level` - Include field-level (column-level) lineage
-- `--catalog-path <path>` - Path to catalog.json (used with `--field-level`)
-
----
-
-### run-report
-
-Generate **aggregated** execution report from run_results.json (totals, critical path, bottlenecks).
-For **row-level** per-node timings, use [`timeline`](#timeline) instead.
-
-```bash
-# Uses ./target/run_results.json and ./target/manifest.json by default
-dbt-tools run-report
-
-# Include bottleneck section (top 10 slowest nodes by default)
-dbt-tools run-report --bottlenecks
-
-# Top 5 slowest nodes
-dbt-tools run-report --bottlenecks --bottlenecks-top 5
-
-# Nodes exceeding 10 seconds
-dbt-tools run-report --bottlenecks --bottlenecks-threshold 10
-
-# Field filtering
-dbt-tools run-report --fields "total_execution_time,critical_path"
-
-# Custom paths
-dbt-tools run-report ./custom/run_results.json ./custom/manifest.json
-
-# JSON output
-dbt-tools run-report --json
+dbt-tools inspect run
+dbt-tools inspect run --bottlenecks
+dbt-tools inspect run --bottlenecks --bottlenecks-top 5
+dbt-tools inspect run --bottlenecks --bottlenecks-threshold 10
+dbt-tools inspect run --fields "total_execution_time,critical_path"
+dbt-tools inspect run ./custom/run_results.json ./custom/manifest.json
+dbt-tools inspect run --json
 ```
 
 **Options:**
@@ -173,517 +133,148 @@ dbt-tools run-report --json
 - `--target-dir <dir>` - Custom target directory
 - `--fields <fields>` - Comma-separated list of fields to include
 - `--bottlenecks` - Include bottleneck section in report
-- `--bottlenecks-top <n>` - Top N slowest nodes (default: 10 when `--bottlenecks`)
-- `--bottlenecks-threshold <s>` - Nodes exceeding s seconds (cannot combine with `--bottlenecks-top`)
+- `--bottlenecks-top <n>` - Top N slowest nodes
+- `--bottlenecks-threshold <s>` - Nodes exceeding s seconds
+- `--adapter-summary` - Include adapter_response aggregates
+- `--adapter-top-by <metric>` - Rank nodes by adapter metric
+- `--adapter-top-n <n>` - Top N for `--adapter-top-by`
+- `--adapter-min-bytes <n>` - Minimum bytes_processed threshold
+- `--adapter-min-slot-ms <n>` - Minimum slot_ms threshold
+- `--adapter-min-rows-affected <n>` - Minimum rows_affected threshold
 - `--json` - Force JSON output
 - `--no-json` - Force human-readable output
 
----
+### inspect timeline
 
-### deps
-
-Get upstream or downstream dependencies for a dbt resource.
+Show **row-level execution entries** from `run_results.json`. This is the row-level complement to `inspect run`.
 
 ```bash
-# Get downstream dependencies (default)
-dbt-tools deps model.my_project.customers
-
-# Get upstream dependencies
-dbt-tools deps model.my_project.customers --direction upstream
-
-# Get immediate neighbors only
-dbt-tools deps model.my_project.customers --depth 1
-
-# Output as a flat list
-dbt-tools deps model.my_project.customers --format flat
-
-# Get upstream dependencies in build order
-dbt-tools deps model.my_project.customers --direction upstream --build-order
-
-# With field filtering to reduce output size
-dbt-tools deps model.my_project.customers --fields "unique_id,name"
-
-# Custom manifest path
-dbt-tools deps model.my_project.customers --manifest-path ./custom/manifest.json
-```
-
-**Options:**
-
-- `<resource-id>` - Unique ID of the dbt resource (required)
-- `--direction <direction>` - `upstream` or `downstream` (default: `downstream`)
-- `--manifest-path <path>` - Path to manifest.json (defaults to `./target/manifest.json`)
-- `--target-dir <dir>` - Custom target directory
-- `--fields <fields>` - Comma-separated list of fields to include (e.g., `unique_id,name`)
-- `--depth <number>` - Max traversal depth; 1 = immediate neighbors, omit for all levels
-- `--format <format>` - Output structure: `flat` or `tree` (default: `tree`)
-- `--build-order` - Output upstream dependencies in topological build order
-- `--json` - Force JSON output
-- `--no-json` - Force human-readable output
-
----
-
-### inventory
-
-List and filter all dbt resources from the manifest. Useful for browsing what's in the project, or feeding results into downstream commands.
-
-Requires: `manifest.json`
-
-```bash
-# All resources
-dbt-tools inventory
-
-# Filter by type
-dbt-tools inventory --type model
-
-# Multiple types
-dbt-tools inventory --type model,test
-
-# Filter by package
-dbt-tools inventory --package my_project
-
-# Filter by tag
-dbt-tools inventory --tag finance
-
-# Filter by file path substring
-dbt-tools inventory --path models/staging
-
-# Combine filters
-dbt-tools inventory --type model --tag finance --package my_project
-
-# Only return specific fields
-dbt-tools inventory --type model --fields "entries"
-
-# Force JSON (default in non-TTY)
-dbt-tools inventory --json
-```
-
-**Options:**
-
-- `[manifest-path]` - Path to manifest.json (defaults to `./target/manifest.json`)
-- `--type <type>` - Filter by resource type(s), comma-separated (e.g. `model`, `model,test`)
-- `--package <package>` - Filter by exact package name
-- `--tag <tag>` - Filter by tag(s), comma-separated (any match)
-- `--path <path>` - Filter by file path substring
-- `--fields <fields>` - Comma-separated fields to include
-- `--target-dir <dir>` - Custom target directory
-- `--json` - Force JSON output
-- `--no-json` - Force human-readable output
-
-**Example JSON output:**
-
-```json
-{
-  "total": 42,
-  "entries": [
-    {
-      "unique_id": "model.my_project.orders",
-      "resource_type": "model",
-      "name": "orders",
-      "package_name": "my_project",
-      "path": "models/marts/orders.sql",
-      "tags": ["finance"],
-      "description": "Core orders model"
-    }
-  ]
-}
-```
-
----
-
-### timeline
-
-Show **per-node execution entries** from run_results.json, sorted by duration. This is the row-level complement to `run-report`.
-
-**How `timeline` differs from `run-report`:**
-
-|                     | `run-report`                                          | `timeline`                           |
-| ------------------- | ----------------------------------------------------- | ------------------------------------ |
-| Output              | Aggregated stats (totals, critical path, bottlenecks) | One row per executed node            |
-| Use case            | Overall health summary                                | Inspect individual execution timings |
-| CSV output          | No                                                    | Yes                                  |
-| Filtering by status | No                                                    | Yes (`--failed-only`, `--status`)    |
-
-Requires: `run_results.json`. Optionally enriched by `manifest.json` (adds `name` and `resource_type`).
-
-```bash
-# All nodes sorted by duration (slowest first)
-dbt-tools timeline
-
-# With manifest enrichment (adds name and type to each row)
-dbt-tools timeline /path/to/run_results.json /path/to/manifest.json
-
-# Top 20 slowest
-dbt-tools timeline --top 20
-
-# Only failures
-dbt-tools timeline --failed-only
-
-# Filter by specific status
-dbt-tools timeline --status error,warn
-
-# Sort by start time
-dbt-tools timeline --sort start
-
-# CSV output
-dbt-tools timeline --format csv > timeline.csv
-
-# JSON output
-dbt-tools timeline --json
+dbt-tools inspect timeline
+dbt-tools inspect timeline /path/to/run_results.json /path/to/manifest.json
+dbt-tools inspect timeline --top 20
+dbt-tools inspect timeline --failed-only
+dbt-tools inspect timeline --status error,warn
+dbt-tools inspect timeline --sort start
+dbt-tools inspect timeline --format csv > timeline.csv
+dbt-tools inspect timeline --json
 ```
 
 **Options:**
 
 - `[run-results-path]` - Path to run_results.json (defaults to `./target/run_results.json`)
 - `[manifest-path]` - Path to manifest.json (optional, enriches rows with name and resource_type)
-- `--sort <key>` - Sort order: `duration` (default, slowest first) or `start` (chronological)
+- `--sort <key>` - Sort order, default `duration`
 - `--top <n>` - Show top N entries only
-- `--failed-only` - Show only non-successful entries (excludes `success` and `pass`)
-- `--status <status>` - Filter by status, comma-separated (e.g. `error,warn`)
-- `--format <format>` - Output format: `json`, `table`, or `csv` (default: `json` non-TTY, `table` TTY)
+- `--failed-only` - Show only non-successful entries
+- `--status <status>` - Filter by status, comma-separated
+- `--adapter-text <text>` - Filter by normalized adapter text
+- `--format <format>` - Output format: `json`, `table`, or `csv`
 - `--target-dir <dir>` - Custom target directory
 - `--json` - Force JSON output
 - `--no-json` - Force human-readable output
 
-**Example JSON output:**
+### inspect inventory
 
-```json
-{
-  "total": 3,
-  "entries": [
-    {
-      "unique_id": "model.my_project.orders",
-      "name": "orders",
-      "resource_type": "model",
-      "status": "success",
-      "execution_time": 12.45,
-      "started_at": "2024-01-15T10:00:00Z",
-      "completed_at": "2024-01-15T10:00:12Z"
-    }
-  ]
-}
-```
-
----
-
-### search
-
-Discover dbt resources by name, tag, type, or free-text query. Acts as a starting point before running `deps`, `inventory`, or other commands.
-
-Requires: `manifest.json`
+List and filter dbt resources from the manifest. Use this when you already know you want a structured inventory view rather than fuzzy search.
 
 ```bash
-# Free-text search (substring matches on name, unique_id, tags, path)
-dbt-tools search orders
-
-# Inline key:value tokens in query
-dbt-tools search "type:model orders"
-dbt-tools search "tag:finance"
-dbt-tools search "package:core source:stripe"
-
-# Flag-based filters
-dbt-tools search --type model
-dbt-tools search --tag finance
-dbt-tools search --package my_project
-
-# Combine query with flags (flags take precedence over inline tokens)
-dbt-tools search orders --type model
-
-# Human-readable output (TTY default)
-dbt-tools search orders --no-json
-
-# Force JSON
-dbt-tools search orders --json
+dbt-tools inspect inventory
+dbt-tools inspect inventory --type model
+dbt-tools inspect inventory --type model,test
+dbt-tools inspect inventory --package my_project
+dbt-tools inspect inventory --tag finance
+dbt-tools inspect inventory --path models/staging
+dbt-tools inspect inventory --type model --tag finance --package my_project
+dbt-tools inspect inventory --type model --fields "entries"
+dbt-tools inspect inventory --json
 ```
 
-**Supported inline tokens in query:**
+### find resources
 
-- `type:<value>` — filter by resource type
-- `package:<value>` — filter by package
-- `tag:<value>` — filter by tag
-- `owner:<value>` / `source:<value>` — matched as plain text terms
-
-**Options:**
-
-- `[query]` - Free-text search query with optional `key:value` tokens
-- `[manifest-path]` - Path to manifest.json (defaults to `./target/manifest.json`)
-- `--type <type>` - Filter by resource type(s), comma-separated
-- `--package <package>` - Filter by package name
-- `--tag <tag>` - Filter by tag(s), comma-separated
-- `--path <path>` - Filter by file path substring
-- `--fields <fields>` - Comma-separated fields to include
-- `--target-dir <dir>` - Custom target directory
-- `--json` - Force JSON output
-- `--no-json` - Force human-readable output
-
-**Example JSON output:**
-
-```json
-{
-  "query": "orders",
-  "total": 2,
-  "results": [
-    {
-      "unique_id": "model.my_project.orders",
-      "resource_type": "model",
-      "name": "orders",
-      "package_name": "my_project",
-      "path": "models/marts/orders.sql"
-    }
-  ]
-}
-```
-
----
-
-### status / freshness
-
-Report dbt artifact presence, file modification times, and analysis readiness. `freshness` is an alias for `status`.
-
-This command does **not** parse artifact content — it only checks the filesystem. It is safe to run even when artifacts are missing or invalid.
+Discover dbt resources by name, tag, type, or free-text query. Use this when you need to find a likely resource before running a more specific command.
 
 ```bash
-# Check default ./target directory
-dbt-tools status
-
-# Custom target directory
-dbt-tools status --target-dir ./custom-target
-
-# JSON output (machine-readable)
-dbt-tools status --json
-
-# Freshness alias
-dbt-tools freshness
-dbt-tools freshness --target-dir ./custom-target
+dbt-tools find resources orders
+dbt-tools find resources "type:model orders"
+dbt-tools find resources "tag:finance"
+dbt-tools find resources --type model
+dbt-tools find resources --tag finance
+dbt-tools find resources --package my_project
+dbt-tools find resources orders --type model
+dbt-tools find resources orders --no-json
+dbt-tools find resources orders --json
 ```
 
-**Readiness values:**
+### trace lineage
 
-| Value           | Meaning                                                                                         |
-| --------------- | ----------------------------------------------------------------------------------------------- |
-| `full`          | Both `manifest.json` and `run_results.json` are present. All commands available.                |
-| `manifest-only` | `manifest.json` found; `run_results.json` missing. `timeline` and `run-report` are unavailable. |
-| `unavailable`   | `manifest.json` not found. Most commands will fail.                                             |
-
-**Options:**
-
-- `--target-dir <dir>` - Custom target directory (defaults to `./target`)
-- `--json` - Force JSON output
-- `--no-json` - Force human-readable output
-
-**Example JSON output:**
-
-```json
-{
-  "target_dir": "./target",
-  "manifest": {
-    "path": "/project/target/manifest.json",
-    "exists": true,
-    "modified_at": "2024-01-15T10:00:00Z",
-    "age_seconds": 3600
-  },
-  "run_results": {
-    "path": "/project/target/run_results.json",
-    "exists": true,
-    "modified_at": "2024-01-15T10:01:00Z",
-    "age_seconds": 3540
-  },
-  "readiness": "full",
-  "latest_modified_at": "2024-01-15T10:01:00Z",
-  "age_seconds": 3540,
-  "summary": "All artifacts present. Manifest and execution analysis available."
-}
-```
-
-**Caveats:**
-
-- Remote artifact sources (S3, GCS) are not checked; only local filesystem paths are inspected.
-- Age values are computed at the time of the command, not relative to any dbt run.
-
----
-
-### schema
-
-Get machine-readable schema for commands (runtime introspection).
+Get upstream or downstream dependencies for a dbt resource.
 
 ```bash
-# Get schema for specific command
-dbt-tools schema deps
-
-# Get all command schemas
-dbt-tools schema
+dbt-tools trace lineage model.my_project.customers
+dbt-tools trace lineage model.my_project.customers --direction upstream
+dbt-tools trace lineage model.my_project.customers --depth 1
+dbt-tools trace lineage model.my_project.customers --format flat
+dbt-tools trace lineage model.my_project.customers --direction upstream --build-order
+dbt-tools trace lineage model.my_project.customers --fields "unique_id,name"
+dbt-tools trace lineage model.my_project.customers --manifest-path ./custom/manifest.json
 ```
 
-**Options:**
+### export graph
 
-- `[command]` - Command name (if omitted, returns all schemas)
-- `--json` - Force JSON output (always JSON by default)
+Export dependency graph in various formats, including focused subgraphs.
 
-**Use Cases:**
+```bash
+dbt-tools export graph
+dbt-tools export graph --format dot --output graph.dot
+dbt-tools export graph --format gexf --output graph.gexf
+dbt-tools export graph --format json --fields "name,resource_type"
+dbt-tools export graph --focus model.my_project.orders --focus-depth 2
+dbt-tools export graph --focus model.my_project.orders --focus-direction upstream
+dbt-tools export graph --target-dir ./custom-target
+```
 
-- Discover available commands and options at runtime
-- Understand argument requirements
-- Get example usage for each command
+### check artifacts
 
----
+Report dbt artifact presence, file modification times, and analysis readiness. This command does **not** parse artifact content; it inspects the filesystem only.
 
-## Default Directory Behavior
+```bash
+dbt-tools check artifacts
+dbt-tools check artifacts --target-dir ./custom-target
+dbt-tools check artifacts --json
+```
 
-All commands default to the `./target` directory where dbt stores artifacts:
+Readiness values:
 
-- `manifest.json` → `./target/manifest.json`
-- `run_results.json` → `./target/run_results.json`
+| Value           | Meaning                                                                                                             |
+| :-------------- | :------------------------------------------------------------------------------------------------------------------ |
+| `full`          | Both `manifest.json` and `run_results.json` are present. All analysis commands are available.                       |
+| `manifest-only` | `manifest.json` is present and `run_results.json` is missing. `inspect run` and `inspect timeline` are unavailable. |
+| `unavailable`   | `manifest.json` is not found. Most analysis commands will fail.                                                     |
 
-Override with:
+### describe schema
 
-- `--target-dir <directory>` flag
-- `DBT_TOOLS_TARGET_DIR` environment variable (legacy: `DBT_TARGET_DIR`, `DBT_TARGET`)
+Get machine-readable schema for the full command tree or a specific command path.
 
----
-
-## JSON Output
-
-The CLI automatically outputs JSON when stdout is not a TTY (non-interactive environments):
-
-- **Non-TTY (agents/pipes)**: JSON output by default
-- **TTY (interactive)**: Human-readable output by default
-- Use `--json` to force JSON
-- Use `--no-json` to force human-readable
-
----
+```bash
+dbt-tools describe schema
+dbt-tools describe schema inspect
+dbt-tools describe schema inspect run
+dbt-tools describe schema trace lineage
+```
 
 ## Field Filtering
 
-Use `--fields` to limit response size and reduce context window usage. Supported in `summary`, `deps`, `graph` (JSON), `run-report`, `inventory`, and `search`.
+Use `--fields` to limit response size and reduce context window usage. Supported in `inspect summary`, `inspect run`, `inspect inventory`, `find resources`, `trace lineage`, and JSON mode of `export graph`.
 
 ```bash
-# Only return specific fields
-dbt-tools deps model.my_project.customers --fields "unique_id,name"
-
-# Supports nested fields
-dbt-tools deps model.my_project.customers --fields "unique_id,name,attributes.resource_type"
+dbt-tools trace lineage model.my_project.customers --fields "unique_id,name"
+dbt-tools inspect summary --fields "total_nodes,total_edges"
 ```
 
----
+## Patterns For Agents And Automation
 
-## Input Validation
-
-The CLI validates all inputs to prevent common mistakes:
-
-- **Path traversals**: Rejects `../` and `..\` patterns
-- **Control characters**: Rejects invisible characters (< 0x20 except `\n`, `\r`, `\t`)
-- **Resource IDs**: Rejects embedded query params (`?`, `#`) and URL-encoded strings (`%`)
-- **Pre-encoded URLs**: Rejects patterns like `%2e%2e` (encoded `..`)
-
-**Common mistakes to avoid:**
-
-- `model.x?fields=name` — embedded query param
-- `model%2ex` — pre-encoded
-- `../../.ssh` — path traversal
-- `model.my_project.customers` — correct
-
----
-
-## Error Handling
-
-Errors are formatted as JSON in non-TTY environments:
-
-```json
-{
-  "error": "ValidationError",
-  "code": "VALIDATION_ERROR",
-  "message": "Resource ID contains invalid characters",
-  "details": {
-    "field": "resource_id"
-  }
-}
-```
-
-**Common Error Codes:**
-
-- `VALIDATION_ERROR`: Input validation failed
-- `FILE_NOT_FOUND`: Artifact file not found
-- `PARSE_ERROR`: Failed to parse JSON
-- `UNSUPPORTED_VERSION`: Unsupported dbt version
-- `UNKNOWN_ERROR`: Other errors
-
----
-
-## Automation and agent workflows
-
-The same patterns help **scripts and CI** and **coding agents** (e.g. discover resources, then query deps with minimal fields).
-
-1. **Run `status` first** to check which artifacts are available before running analysis commands.
-2. **Use `search` to discover resources** before running `deps` or `inventory`.
-3. **Use field filtering** on large outputs to keep JSON payloads small.
-4. **Use default `./target` directory** unless you have a specific reason not to.
-5. **Validate resource IDs** before querying (use schema introspection if unsure).
-6. **Handle errors programmatically** using error codes in non-interactive environments.
-7. **Use schema introspection** to discover command capabilities at runtime.
-
-Compose with other tooling as needed (e.g. warehouse job metadata, CI environment variables, or separate analysis of warehouse query logs)—`dbt-tools` stays artifact-grounded and does not execute warehouse queries.
-
----
-
-## Examples
-
-```bash
-# Check artifact readiness before doing any analysis
-dbt-tools status
-
-# Find a resource before querying its deps
-dbt-tools search orders --json | jq '.results[0].unique_id'
-
-# List all models with the finance tag
-dbt-tools inventory --type model --tag finance
-
-# Find downstream dependencies
-dbt-tools deps model.my_project.customers
-
-# Find upstream dependencies with minimal output
-dbt-tools deps model.my_project.customers --direction upstream --fields "unique_id"
-
-# Execution timeline (slowest 10 nodes)
-dbt-tools timeline --top 10
-
-# Failed executions only
-dbt-tools timeline --failed-only
-
-# Export full graph for visualization
-dbt-tools graph --format dot --output graph.dot
-
-# Export focused subgraph around one node
-dbt-tools graph --focus model.my_project.orders --focus-depth 2 --format dot --output orders_subgraph.dot
-
-# Aggregated execution report with critical path
-dbt-tools run-report
-
-# Get command schema
-dbt-tools schema deps | jq '.options[] | select(.name == "--direction")'
-```
-
----
-
-## Environment Variables
-
-- `DBT_TOOLS_TARGET_DIR` - Override default target directory (defaults to `./target`; legacy: `DBT_TARGET_DIR`, `DBT_TARGET`)
-
----
-
-## Development
-
-```bash
-pnpm build
-pnpm test
-```
-
-See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for the full developer guide.
-
----
-
-## License
-
-The `@dbt-tools/*` packages use a **custom source-available license**; they are **not** OSI "open source." The following is a **short summary** — the binding terms are in the **`LICENSE`** file at the root of each published npm package (`package.json` uses `SEE LICENSE IN LICENSE`).
-
-- **You may** use and modify the software for **personal use** and for **internal use** within your organization for your own business purposes, **provided** you do not offer a **commercial service** where the software (or a derivative intended to replace or substantially replicate the published `@dbt-tools/*` packages) is a material part of the value you sell or deliver to third parties (for example hosted access, resale, or client production work centered on operating the software — see `LICENSE` for definitions).
-- **You may not**, without **prior written permission** from the copyright holder, offer such a **commercial service**, or **publish** the software or that kind of derivative to a **package registry** (npm, GitHub Packages, and similar) for third-party consumption.
-- **Dependencies** such as **`dbt-artifacts-parser`** remain under **their own** licenses (**Apache-2.0** for that library). This license does not override them.
+- Run `dbt-tools check artifacts` first to see which artifacts are available.
+- Use `dbt-tools find resources` before `dbt-tools trace lineage` if the exact `unique_id` is unknown.
+- Prefer `--json` in automation and pair it with `--fields` when you only need a subset.
+- Use `dbt-tools describe schema ...` when option shapes are unclear at runtime.
+- Choose `inspect run` for aggregated execution health and `inspect timeline` for row-level investigation.

--- a/packages/dbt-tools/cli/src/cli.test.ts
+++ b/packages/dbt-tools/cli/src/cli.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { Command } from "commander";
 import {
   validateResourceId,
   validateSafePath,
@@ -10,6 +11,7 @@ import {
   getCommandSchema,
   getAllSchemas,
 } from "@dbt-tools/core";
+import { createProgram, run } from "./cli";
 
 describe("CLI Integration", () => {
   describe("Core service integration", () => {
@@ -30,69 +32,58 @@ describe("CLI Integration", () => {
   });
 
   describe("Command schema validation", () => {
-    it("should have schema for all commands", () => {
+    it("should have schema for all command families", () => {
       const schemas = getAllSchemas();
-      expect(schemas).toHaveProperty("summary");
-      expect(schemas).toHaveProperty("deps");
-      expect(schemas).toHaveProperty("graph");
-      expect(schemas).toHaveProperty("run-report");
-      expect(schemas).toHaveProperty("schema");
-      // New commands
-      expect(schemas).toHaveProperty("inventory");
-      expect(schemas).toHaveProperty("timeline");
-      expect(schemas).toHaveProperty("search");
-      expect(schemas).toHaveProperty("status");
-      expect(schemas).toHaveProperty("freshness");
+      expect(schemas.subcommands).toHaveProperty("inspect");
+      expect(schemas.subcommands).toHaveProperty("find");
+      expect(schemas.subcommands).toHaveProperty("trace");
+      expect(schemas.subcommands).toHaveProperty("export");
+      expect(schemas.subcommands).toHaveProperty("check");
+      expect(schemas.subcommands).toHaveProperty("describe");
     });
 
-    it("should have correct inventory schema", () => {
-      const schema = getCommandSchema("inventory");
+    it("should have correct inspect inventory schema", () => {
+      const schema = getCommandSchema("inspect inventory");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("inventory");
+      expect(schema?.command).toBe("inspect inventory");
       const typeOpt = schema?.options?.find((o) => o.name === "--type");
       expect(typeOpt).toBeDefined();
       const tagOpt = schema?.options?.find((o) => o.name === "--tag");
       expect(tagOpt).toBeDefined();
     });
 
-    it("should have correct timeline schema", () => {
-      const schema = getCommandSchema("timeline");
+    it("should have correct inspect timeline schema", () => {
+      const schema = getCommandSchema("inspect timeline");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("timeline");
+      expect(schema?.command).toBe("inspect timeline");
       const sortOpt = schema?.options?.find((o) => o.name === "--sort");
       expect(sortOpt?.type).toBe("enum");
       const topOpt = schema?.options?.find((o) => o.name === "--top");
       expect(topOpt?.type).toBe("number");
     });
 
-    it("should have correct search schema", () => {
-      const schema = getCommandSchema("search");
+    it("should have correct find resources schema", () => {
+      const schema = getCommandSchema("find resources");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("search");
+      expect(schema?.command).toBe("find resources");
       expect(schema?.arguments[0]?.name).toBe("query");
       expect(schema?.arguments[0]?.required).toBe(false);
     });
 
-    it("should have correct status schema", () => {
-      const schema = getCommandSchema("status");
+    it("should have correct check artifacts schema", () => {
+      const schema = getCommandSchema("check artifacts");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("status");
+      expect(schema?.command).toBe("check artifacts");
       const targetDirOpt = schema?.options?.find(
         (o) => o.name === "--target-dir",
       );
       expect(targetDirOpt).toBeDefined();
     });
 
-    it("freshness schema should have command = freshness", () => {
-      const schema = getCommandSchema("freshness");
+    it("should have correct trace lineage command schema", () => {
+      const schema = getCommandSchema("trace lineage");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("freshness");
-    });
-
-    it("should have correct deps command schema", () => {
-      const schema = getCommandSchema("deps");
-      expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("deps");
+      expect(schema?.command).toBe("trace lineage");
       expect(schema?.arguments.length).toBeGreaterThan(0);
       expect(schema?.arguments[0]?.name).toBe("resource-id");
       expect(schema?.arguments[0]?.required).toBe(true);
@@ -112,10 +103,10 @@ describe("CLI Integration", () => {
       expect(fieldOpt?.type).toBe("string");
     });
 
-    it("should have correct graph command schema with field-level", () => {
-      const schema = getCommandSchema("graph");
+    it("should have correct export graph command schema with field-level", () => {
+      const schema = getCommandSchema("export graph");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("graph");
+      expect(schema?.command).toBe("export graph");
 
       const fieldLevelOpt = schema?.options?.find(
         (o) => o.name === "--field-level",
@@ -130,10 +121,10 @@ describe("CLI Integration", () => {
       expect(catalogOpt?.type).toBe("string");
     });
 
-    it("should have run-report schema with bottleneck options", () => {
-      const schema = getCommandSchema("run-report");
+    it("should have inspect run schema with bottleneck options", () => {
+      const schema = getCommandSchema("inspect run");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("run-report");
+      expect(schema?.command).toBe("inspect run");
 
       const bottlenecksOpt = schema?.options?.find(
         (o) => o.name === "--bottlenecks",
@@ -155,6 +146,53 @@ describe("CLI Integration", () => {
     });
   });
 
+  describe("Program construction", () => {
+    it("creates a root program with the expected task families", () => {
+      const program = createProgram();
+      const subcommandNames = program.commands.map((command) => command.name());
+      expect(subcommandNames).toEqual([
+        "inspect",
+        "find",
+        "trace",
+        "export",
+        "check",
+        "describe",
+      ]);
+    });
+
+    it("creates nested inspect subcommands", () => {
+      const program = createProgram();
+      const inspect = program.commands.find(
+        (command) => command.name() === "inspect",
+      );
+      expect(inspect).toBeInstanceOf(Command);
+      expect(inspect?.commands.map((command) => command.name())).toEqual([
+        "summary",
+        "run",
+        "timeline",
+        "inventory",
+      ]);
+    });
+
+    it("fails legacy commands with a targeted migration message", () => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+        code?: string | number | null,
+      ) => {
+        throw new Error(`exit:${code}`);
+      }) as typeof process.exit);
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      expect(() => run(["node", "dbt-tools", "deps"])).toThrow("exit:1");
+      expect(errorSpy).toHaveBeenCalled();
+      expect(errorSpy.mock.calls[0]?.[0]).toContain("trace lineage");
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
   describe("Input validation patterns", () => {
     it("should validate resource IDs correctly", () => {
       expect(() =>
@@ -169,7 +207,7 @@ describe("CLI Integration", () => {
       expect(() => validateSafePath("../../.ssh")).toThrow();
     });
 
-    it("should reject invalid depth (NaN / non-integer) for deps", () => {
+    it("should reject invalid depth (NaN / non-integer) for lineage", () => {
       expect(() => validateDepth(undefined)).not.toThrow();
       expect(() => validateDepth(1)).not.toThrow();
       expect(() => validateDepth(Number.NaN)).toThrow("Invalid depth");
@@ -180,7 +218,7 @@ describe("CLI Integration", () => {
   });
 
   describe("Output formatting", () => {
-    it("should format deps output correctly", () => {
+    it("should format lineage output correctly", () => {
       const result = {
         resource_id: "model.test.example",
         direction: "downstream" as const,

--- a/packages/dbt-tools/cli/src/cli.ts
+++ b/packages/dbt-tools/cli/src/cli.ts
@@ -32,7 +32,18 @@ import {
 } from "./cli-actions";
 import { CLI_PACKAGE_VERSION } from "./version";
 
-const program = new Command();
+const LEGACY_COMMAND_SUGGESTIONS: Record<string, string> = {
+  summary: "inspect summary",
+  "run-report": "inspect run",
+  timeline: "inspect timeline",
+  inventory: "inspect inventory",
+  search: "find resources",
+  deps: "trace lineage",
+  graph: "export graph",
+  status: "check artifacts",
+  freshness: "check artifacts",
+  schema: "describe schema",
+};
 
 /** CLI option/argument description constants (avoid no-duplicate-string) */
 const ARG_MANIFEST_PATH = "[manifest-path]";
@@ -50,18 +61,13 @@ const OPT_FIELDS = "--fields <fields>";
 const DESC_FIELDS = "Comma-separated list of fields to include";
 const OPT_FORMAT = "--format <format>";
 
-program
-  .name("dbt-tools")
-  .description("Command-line interface for dbt artifact analysis")
-  .version(CLI_PACKAGE_VERSION);
-
 /**
  * Handle errors with proper formatting
  */
-function handleError(error: unknown, isTTY: boolean): void {
+function handleError(error: unknown, tty: boolean): never {
   const formatted = ErrorHandler.formatError(
     error instanceof Error ? error : new Error(String(error)),
-    isTTY,
+    tty,
   );
 
   if (typeof formatted === "string") {
@@ -112,239 +118,129 @@ function tryApplyFieldLevelLineageToGraph(
   }
 }
 
-/**
- * Summary command: Basic summary of project structure
- */
-program
-  .command("summary")
-  .description("Provide summary statistics for dbt manifest")
-  .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action(
-    (
-      manifestPath: string | undefined,
-      options: {
-        targetDir?: string;
-        fields?: string;
-        json?: boolean;
-        noJson?: boolean;
-      },
-    ) => {
-      try {
-        // Resolve artifact paths
-        const paths = resolveArtifactPaths(
-          manifestPath,
-          undefined,
-          options.targetDir,
-        );
+function addSharedJsonOptions(command: Command): Command {
+  return command.option(OPT_JSON, DESC_JSON).option(OPT_NO_JSON, DESC_NO_JSON);
+}
 
-        // Validate path
-        validateSafePath(paths.manifest);
+function configureProgram(program: Command): Command {
+  return program
+    .name("dbt-tools")
+    .description("Command-line interface for dbt artifact analysis")
+    .version(CLI_PACKAGE_VERSION)
+    .showSuggestionAfterError()
+    .showHelpAfterError();
+}
 
-        // Load manifest
-        const manifest = loadManifest(paths.manifest);
-        const graph = new ManifestGraph(manifest);
-        let summary = graph.getSummary();
+function registerInspectCommands(program: Command): void {
+  const inspect = program
+    .command("inspect")
+    .description("Inspect dbt artifacts and derived analysis views");
 
-        // Apply field filtering if requested
-        if (options.fields) {
-          summary = FieldFilter.filterFields(
-            summary,
-            options.fields,
-          ) as typeof summary;
-        }
-
-        // Format output
-        const useJson = shouldOutputJSON(options.json, options.noJson);
-
-        if (useJson) {
-          console.log(formatOutput(summary, true));
-        } else {
-          console.log(formatSummary(summary));
-        }
-      } catch (error) {
-        handleError(error, isTTY());
-      }
-    },
-  );
-
-/**
- * Graph export command: Export graph in various formats.
- * Supports optional subgraph focus via --focus, --focus-depth, --focus-direction,
- * and --resource-types.
- */
-program
-  .command("graph")
-  .description("Export dependency graph")
-  .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
-  .option(OPT_FORMAT, DESC_GRAPH_FORMAT, DEFAULT_GRAPH_FORMAT)
-  .option("--output <path>", "Output file path (default: stdout)")
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_FIELDS, DESC_FIELDS)
-  .option("--field-level", "Include field-level (column-level) lineage")
-  .option("--catalog-path <path>", "Path to catalog.json file")
-  .option(
-    "--focus <resource-id>",
-    "Focus on a single node; exports its subgraph only",
+  addSharedJsonOptions(
+    inspect
+      .command("summary")
+      .description("Manifest-level summary statistics")
+      .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
+      .option(OPT_TARGET_DIR, DESC_TARGET_DIR),
   )
-  .option(
-    "--focus-depth <number>",
-    "Max traversal depth for --focus (default: unlimited)",
-    parseInt,
-  )
-  .option(
-    "--focus-direction <direction>",
-    "Traversal direction for --focus: upstream, downstream, or both (default: both)",
-    "both",
-  )
-  .option(
-    "--resource-types <types>",
-    "Comma-separated resource types to include (filters nodes when --focus is set)",
-  )
-  .action(
-    (
-      manifestPath: string | undefined,
-      options: {
-        format?: string;
-        output?: string;
-        targetDir?: string;
-        fields?: string;
-        fieldLevel?: boolean;
-        catalogPath?: string;
-        focus?: string;
-        focusDepth?: number;
-        focusDirection?: string;
-        resourceTypes?: string;
-      },
-    ) => {
-      try {
-        // Resolve artifact paths
-        const paths = resolveArtifactPaths(
-          manifestPath,
-          undefined,
-          options.targetDir,
-          options.catalogPath,
-        );
-
-        // Validate path
-        validateSafePath(paths.manifest);
-        if (options.output) {
-          validateSafePath(options.output);
-        }
-
-        const focusDirection = (options.focusDirection ?? "both").toLowerCase();
-        if (!["upstream", "downstream", "both"].includes(focusDirection)) {
-          throw new Error(
-            `--focus-direction must be one of: upstream, downstream, both`,
+    .option(OPT_FIELDS, DESC_FIELDS)
+    .action(
+      (
+        manifestPath: string | undefined,
+        options: {
+          targetDir?: string;
+          fields?: string;
+          json?: boolean;
+          noJson?: boolean;
+        },
+      ) => {
+        try {
+          const paths = resolveArtifactPaths(
+            manifestPath,
+            undefined,
+            options.targetDir,
           );
+
+          validateSafePath(paths.manifest);
+
+          const manifest = loadManifest(paths.manifest);
+          const graph = new ManifestGraph(manifest);
+          let summary = graph.getSummary();
+
+          if (options.fields) {
+            summary = FieldFilter.filterFields(
+              summary,
+              options.fields,
+            ) as typeof summary;
+          }
+
+          const useJson = shouldOutputJSON(options.json, options.noJson);
+
+          if (useJson) {
+            console.log(formatOutput(summary, true));
+          } else {
+            console.log(formatSummary(summary));
+          }
+        } catch (error) {
+          handleError(error, isTTY());
         }
+      },
+    );
 
-        if (options.focusDepth !== undefined) {
-          validateDepth(options.focusDepth);
-        }
-
-        // Load manifest
-        const manifest = loadManifest(paths.manifest);
-        const graph = new ManifestGraph(manifest);
-
-        // Enhance with field-level lineage if requested
-        if (options.fieldLevel && paths.catalog) {
-          tryApplyFieldLevelLineageToGraph(graph, manifest, paths.catalog);
-        }
-
-        let targetGraph = graph.getGraph();
-
-        // Apply subgraph focus if requested
-        if (options.focus) {
-          validateResourceId(options.focus);
-          const allowedTypes = options.resourceTypes
-            ? new Set(
-                options.resourceTypes
-                  .split(",")
-                  .map((t) => t.trim().toLowerCase())
-                  .filter(Boolean),
-              )
-            : undefined;
-          targetGraph = graph.buildSubgraph(
-            options.focus,
-            focusDirection as "upstream" | "downstream" | "both",
-            options.focusDepth,
-            allowedTypes,
-          );
-        }
-
-        const output = exportGraphToFormat(targetGraph, {
-          format: options.format,
-          output: options.output,
-          fields: options.fields,
-        });
-        writeGraphOutput(output, options.output);
-      } catch (error) {
-        handleError(error, isTTY());
-      }
-    },
-  );
-
-/**
- * Run report command: Execution summary from run_results.json
- */
-program
-  .command("run-report")
-  .description("Generate execution report from run_results.json")
-  .argument(
-    "[run-results-path]",
-    "Path to run_results.json file (defaults to ./target/run_results.json)",
-  )
-  .argument(
-    ARG_MANIFEST_PATH,
-    "Path to manifest.json file (optional, for critical path)",
-  )
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_FIELDS, DESC_FIELDS)
-  .option("--bottlenecks", "Include bottleneck section in report")
-  .option(
-    "--bottlenecks-top <n>",
-    "Top N slowest nodes (default: 10 when --bottlenecks)",
-    parseInt,
-  )
-  .option(
-    "--bottlenecks-threshold <s>",
-    "Nodes exceeding s seconds (alternative to top-N)",
-    parseFloat,
-  )
-  .option(
-    "--adapter-summary",
-    "Include adapter_response aggregates (and default top-5 slot/bytes in human output)",
-  )
-  .option(
-    "--adapter-top-by <metric>",
-    "Rank nodes by adapter metric: bytes_processed | bytes_billed | slot_ms | rows_affected | rows_inserted | rows_updated | rows_deleted | rows_duplicated",
-  )
-  .option(
-    "--adapter-top-n <n>",
-    "Top N for --adapter-top-by (default: 10)",
-    parseInt,
-  )
-  .option(
-    "--adapter-min-bytes <n>",
-    "When using --adapter-top-by, require bytes_processed >= n",
-    parseFloat,
-  )
-  .option(
-    "--adapter-min-slot-ms <n>",
-    "When using --adapter-top-by, require slot_ms >= n",
-    parseFloat,
-  )
-  .option(
-    "--adapter-min-rows-affected <n>",
-    "When using --adapter-top-by, require rows_affected >= n",
-    parseFloat,
-  )
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action(
+  addSharedJsonOptions(
+    inspect
+      .command("run")
+      .description("Aggregated execution report from run_results.json")
+      .argument(
+        "[run-results-path]",
+        "Path to run_results.json file (defaults to ./target/run_results.json)",
+      )
+      .argument(
+        ARG_MANIFEST_PATH,
+        "Path to manifest.json file (optional, for critical path)",
+      )
+      .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+      .option(OPT_FIELDS, DESC_FIELDS)
+      .option("--bottlenecks", "Include bottleneck section in report")
+      .option(
+        "--bottlenecks-top <n>",
+        "Top N slowest nodes (default: 10 when --bottlenecks)",
+        parseInt,
+      )
+      .option(
+        "--bottlenecks-threshold <s>",
+        "Nodes exceeding s seconds (alternative to top-N)",
+        parseFloat,
+      )
+      .option(
+        "--adapter-summary",
+        "Include adapter_response aggregates (and default top-5 slot/bytes in human output)",
+      )
+      .option(
+        "--adapter-top-by <metric>",
+        "Rank nodes by adapter metric: bytes_processed | bytes_billed | slot_ms | rows_affected | rows_inserted | rows_updated | rows_deleted | rows_duplicated",
+      )
+      .option(
+        "--adapter-top-n <n>",
+        "Top N for --adapter-top-by (default: 10)",
+        parseInt,
+      )
+      .option(
+        "--adapter-min-bytes <n>",
+        "When using --adapter-top-by, require bytes_processed >= n",
+        parseFloat,
+      )
+      .option(
+        "--adapter-min-slot-ms <n>",
+        "When using --adapter-top-by, require slot_ms >= n",
+        parseFloat,
+      )
+      .option(
+        "--adapter-min-rows-affected <n>",
+        "When using --adapter-top-by, require rows_affected >= n",
+        parseFloat,
+      ),
+  ).action(
     (
       runResultsPath: string | undefined,
       manifestPath: string | undefined,
@@ -392,7 +288,6 @@ program
             ),
             isTTY(),
           );
-          return;
         }
         adapterTopBy = options.adapterTopBy as
           | "bytes_processed"
@@ -428,127 +323,39 @@ program
     },
   );
 
-/**
- * Deps command: Get upstream or downstream dependencies
- */
-program
-  .command("deps")
-  .description("Get upstream or downstream dependencies for a dbt resource")
-  .argument(
-    "<resource-id>",
-    "Unique ID of the dbt resource (e.g., model.my_project.customers)",
-  )
-  .option(
-    "--direction <direction>",
-    "Direction: upstream or downstream",
-    "downstream",
-  )
-  .option("--manifest-path <path>", "Path to manifest.json file")
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_FIELDS, DESC_FIELDS)
-  .option("--field <name>", "Specific field (column) to trace dependencies for")
-  .option("--catalog-path <path>", "Path to catalog.json file")
-  .option(
-    "--depth <number>",
-    "Max traversal depth; 1 = immediate neighbors, omit for all levels",
-    parseInt,
-  )
-  .option(OPT_FORMAT, "Output structure: flat list or nested tree", "tree")
-  .option(
-    "--build-order",
-    "Output upstream dependencies in topological build order (only with --direction upstream)",
-  )
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action(
-    (
-      resourceId: string,
-      options: {
-        direction?: string;
-        manifestPath?: string;
-        targetDir?: string;
-        fields?: string;
-        field?: string;
-        catalogPath?: string;
-        depth?: number;
-        format?: string;
-        buildOrder?: boolean;
-        json?: boolean;
-        noJson?: boolean;
-      },
-    ) => depsAction(resourceId, options, handleError, isTTY),
-  );
-
-/**
- * Inventory command: List and filter dbt resources from manifest
- */
-program
-  .command("inventory")
-  .description("List and filter dbt resources from manifest")
-  .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
-  .option("--type <type>", "Filter by resource type(s), comma-separated")
-  .option("--package <package>", "Filter by package name")
-  .option("--tag <tag>", "Filter by tag(s), comma-separated")
-  .option("--path <path>", "Filter by file path substring")
-  .option(OPT_FIELDS, DESC_FIELDS)
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action(
-    (
-      manifestPath: string | undefined,
-      options: {
-        type?: string;
-        package?: string;
-        tag?: string;
-        path?: string;
-        fields?: string;
-        targetDir?: string;
-        json?: boolean;
-        noJson?: boolean;
-      },
-    ) => inventoryAction(manifestPath, options, handleError, isTTY),
-  );
-
-/**
- * Timeline command: Per-node execution entries from run_results.json
- */
-program
-  .command("timeline")
-  .description(
-    "Show per-node execution timeline from run_results.json (row-level, unlike run-report)",
-  )
-  .argument(
-    "[run-results-path]",
-    "Path to run_results.json (defaults to ./target/run_results.json)",
-  )
-  .argument(
-    "[manifest-path]",
-    "Path to manifest.json (optional, enriches entries with name and type)",
-  )
-  .option(
-    "--sort <key>",
-    "Sort key: duration | start | query_id | adapter_code | adapter_message | bytes_processed | bytes_billed | slot_ms | rows_affected | rows_inserted | rows_updated | rows_deleted | rows_duplicated",
-    "duration",
-  )
-  .option("--top <n>", "Show top N entries only", parseInt)
-  .option("--failed-only", "Show only non-successful executions")
-  .option(
-    "--status <status>",
-    "Filter by status (comma-separated, e.g. error,warn)",
-  )
-  .option(
-    "--adapter-text <text>",
-    "Filter by normalized adapter text (query ID, code, message, location, project)",
-  )
-  .option(
-    OPT_FORMAT,
-    "Output format: json (default non-TTY), table (default TTY), csv",
-  )
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action(
+  addSharedJsonOptions(
+    inspect
+      .command("timeline")
+      .description("Row-level execution entries from run_results.json")
+      .argument(
+        "[run-results-path]",
+        "Path to run_results.json (defaults to ./target/run_results.json)",
+      )
+      .argument(
+        "[manifest-path]",
+        "Path to manifest.json (optional, enriches entries with name and type)",
+      )
+      .option(
+        "--sort <key>",
+        "Sort key: duration | start | query_id | adapter_code | adapter_message | bytes_processed | bytes_billed | slot_ms | rows_affected | rows_inserted | rows_updated | rows_deleted | rows_duplicated",
+        "duration",
+      )
+      .option("--top <n>", "Show top N entries only", parseInt)
+      .option("--failed-only", "Show only non-successful executions")
+      .option(
+        "--status <status>",
+        "Filter by status (comma-separated, e.g. error,warn)",
+      )
+      .option(
+        "--adapter-text <text>",
+        "Filter by normalized adapter text (query ID, code, message, location, project)",
+      )
+      .option(
+        OPT_FORMAT,
+        "Output format: json (default non-TTY), table (default TTY), csv",
+      )
+      .option(OPT_TARGET_DIR, DESC_TARGET_DIR),
+  ).action(
     (
       runResultsPath: string | undefined,
       manifestPath: string | undefined,
@@ -567,26 +374,55 @@ program
       timelineAction(runResultsPath, manifestPath, options, handleError, isTTY),
   );
 
-/**
- * Search command: Fast manifest search across dbt entities
- */
-program
-  .command("search")
-  .description("Search for dbt resources by name, tag, type, or free text")
-  .argument(
-    "[query]",
-    "Search query; supports key:value tokens like type:model tag:finance",
-  )
-  .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
-  .option("--type <type>", "Filter by resource type(s), comma-separated")
-  .option("--package <package>", "Filter by package name")
-  .option("--tag <tag>", "Filter by tag(s), comma-separated")
-  .option("--path <path>", "Filter by file path substring")
-  .option(OPT_FIELDS, DESC_FIELDS)
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action(
+  addSharedJsonOptions(
+    inspect
+      .command("inventory")
+      .description("Enumerate and filter manifest resources")
+      .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
+      .option("--type <type>", "Filter by resource type(s), comma-separated")
+      .option("--package <package>", "Filter by package name")
+      .option("--tag <tag>", "Filter by tag(s), comma-separated")
+      .option("--path <path>", "Filter by file path substring")
+      .option(OPT_FIELDS, DESC_FIELDS)
+      .option(OPT_TARGET_DIR, DESC_TARGET_DIR),
+  ).action(
+    (
+      manifestPath: string | undefined,
+      options: {
+        type?: string;
+        package?: string;
+        tag?: string;
+        path?: string;
+        fields?: string;
+        targetDir?: string;
+        json?: boolean;
+        noJson?: boolean;
+      },
+    ) => inventoryAction(manifestPath, options, handleError, isTTY),
+  );
+}
+
+function registerFindCommands(program: Command): void {
+  const find = program
+    .command("find")
+    .description("Find likely matches before narrowing into a focused command");
+
+  addSharedJsonOptions(
+    find
+      .command("resources")
+      .description("Discover likely resource matches from text and filters")
+      .argument(
+        "[query]",
+        "Search query; supports key:value tokens like type:model tag:finance",
+      )
+      .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
+      .option("--type <type>", "Filter by resource type(s), comma-separated")
+      .option("--package <package>", "Filter by package name")
+      .option("--tag <tag>", "Filter by tag(s), comma-separated")
+      .option("--path <path>", "Filter by file path substring")
+      .option(OPT_FIELDS, DESC_FIELDS)
+      .option(OPT_TARGET_DIR, DESC_TARGET_DIR),
+  ).action(
     (
       query: string | undefined,
       manifestPath: string | undefined,
@@ -602,66 +438,267 @@ program
       },
     ) => searchAction(query, manifestPath, options, handleError, isTTY),
   );
+}
 
-/**
- * Status command: Report artifact presence, freshness, and readiness
- */
-program
-  .command("status")
-  .description(
-    "Report dbt artifact presence, modification times, and analysis readiness",
-  )
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action((options: { targetDir?: string; json?: boolean; noJson?: boolean }) =>
-    statusAction(options, handleError, isTTY),
+function registerTraceCommands(program: Command): void {
+  const trace = program
+    .command("trace")
+    .description("Trace lineage and traversal-based relationships");
+
+  addSharedJsonOptions(
+    trace
+      .command("lineage")
+      .description("Dependency traversal from a dbt resource")
+      .argument(
+        "<resource-id>",
+        "Unique ID of the dbt resource (e.g., model.my_project.customers)",
+      )
+      .option(
+        "--direction <direction>",
+        "Direction: upstream or downstream",
+        "downstream",
+      )
+      .option("--manifest-path <path>", "Path to manifest.json file")
+      .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+      .option(OPT_FIELDS, DESC_FIELDS)
+      .option(
+        "--field <name>",
+        "Specific field (column) to trace dependencies for",
+      )
+      .option("--catalog-path <path>", "Path to catalog.json file")
+      .option(
+        "--depth <number>",
+        "Max traversal depth; 1 = immediate neighbors, omit for all levels",
+        parseInt,
+      )
+      .option(OPT_FORMAT, "Output structure: flat list or nested tree", "tree")
+      .option(
+        "--build-order",
+        "Output upstream dependencies in topological build order (only with --direction upstream)",
+      ),
+  ).action(
+    (
+      resourceId: string,
+      options: {
+        direction?: string;
+        manifestPath?: string;
+        targetDir?: string;
+        fields?: string;
+        field?: string;
+        catalogPath?: string;
+        depth?: number;
+        format?: string;
+        buildOrder?: boolean;
+        json?: boolean;
+        noJson?: boolean;
+      },
+    ) => depsAction(resourceId, options, handleError, isTTY),
   );
+}
 
-/**
- * Freshness command: Alias for status with freshness framing
- */
-program
-  .command("freshness")
-  .description("Alias for status – shows artifact recency and readiness")
-  .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
-  .option(OPT_JSON, DESC_JSON)
-  .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action((options: { targetDir?: string; json?: boolean; noJson?: boolean }) =>
-    statusAction(options, handleError, isTTY),
-  );
+function registerExportCommands(program: Command): void {
+  const exportCommand = program
+    .command("export")
+    .description("Export dbt-derived structures for downstream tooling");
 
-/**
- * Schema command: Get command schema for introspection
- */
-program
-  .command("schema")
-  .description("Get machine-readable schema for a command")
-  .argument(
-    "[command]",
-    "Command name (if omitted, returns all command schemas)",
-  )
-  .option("--json", "Force JSON output (always JSON by default)")
-  .action((command: string | undefined, _options: { json?: boolean }) => {
-    try {
-      let result: unknown;
+  exportCommand
+    .command("graph")
+    .description("Export dependency graph")
+    .argument(ARG_MANIFEST_PATH, DESC_MANIFEST)
+    .option(OPT_FORMAT, DESC_GRAPH_FORMAT, DEFAULT_GRAPH_FORMAT)
+    .option("--output <path>", "Output file path (default: stdout)")
+    .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+    .option(OPT_FIELDS, DESC_FIELDS)
+    .option("--field-level", "Include field-level (column-level) lineage")
+    .option("--catalog-path <path>", "Path to catalog.json file")
+    .option(
+      "--focus <resource-id>",
+      "Focus on a single node; exports its subgraph only",
+    )
+    .option(
+      "--focus-depth <number>",
+      "Max traversal depth for --focus (default: unlimited)",
+      parseInt,
+    )
+    .option(
+      "--focus-direction <direction>",
+      "Traversal direction for --focus: upstream, downstream, or both (default: both)",
+      "both",
+    )
+    .option(
+      "--resource-types <types>",
+      "Comma-separated resource types to include (filters nodes when --focus is set)",
+    )
+    .action(
+      (
+        manifestPath: string | undefined,
+        options: {
+          format?: string;
+          output?: string;
+          targetDir?: string;
+          fields?: string;
+          fieldLevel?: boolean;
+          catalogPath?: string;
+          focus?: string;
+          focusDepth?: number;
+          focusDirection?: string;
+          resourceTypes?: string;
+        },
+      ) => {
+        try {
+          const paths = resolveArtifactPaths(
+            manifestPath,
+            undefined,
+            options.targetDir,
+            options.catalogPath,
+          );
 
-      if (command) {
-        const schema = getCommandSchema(command);
-        if (!schema) {
-          throw new Error(`Unknown command: ${command}`);
+          validateSafePath(paths.manifest);
+          if (options.output) {
+            validateSafePath(options.output);
+          }
+
+          const focusDirection = (
+            options.focusDirection ?? "both"
+          ).toLowerCase();
+          if (!["upstream", "downstream", "both"].includes(focusDirection)) {
+            throw new Error(
+              `--focus-direction must be one of: upstream, downstream, both`,
+            );
+          }
+
+          if (options.focusDepth !== undefined) {
+            validateDepth(options.focusDepth);
+          }
+
+          const manifest = loadManifest(paths.manifest);
+          const graph = new ManifestGraph(manifest);
+
+          if (options.fieldLevel && paths.catalog) {
+            tryApplyFieldLevelLineageToGraph(graph, manifest, paths.catalog);
+          }
+
+          let targetGraph = graph.getGraph();
+
+          if (options.focus) {
+            validateResourceId(options.focus);
+            const allowedTypes = options.resourceTypes
+              ? new Set(
+                  options.resourceTypes
+                    .split(",")
+                    .map((t) => t.trim().toLowerCase())
+                    .filter(Boolean),
+                )
+              : undefined;
+            targetGraph = graph.buildSubgraph(
+              options.focus,
+              focusDirection as "upstream" | "downstream" | "both",
+              options.focusDepth,
+              allowedTypes,
+            );
+          }
+
+          const output = exportGraphToFormat(targetGraph, {
+            format: options.format,
+            output: options.output,
+            fields: options.fields,
+          });
+          writeGraphOutput(output, options.output);
+        } catch (error) {
+          handleError(error, isTTY());
         }
-        result = schema;
-      } else {
-        result = getAllSchemas();
-      }
+      },
+    );
+}
 
-      // Schema command always outputs JSON
-      console.log(formatOutput(result, true));
-    } catch (error) {
-      handleError(error, isTTY());
-    }
-  });
+function registerCheckCommands(program: Command): void {
+  const check = program
+    .command("check")
+    .description("Check artifact availability and operational readiness");
 
-// Parse command line arguments
-program.parse();
+  addSharedJsonOptions(
+    check
+      .command("artifacts")
+      .description("Artifact presence, recency, and readiness")
+      .option(OPT_TARGET_DIR, DESC_TARGET_DIR),
+  ).action(
+    (options: { targetDir?: string; json?: boolean; noJson?: boolean }) =>
+      statusAction(options, handleError, isTTY),
+  );
+}
+
+function registerDescribeCommands(program: Command): void {
+  const describe = program
+    .command("describe")
+    .description("Describe commands for human and machine discovery");
+
+  describe
+    .command("schema")
+    .description(
+      "Machine-readable schema for the full command tree or a specific path",
+    )
+    .argument(
+      "[command-path...]",
+      "Command path segments (if omitted, returns the full command tree)",
+    )
+    .option("--json", "Force JSON output (always JSON by default)")
+    .action(
+      (commandPath: string[] | undefined, _options: { json?: boolean }) => {
+        try {
+          const result =
+            commandPath && commandPath.length > 0
+              ? getCommandSchema(commandPath)
+              : getAllSchemas();
+
+          if (!result) {
+            throw new Error(`Unknown command path: ${commandPath?.join(" ")}`);
+          }
+
+          console.log(formatOutput(result, true));
+        } catch (error) {
+          handleError(error, isTTY());
+        }
+      },
+    );
+}
+
+function findLegacyCommandSuggestion(argv: string[]): string | null {
+  const firstToken = argv.find((token) => !token.startsWith("-"));
+  if (!firstToken) {
+    return null;
+  }
+
+  return LEGACY_COMMAND_SUGGESTIONS[firstToken] ?? null;
+}
+
+export function createProgram(): Command {
+  const program = configureProgram(new Command());
+
+  registerInspectCommands(program);
+  registerFindCommands(program);
+  registerTraceCommands(program);
+  registerExportCommands(program);
+  registerCheckCommands(program);
+  registerDescribeCommands(program);
+
+  return program;
+}
+
+export function run(argv = process.argv): void {
+  const suggestion = findLegacyCommandSuggestion(argv.slice(2));
+  if (suggestion) {
+    const attempted = argv.slice(2).find((token) => !token.startsWith("-"));
+    handleError(
+      new Error(
+        `Unknown command: ${attempted}. Use "dbt-tools ${suggestion}" instead.`,
+      ),
+      isTTY(),
+    );
+  }
+
+  createProgram().parse(argv);
+}
+
+if (require.main === module) {
+  run();
+}

--- a/packages/dbt-tools/core/src/introspection/schema-generator.test.ts
+++ b/packages/dbt-tools/core/src/introspection/schema-generator.test.ts
@@ -3,73 +3,60 @@ import { getCommandSchema, getAllSchemas } from "./schema-generator";
 
 describe("SchemaGenerator", () => {
   describe("getCommandSchema", () => {
-    it("should return schema for summary command", () => {
-      const schema = getCommandSchema("summary");
-      expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("summary");
-      expect(schema?.arguments).toBeInstanceOf(Array);
-      expect(schema?.options).toBeInstanceOf(Array);
+    it("returns the root schema tree", () => {
+      const schema = getAllSchemas();
+      expect(schema.kind).toBe("root");
+      expect(schema.path).toEqual([]);
+      expect(schema.subcommands).toHaveProperty("inspect");
+      expect(schema.subcommands).toHaveProperty("find");
+      expect(schema.subcommands).toHaveProperty("trace");
+      expect(schema.subcommands).toHaveProperty("export");
+      expect(schema.subcommands).toHaveProperty("check");
+      expect(schema.subcommands).toHaveProperty("describe");
     });
 
-    it("should return schema for deps command", () => {
-      const schema = getCommandSchema("deps");
+    it("returns schema for a command group path", () => {
+      const schema = getCommandSchema("inspect");
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("deps");
-      expect(schema?.arguments).toBeInstanceOf(Array);
-      expect(schema?.options).toBeInstanceOf(Array);
+      expect(schema?.kind).toBe("group");
+      expect(schema?.command).toBe("inspect");
+      expect(schema?.subcommands).toHaveProperty("summary");
+      expect(schema?.subcommands).toHaveProperty("run");
+    });
+
+    it("returns schema for a leaf command path", () => {
+      const schema = getCommandSchema("trace lineage");
+      expect(schema).not.toBeNull();
+      expect(schema?.kind).toBe("command");
+      expect(schema?.command).toBe("trace lineage");
       expect(schema?.arguments[0]?.name).toBe("resource-id");
       expect(schema?.arguments[0]?.required).toBe(true);
     });
 
-    it("should return schema for graph command", () => {
-      const schema = getCommandSchema("graph");
+    it("accepts array-based command path segments", () => {
+      const schema = getCommandSchema(["describe", "schema"]);
       expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("graph");
+      expect(schema?.command).toBe("describe schema");
+      expect(schema?.path).toEqual(["describe", "schema"]);
     });
 
-    it("should return schema for run-report command", () => {
-      const schema = getCommandSchema("run-report");
-      expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("run-report");
-    });
-
-    it("should return schema for schema command", () => {
-      const schema = getCommandSchema("schema");
-      expect(schema).not.toBeNull();
-      expect(schema?.command).toBe("schema");
-    });
-
-    it("should return null for invalid command", () => {
-      const schema = getCommandSchema("invalid-command");
+    it("returns null for an invalid command path", () => {
+      const schema = getCommandSchema("inspect invalid-command");
       expect(schema).toBeNull();
     });
   });
 
-  describe("getAllSchemas", () => {
-    it("should return all command schemas", () => {
-      const schemas = getAllSchemas();
-      expect(schemas).toHaveProperty("summary");
-      expect(schemas).toHaveProperty("deps");
-      expect(schemas).toHaveProperty("graph");
-      expect(schemas).toHaveProperty("run-report");
-      expect(schemas).toHaveProperty("schema");
-    });
-
-    it("should have complete schema structure for all commands", () => {
-      const schemas = getAllSchemas();
-      for (const [command, schema] of Object.entries(schemas)) {
-        expect(schema.command).toBe(command);
+  describe("schema structure", () => {
+    it("has complete schema structure for every node in the tree", () => {
+      const visit = (schema = getAllSchemas()): void => {
+        expect(schema.command).toBeTypeOf("string");
         expect(schema.description).toBeTruthy();
+        expect(schema.path).toBeInstanceOf(Array);
         expect(schema.arguments).toBeInstanceOf(Array);
         expect(schema.options).toBeInstanceOf(Array);
         expect(schema.output_format).toBeTruthy();
         expect(schema.example).toBeTruthy();
-      }
-    });
 
-    it("should have correct argument structure", () => {
-      const schemas = getAllSchemas();
-      for (const schema of Object.values(schemas)) {
         for (const arg of schema.arguments) {
           expect(arg).toHaveProperty("name");
           expect(arg).toHaveProperty("required");
@@ -78,12 +65,7 @@ describe("SchemaGenerator", () => {
           expect(typeof arg.required).toBe("boolean");
           expect(typeof arg.description).toBe("string");
         }
-      }
-    });
 
-    it("should have correct option structure", () => {
-      const schemas = getAllSchemas();
-      for (const schema of Object.values(schemas)) {
         for (const option of schema.options) {
           expect(option).toHaveProperty("name");
           expect(option).toHaveProperty("type");
@@ -92,27 +74,45 @@ describe("SchemaGenerator", () => {
           expect(typeof option.type).toBe("string");
           expect(typeof option.description).toBe("string");
         }
-      }
+
+        for (const child of Object.values(schema.subcommands ?? {})) {
+          visit(child);
+        }
+      };
+
+      visit();
     });
 
-    it("should have enum values for enum type options", () => {
-      const depsSchema = getCommandSchema("deps");
-      const directionOption = depsSchema?.options.find(
+    it("has enum values for trace lineage direction", () => {
+      const schema = getCommandSchema("trace lineage");
+      const directionOption = schema?.options.find(
         (opt) => opt.name === "--direction",
       );
       expect(directionOption?.type).toBe("enum");
       expect(directionOption?.values).toEqual(["upstream", "downstream"]);
     });
 
-    it("should have --format option for deps with flat and tree values", () => {
-      const depsSchema = getCommandSchema("deps");
-      const formatOption = depsSchema?.options.find(
+    it("has flat and tree format values for trace lineage", () => {
+      const schema = getCommandSchema("trace lineage");
+      const formatOption = schema?.options.find(
         (opt) => opt.name === "--format",
       );
       expect(formatOption).toBeDefined();
       expect(formatOption?.type).toBe("enum");
       expect(formatOption?.values).toEqual(["flat", "tree"]);
       expect(formatOption?.default).toBe("tree");
+    });
+
+    it("includes future-friendly grouped command families at the root", () => {
+      const root = getAllSchemas();
+      expect(Object.keys(root.subcommands ?? {})).toEqual([
+        "inspect",
+        "find",
+        "trace",
+        "export",
+        "check",
+        "describe",
+      ]);
     });
   });
 });

--- a/packages/dbt-tools/core/src/introspection/schema-generator.ts
+++ b/packages/dbt-tools/core/src/introspection/schema-generator.ts
@@ -1,8 +1,13 @@
 /**
- * Command schema definition for runtime introspection
+ * Command schema definition for runtime introspection.
+ *
+ * The schema is hierarchical so the CLI can expose both human-friendly
+ * grouped help and machine-readable discovery for command families and leaves.
  */
 export interface CommandSchema {
+  kind: "root" | "group" | "command";
   command: string;
+  path: string[];
   description: string;
   arguments: Array<{
     name: string;
@@ -18,6 +23,7 @@ export interface CommandSchema {
   }>;
   output_format: string;
   example: string;
+  subcommands?: Record<string, CommandSchema>;
 }
 
 const ARG_MANIFEST_PATH = "manifest-path";
@@ -39,48 +45,82 @@ const DESC_RUN_RESULTS_PATH =
 const DESC_MANIFEST_OPTIONAL =
   "Path to manifest.json file (optional, for critical path analysis)";
 
-function getSummarySchema(): CommandSchema {
+type SchemaOption = {
+  name: string;
+  type: string;
+  values?: string[];
+  default?: string;
+  description: string;
+};
+
+function createSchemaNode(
+  kind: "root" | "group" | "command",
+  path: string[],
+  description: string,
+  config: {
+    arguments?: CommandSchema["arguments"];
+    options?: CommandSchema["options"];
+    outputFormat?: string;
+    example?: string;
+    subcommands?: Record<string, CommandSchema>;
+  } = {},
+): CommandSchema {
   return {
-    command: "summary",
-    description: "Provide summary statistics for dbt manifest",
-    arguments: [
-      {
-        name: ARG_MANIFEST_PATH,
-        required: false,
-        description: DESC_MANIFEST_PATH,
-      },
-    ],
-    options: [
-      {
-        name: OPT_TARGET_DIR,
-        type: TYPE_STRING,
-        description: DESC_TARGET_DIR,
-      },
-      {
-        name: "--fields",
-        type: TYPE_STRING,
-        description: DESC_FIELDS,
-      },
-      {
-        name: OPT_JSON,
-        type: TYPE_BOOLEAN,
-        description: DESC_FORCE_JSON,
-      },
-      {
-        name: OPT_NO_JSON,
-        type: TYPE_BOOLEAN,
-        description: DESC_FORCE_HUMAN,
-      },
-    ],
-    output_format: OUTPUT_JSON_OR_HUMAN,
-    example: "dbt-tools summary",
+    kind,
+    command: path.join(" "),
+    path,
+    description,
+    arguments: config.arguments ?? [],
+    options: config.options ?? [],
+    output_format: config.outputFormat ?? "n/a",
+    example: config.example ?? `dbt-tools ${path.join(" ")}`.trim(),
+    subcommands: config.subcommands,
   };
 }
 
-function getGraphSchema(): CommandSchema {
-  return {
-    command: "graph",
-    description: "Export dependency graph in various formats",
+function getSummarySchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Provide manifest-level summary statistics",
+    {
+      arguments: [
+        {
+          name: ARG_MANIFEST_PATH,
+          required: false,
+          description: DESC_MANIFEST_PATH,
+        },
+      ],
+      options: [
+        {
+          name: OPT_TARGET_DIR,
+          type: TYPE_STRING,
+          description: DESC_TARGET_DIR,
+        },
+        {
+          name: "--fields",
+          type: TYPE_STRING,
+          description: DESC_FIELDS,
+        },
+        {
+          name: OPT_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_JSON,
+        },
+        {
+          name: OPT_NO_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_HUMAN,
+        },
+      ],
+      outputFormat: OUTPUT_JSON_OR_HUMAN,
+      example: "dbt-tools inspect summary",
+    },
+  );
+}
+
+function getGraphSchema(path: string[]): CommandSchema {
+  return createSchemaNode("command", path, "Export dependency graph", {
     arguments: [
       {
         name: ARG_MANIFEST_PATH,
@@ -146,107 +186,117 @@ function getGraphSchema(): CommandSchema {
           "Comma-separated resource types to keep in the subgraph (e.g. model,test); focus node is always included",
       },
     ],
-    output_format: "json, dot, or gexf",
-    example: "dbt-tools graph --focus model.my_project.orders --focus-depth 2",
-  };
+    outputFormat: "json, dot, or gexf",
+    example:
+      "dbt-tools export graph --focus model.my_project.orders --focus-depth 2",
+  });
 }
 
-function getRunReportSchema(): CommandSchema {
-  return {
-    command: "run-report",
-    description: "Generate execution report from run_results.json",
-    arguments: [
-      {
-        name: "run-results-path",
-        required: false,
-        description: DESC_RUN_RESULTS_PATH,
-      },
-      {
-        name: ARG_MANIFEST_PATH,
-        required: false,
-        description: DESC_MANIFEST_OPTIONAL,
-      },
-    ],
-    options: [
-      {
-        name: OPT_TARGET_DIR,
-        type: TYPE_STRING,
-        description: DESC_TARGET_DIR,
-      },
-      {
-        name: "--fields",
-        type: TYPE_STRING,
-        description: DESC_FIELDS,
-      },
-      {
-        name: "--bottlenecks",
-        type: TYPE_BOOLEAN,
-        description: "Include bottleneck section in report",
-      },
-      {
-        name: "--bottlenecks-top",
-        type: "number",
-        default: "10",
-        description: "Top N slowest nodes (default: 10 when --bottlenecks)",
-      },
-      {
-        name: "--bottlenecks-threshold",
-        type: "number",
-        description: "Nodes exceeding N seconds (alternative to top-N)",
-      },
-      {
-        name: "--adapter-summary",
-        type: TYPE_BOOLEAN,
-        description:
-          "Include adapter_response aggregates (human default top-5 slot/bytes)",
-      },
-      {
-        name: "--adapter-top-by",
-        type: TYPE_STRING,
-        values: ["bytes_processed", "slot_ms", "rows_affected"],
-        description: "Rank nodes by adapter metric",
-      },
-      {
-        name: "--adapter-top-n",
-        type: "number",
-        default: "10",
-        description: "Top N for --adapter-top-by",
-      },
-      {
-        name: "--adapter-min-bytes",
-        type: "number",
-        description: "With --adapter-top-by, require bytes_processed >= n",
-      },
-      {
-        name: "--adapter-min-slot-ms",
-        type: "number",
-        description: "With --adapter-top-by, require slot_ms >= n",
-      },
-      {
-        name: OPT_JSON,
-        type: TYPE_BOOLEAN,
-        description: DESC_FORCE_JSON,
-      },
-      {
-        name: OPT_NO_JSON,
-        type: TYPE_BOOLEAN,
-        description: DESC_FORCE_HUMAN,
-      },
-    ],
-    output_format: OUTPUT_JSON_OR_HUMAN,
-    example: "dbt-tools run-report --bottlenecks",
-  };
+function getRunReportSchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Inspect aggregated execution report from run_results.json",
+    {
+      arguments: [
+        {
+          name: "run-results-path",
+          required: false,
+          description: DESC_RUN_RESULTS_PATH,
+        },
+        {
+          name: ARG_MANIFEST_PATH,
+          required: false,
+          description: DESC_MANIFEST_OPTIONAL,
+        },
+      ],
+      options: [
+        {
+          name: OPT_TARGET_DIR,
+          type: TYPE_STRING,
+          description: DESC_TARGET_DIR,
+        },
+        {
+          name: "--fields",
+          type: TYPE_STRING,
+          description: DESC_FIELDS,
+        },
+        {
+          name: "--bottlenecks",
+          type: TYPE_BOOLEAN,
+          description: "Include bottleneck section in report",
+        },
+        {
+          name: "--bottlenecks-top",
+          type: "number",
+          default: "10",
+          description: "Top N slowest nodes (default: 10 when --bottlenecks)",
+        },
+        {
+          name: "--bottlenecks-threshold",
+          type: "number",
+          description: "Nodes exceeding N seconds (alternative to top-N)",
+        },
+        {
+          name: "--adapter-summary",
+          type: TYPE_BOOLEAN,
+          description:
+            "Include adapter_response aggregates (human default top-5 slot/bytes)",
+        },
+        {
+          name: "--adapter-top-by",
+          type: "enum",
+          values: [
+            "bytes_processed",
+            "bytes_billed",
+            "slot_ms",
+            "rows_affected",
+            "rows_inserted",
+            "rows_updated",
+            "rows_deleted",
+            "rows_duplicated",
+          ],
+          description: "Rank nodes by adapter metric",
+        },
+        {
+          name: "--adapter-top-n",
+          type: "number",
+          default: "10",
+          description: "Top N for --adapter-top-by",
+        },
+        {
+          name: "--adapter-min-bytes",
+          type: "number",
+          description: "With --adapter-top-by, require bytes_processed >= n",
+        },
+        {
+          name: "--adapter-min-slot-ms",
+          type: "number",
+          description: "With --adapter-top-by, require slot_ms >= n",
+        },
+        {
+          name: "--adapter-min-rows-affected",
+          type: "number",
+          description: "With --adapter-top-by, require rows_affected >= n",
+        },
+        {
+          name: OPT_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_JSON,
+        },
+        {
+          name: OPT_NO_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_HUMAN,
+        },
+      ],
+      outputFormat: OUTPUT_JSON_OR_HUMAN,
+      example: "dbt-tools inspect run --bottlenecks",
+    },
+  );
 }
 
-type SchemaOption = {
-  name: string;
-  type: string;
-  values?: string[];
-  default?: string;
-  description: string;
-};
-
-function getDepsSchemaOptions(): SchemaOption[] {
+function getLineageSchemaOptions(): SchemaOption[] {
   return [
     {
       name: "--direction",
@@ -305,260 +355,410 @@ function getDepsSchemaOptions(): SchemaOption[] {
   ];
 }
 
-function getDepsSchema(): CommandSchema {
-  return {
-    command: "deps",
-    description: "Get upstream or downstream dependencies for a dbt resource",
-    arguments: [
-      {
-        name: "resource-id",
-        required: true,
-        description:
-          "Unique ID of the dbt resource (e.g., model.my_project.customers)",
-      },
-    ],
-    options: getDepsSchemaOptions(),
-    output_format: OUTPUT_JSON_OR_HUMAN,
-    example: "dbt-tools deps model.my_project.customers --direction downstream",
-  };
-}
-
-function getSchemaCommandSchema(): CommandSchema {
-  return {
-    command: "schema",
-    description: "Get machine-readable schema for a command",
-    arguments: [
-      {
-        name: "command",
-        required: false,
-        description: "Command name (if omitted, returns all command schemas)",
-      },
-    ],
-    options: [
-      {
-        name: OPT_JSON,
-        type: TYPE_BOOLEAN,
-        description: DESC_FORCE_JSON,
-      },
-    ],
-    output_format: "json",
-    example: "dbt-tools schema deps",
-  };
-}
-
-/**
- * Get schema for a specific command
- */
-export function getCommandSchema(command: string): CommandSchema | null {
-  const schemas = getAllSchemas();
-  return schemas[command] || null;
-}
-
-function getInventorySchema(): CommandSchema {
-  return {
-    command: "inventory",
-    description: "List and filter dbt resources from manifest",
-    arguments: [
-      {
-        name: ARG_MANIFEST_PATH,
-        required: false,
-        description: DESC_MANIFEST_PATH,
-      },
-    ],
-    options: [
-      {
-        name: "--type",
-        type: TYPE_STRING,
-        description:
-          "Filter by resource type(s), comma-separated (e.g. model,test)",
-      },
-      {
-        name: "--package",
-        type: TYPE_STRING,
-        description: "Filter by package name",
-      },
-      {
-        name: "--tag",
-        type: TYPE_STRING,
-        description: "Filter by tag(s), comma-separated",
-      },
-      {
-        name: "--path",
-        type: TYPE_STRING,
-        description: "Filter by file path substring",
-      },
-      {
-        name: "--fields",
-        type: TYPE_STRING,
-        description: DESC_FIELDS,
-      },
-      {
-        name: OPT_TARGET_DIR,
-        type: TYPE_STRING,
-        description: DESC_TARGET_DIR,
-      },
-      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
-      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
-    ],
-    output_format: OUTPUT_JSON_OR_HUMAN,
-    example: "dbt-tools inventory --type model --tag finance",
-  };
-}
-
-function getTimelineSchema(): CommandSchema {
-  return {
-    command: "timeline",
-    description:
-      "Show per-node execution timeline from run_results.json (row-level entries, unlike run-report)",
-    arguments: [
-      {
-        name: "run-results-path",
-        required: false,
-        description: DESC_RUN_RESULTS_PATH,
-      },
-      {
-        name: ARG_MANIFEST_PATH,
-        required: false,
-        description: DESC_MANIFEST_OPTIONAL,
-      },
-    ],
-    options: [
-      {
-        name: "--sort",
-        type: "enum",
-        values: ["duration", "start"],
-        default: "duration",
-        description: "Sort order for entries",
-      },
-      {
-        name: "--top",
-        type: "number",
-        description: "Show top N entries only",
-      },
-      {
-        name: "--failed-only",
-        type: TYPE_BOOLEAN,
-        description: "Show only non-successful executions",
-      },
-      {
-        name: "--status",
-        type: TYPE_STRING,
-        description: "Filter by status (comma-separated, e.g. error,warn)",
-      },
-      {
-        name: "--format",
-        type: "enum",
-        values: ["json", "table", "csv"],
-        description: "Output format (default: json in non-TTY, table in TTY)",
-      },
-      {
-        name: OPT_TARGET_DIR,
-        type: TYPE_STRING,
-        description: DESC_TARGET_DIR,
-      },
-      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
-      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
-    ],
-    output_format: "json, table, or csv",
-    example: "dbt-tools timeline --sort duration --top 20 --failed-only",
-  };
-}
-
-function getSearchSchema(): CommandSchema {
-  return {
-    command: "search",
-    description: "Search for dbt resources by name, tag, type, or free text",
-    arguments: [
-      {
-        name: "query",
-        required: false,
-        description:
-          "Search query; supports key:value tokens like type:model tag:finance",
-      },
-      {
-        name: ARG_MANIFEST_PATH,
-        required: false,
-        description: DESC_MANIFEST_PATH,
-      },
-    ],
-    options: [
-      {
-        name: "--type",
-        type: TYPE_STRING,
-        description: "Filter by resource type(s), comma-separated",
-      },
-      {
-        name: "--package",
-        type: TYPE_STRING,
-        description: "Filter by package name",
-      },
-      {
-        name: "--tag",
-        type: TYPE_STRING,
-        description: "Filter by tag(s), comma-separated",
-      },
-      {
-        name: "--path",
-        type: TYPE_STRING,
-        description: "Filter by file path substring",
-      },
-      {
-        name: "--fields",
-        type: TYPE_STRING,
-        description: DESC_FIELDS,
-      },
-      {
-        name: OPT_TARGET_DIR,
-        type: TYPE_STRING,
-        description: DESC_TARGET_DIR,
-      },
-      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
-      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
-    ],
-    output_format: OUTPUT_JSON_OR_HUMAN,
-    example: "dbt-tools search orders",
-  };
-}
-
-function getStatusSchema(): CommandSchema {
-  return {
-    command: "status",
-    description:
-      "Report dbt artifact presence, modification times, and analysis readiness",
-    arguments: [],
-    options: [
-      {
-        name: OPT_TARGET_DIR,
-        type: TYPE_STRING,
-        description: DESC_TARGET_DIR,
-      },
-      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
-      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
-    ],
-    output_format: OUTPUT_JSON_OR_HUMAN,
-    example: "dbt-tools status --target-dir ./target",
-  };
-}
-
-/**
- * Get all command schemas
- */
-export function getAllSchemas(): Record<string, CommandSchema> {
-  return {
-    summary: getSummarySchema(),
-    graph: getGraphSchema(),
-    "run-report": getRunReportSchema(),
-    deps: getDepsSchema(),
-    inventory: getInventorySchema(),
-    timeline: getTimelineSchema(),
-    search: getSearchSchema(),
-    status: getStatusSchema(),
-    freshness: {
-      ...getStatusSchema(),
-      command: "freshness",
-      description: "Alias for status – shows artifact recency and readiness",
-      example: "dbt-tools freshness --target-dir ./target",
+function getLineageSchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Trace upstream or downstream lineage from a dbt resource",
+    {
+      arguments: [
+        {
+          name: "resource-id",
+          required: true,
+          description:
+            "Unique ID of the dbt resource (e.g., model.my_project.customers)",
+        },
+      ],
+      options: getLineageSchemaOptions(),
+      outputFormat: OUTPUT_JSON_OR_HUMAN,
+      example:
+        "dbt-tools trace lineage model.my_project.customers --direction downstream",
     },
-    schema: getSchemaCommandSchema(),
-  };
+  );
+}
+
+function getInventorySchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Inspect inventory by enumerating and filtering manifest resources",
+    {
+      arguments: [
+        {
+          name: ARG_MANIFEST_PATH,
+          required: false,
+          description: DESC_MANIFEST_PATH,
+        },
+      ],
+      options: [
+        {
+          name: "--type",
+          type: TYPE_STRING,
+          description:
+            "Filter by resource type(s), comma-separated (e.g. model,test)",
+        },
+        {
+          name: "--package",
+          type: TYPE_STRING,
+          description: "Filter by package name",
+        },
+        {
+          name: "--tag",
+          type: TYPE_STRING,
+          description: "Filter by tag(s), comma-separated",
+        },
+        {
+          name: "--path",
+          type: TYPE_STRING,
+          description: "Filter by file path substring",
+        },
+        {
+          name: "--fields",
+          type: TYPE_STRING,
+          description: DESC_FIELDS,
+        },
+        {
+          name: OPT_TARGET_DIR,
+          type: TYPE_STRING,
+          description: DESC_TARGET_DIR,
+        },
+        { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+        {
+          name: OPT_NO_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_HUMAN,
+        },
+      ],
+      outputFormat: OUTPUT_JSON_OR_HUMAN,
+      example: "dbt-tools inspect inventory --type model --tag finance",
+    },
+  );
+}
+
+function getTimelineSchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Inspect row-level execution timeline entries from run_results.json",
+    {
+      arguments: [
+        {
+          name: "run-results-path",
+          required: false,
+          description: DESC_RUN_RESULTS_PATH,
+        },
+        {
+          name: ARG_MANIFEST_PATH,
+          required: false,
+          description: DESC_MANIFEST_OPTIONAL,
+        },
+      ],
+      options: [
+        {
+          name: "--sort",
+          type: "enum",
+          values: [
+            "duration",
+            "start",
+            "query_id",
+            "adapter_code",
+            "adapter_message",
+            "bytes_processed",
+            "bytes_billed",
+            "slot_ms",
+            "rows_affected",
+            "rows_inserted",
+            "rows_updated",
+            "rows_deleted",
+            "rows_duplicated",
+          ],
+          default: "duration",
+          description: "Sort order for entries",
+        },
+        {
+          name: "--top",
+          type: "number",
+          description: "Show top N entries only",
+        },
+        {
+          name: "--failed-only",
+          type: TYPE_BOOLEAN,
+          description: "Show only non-successful executions",
+        },
+        {
+          name: "--status",
+          type: TYPE_STRING,
+          description: "Filter by status (comma-separated, e.g. error,warn)",
+        },
+        {
+          name: "--adapter-text",
+          type: TYPE_STRING,
+          description:
+            "Filter by normalized adapter text (query ID, code, message, location, project)",
+        },
+        {
+          name: "--format",
+          type: "enum",
+          values: ["json", "table", "csv"],
+          description: "Output format (default: json in non-TTY, table in TTY)",
+        },
+        {
+          name: OPT_TARGET_DIR,
+          type: TYPE_STRING,
+          description: DESC_TARGET_DIR,
+        },
+        { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+        {
+          name: OPT_NO_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_HUMAN,
+        },
+      ],
+      outputFormat: "json, table, or csv",
+      example:
+        "dbt-tools inspect timeline --sort duration --top 20 --failed-only",
+    },
+  );
+}
+
+function getResourcesSchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Discover likely resource matches from free text and filters",
+    {
+      arguments: [
+        {
+          name: "query",
+          required: false,
+          description:
+            "Search query; supports key:value tokens like type:model tag:finance",
+        },
+        {
+          name: ARG_MANIFEST_PATH,
+          required: false,
+          description: DESC_MANIFEST_PATH,
+        },
+      ],
+      options: [
+        {
+          name: "--type",
+          type: TYPE_STRING,
+          description: "Filter by resource type(s), comma-separated",
+        },
+        {
+          name: "--package",
+          type: TYPE_STRING,
+          description: "Filter by package name",
+        },
+        {
+          name: "--tag",
+          type: TYPE_STRING,
+          description: "Filter by tag(s), comma-separated",
+        },
+        {
+          name: "--path",
+          type: TYPE_STRING,
+          description: "Filter by file path substring",
+        },
+        {
+          name: "--fields",
+          type: TYPE_STRING,
+          description: DESC_FIELDS,
+        },
+        {
+          name: OPT_TARGET_DIR,
+          type: TYPE_STRING,
+          description: DESC_TARGET_DIR,
+        },
+        { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+        {
+          name: OPT_NO_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_HUMAN,
+        },
+      ],
+      outputFormat: OUTPUT_JSON_OR_HUMAN,
+      example: "dbt-tools find resources orders",
+    },
+  );
+}
+
+function getArtifactsSchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Check artifact presence, recency, and analysis readiness",
+    {
+      options: [
+        {
+          name: OPT_TARGET_DIR,
+          type: TYPE_STRING,
+          description: DESC_TARGET_DIR,
+        },
+        { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+        {
+          name: OPT_NO_JSON,
+          type: TYPE_BOOLEAN,
+          description: DESC_FORCE_HUMAN,
+        },
+      ],
+      outputFormat: OUTPUT_JSON_OR_HUMAN,
+      example: "dbt-tools check artifacts --target-dir ./target",
+    },
+  );
+}
+
+function getDescribeSchemaSchema(path: string[]): CommandSchema {
+  return createSchemaNode(
+    "command",
+    path,
+    "Get machine-readable schema for the full command tree or a specific path",
+    {
+      arguments: [
+        {
+          name: "command-path",
+          required: false,
+          description:
+            "Optional command path segments (e.g. inspect run, trace lineage)",
+        },
+      ],
+      options: [
+        {
+          name: OPT_JSON,
+          type: TYPE_BOOLEAN,
+          description: "Force JSON output (always JSON by default)",
+        },
+      ],
+      outputFormat: "json",
+      example: "dbt-tools describe schema inspect run",
+    },
+  );
+}
+
+function buildSchemaTree(): CommandSchema {
+  const inspectPath = ["inspect"];
+  const findPath = ["find"];
+  const tracePath = ["trace"];
+  const exportPath = ["export"];
+  const checkPath = ["check"];
+  const describePath = ["describe"];
+
+  return createSchemaNode(
+    "root",
+    [],
+    "Command-line interface for dbt artifact analysis",
+    {
+      example: "dbt-tools --help",
+      subcommands: {
+        inspect: createSchemaNode(
+          "group",
+          inspectPath,
+          "Inspect dbt artifacts and derived analysis views",
+          {
+            subcommands: {
+              summary: getSummarySchema([...inspectPath, "summary"]),
+              run: getRunReportSchema([...inspectPath, "run"]),
+              timeline: getTimelineSchema([...inspectPath, "timeline"]),
+              inventory: getInventorySchema([...inspectPath, "inventory"]),
+            },
+          },
+        ),
+        find: createSchemaNode(
+          "group",
+          findPath,
+          "Find likely matches before narrowing into a focused command",
+          {
+            subcommands: {
+              resources: getResourcesSchema([...findPath, "resources"]),
+            },
+          },
+        ),
+        trace: createSchemaNode(
+          "group",
+          tracePath,
+          "Trace lineage and traversal-based relationships",
+          {
+            subcommands: {
+              lineage: getLineageSchema([...tracePath, "lineage"]),
+            },
+          },
+        ),
+        export: createSchemaNode(
+          "group",
+          exportPath,
+          "Export dbt-derived structures for downstream tooling",
+          {
+            subcommands: {
+              graph: getGraphSchema([...exportPath, "graph"]),
+            },
+          },
+        ),
+        check: createSchemaNode(
+          "group",
+          checkPath,
+          "Check artifact availability and operational readiness",
+          {
+            subcommands: {
+              artifacts: getArtifactsSchema([...checkPath, "artifacts"]),
+            },
+          },
+        ),
+        describe: createSchemaNode(
+          "group",
+          describePath,
+          "Describe commands for human and machine discovery",
+          {
+            subcommands: {
+              schema: getDescribeSchemaSchema([...describePath, "schema"]),
+            },
+          },
+        ),
+      },
+    },
+  );
+}
+
+function normalizeCommandPath(commandPath: string | string[]): string[] {
+  const raw =
+    typeof commandPath === "string"
+      ? commandPath.trim().split(/\s+/).filter(Boolean)
+      : commandPath;
+
+  if (raw[0] === "dbt-tools") {
+    return raw.slice(1);
+  }
+
+  return raw;
+}
+
+/**
+ * Get schema for a specific command or command group path.
+ */
+export function getCommandSchema(
+  commandPath: string | string[],
+): CommandSchema | null {
+  const normalizedPath = normalizeCommandPath(commandPath);
+  const root = getAllSchemas();
+
+  if (normalizedPath.length === 0) {
+    return root;
+  }
+
+  let current: CommandSchema | undefined = root;
+  for (const segment of normalizedPath) {
+    current = current.subcommands?.[segment];
+    if (!current) {
+      return null;
+    }
+  }
+
+  return current;
+}
+
+/**
+ * Get the full hierarchical command schema tree.
+ */
+export function getAllSchemas(): CommandSchema {
+  return buildSchemaTree();
 }


### PR DESCRIPTION
- Updated the CLI to adopt a task-oriented hierarchy, improving command discovery for both users and automation agents.
- Removed legacy flat commands and replaced them with structured subcommands under `inspect`, `find`, `trace`, `export`, `check`, and `describe`.
- Enhanced command schema generation to support hierarchical structures, allowing for better introspection and documentation.
- Improved error handling to provide targeted migration messages for deprecated commands.
- Updated documentation to reflect changes in command usage and structure.

These changes aim to streamline the user experience and improve the maintainability of the CLI interface.