### PR TITLE
Implement artifact discovery and selectable artifact candidate loading (CLI, web, UI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tokens:sync": "node scripts/sync-css-tokens-to-ts.mjs && prettier --write packages/dbt-tools/web/src/constants/themeColors.generated.ts",
     "tokens:check": "pnpm tokens:sync && git diff --exit-code packages/dbt-tools/web/src/constants/themeColors.generated.ts",
     "dev:web": "pnpm --filter @dbt-tools/web dev",
-    "format": "pnpm format:trunk && pnpm format:eslint && pnpm format:prettier",
+    "format": "pnpm format:trunk || pnpm format:without-trunk",
     "format:all": "pnpm format:trunk-all",
     "format:eslint": "eslint . --fix",
     "format:prettier": "prettier --write .",

--- a/packages/dbt-tools/cli/README.md
+++ b/packages/dbt-tools/cli/README.md
@@ -52,6 +52,7 @@ pnpm add -g @dbt-tools/cli
 - **Timeline**: Inspect per-node execution timing (row-level, unlike `run-report`)
 - **Search**: Discover resources by name, tag, type, or free-text query
 - **Status / Freshness**: Check if artifacts are present and how recent they are
+- **Directory/prefix discovery**: `status`/`freshness` can discover candidate artifact sets from a single `--location` using `--source-type` and optional `--candidate`.
 - **Subgraph focus**: Export a focused subgraph for any node via `graph --focus`
 
 ---
@@ -444,6 +445,8 @@ This command does **not** parse artifact content — it only checks the filesyst
 ```bash
 # Check default ./target directory
 dbt-tools status
+# Discover from a single location and choose candidate explicitly when needed
+dbt-tools status --source-type local --location ./target --candidate current
 
 # Custom target directory
 dbt-tools status --target-dir ./custom-target
@@ -629,6 +632,8 @@ Compose with other tooling as needed (e.g. warehouse job metadata, CI environmen
 ```bash
 # Check artifact readiness before doing any analysis
 dbt-tools status
+# Discover from a single location and choose candidate explicitly when needed
+dbt-tools status --source-type local --location ./target --candidate current
 
 # Find a resource before querying its deps
 dbt-tools search orders --json | jq '.results[0].unique_id'

--- a/packages/dbt-tools/cli/src/cli.ts
+++ b/packages/dbt-tools/cli/src/cli.ts
@@ -49,6 +49,12 @@ const DEFAULT_GRAPH_FORMAT = "json";
 const OPT_FIELDS = "--fields <fields>";
 const DESC_FIELDS = "Comma-separated list of fields to include";
 const OPT_FORMAT = "--format <format>";
+const OPT_SOURCE_TYPE = "--source-type <type>";
+const DESC_SOURCE_TYPE = "Artifact source type: local | s3 | gcs";
+const OPT_LOCATION = "--location <location>";
+const DESC_LOCATION = "Artifact directory/prefix location";
+const OPT_CANDIDATE = "--candidate <id>";
+const DESC_CANDIDATE = "Candidate set ID when multiple are discovered";
 
 program
   .name("dbt-tools")
@@ -612,10 +618,20 @@ program
     "Report dbt artifact presence, modification times, and analysis readiness",
   )
   .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option(OPT_SOURCE_TYPE, DESC_SOURCE_TYPE, "local")
+  .option(OPT_LOCATION, DESC_LOCATION)
+  .option(OPT_CANDIDATE, DESC_CANDIDATE)
   .option(OPT_JSON, DESC_JSON)
   .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action((options: { targetDir?: string; json?: boolean; noJson?: boolean }) =>
-    statusAction(options, handleError, isTTY),
+  .action(
+    async (options: {
+      targetDir?: string;
+      sourceType?: "local" | "s3" | "gcs";
+      location?: string;
+      candidate?: string;
+      json?: boolean;
+      noJson?: boolean;
+    }) => statusAction(options, handleError, isTTY),
   );
 
 /**
@@ -625,10 +641,20 @@ program
   .command("freshness")
   .description("Alias for status – shows artifact recency and readiness")
   .option(OPT_TARGET_DIR, DESC_TARGET_DIR)
+  .option(OPT_SOURCE_TYPE, DESC_SOURCE_TYPE, "local")
+  .option(OPT_LOCATION, DESC_LOCATION)
+  .option(OPT_CANDIDATE, DESC_CANDIDATE)
   .option(OPT_JSON, DESC_JSON)
   .option(OPT_NO_JSON, DESC_NO_JSON)
-  .action((options: { targetDir?: string; json?: boolean; noJson?: boolean }) =>
-    statusAction(options, handleError, isTTY),
+  .action(
+    async (options: {
+      targetDir?: string;
+      sourceType?: "local" | "s3" | "gcs";
+      location?: string;
+      candidate?: string;
+      json?: boolean;
+      noJson?: boolean;
+    }) => statusAction(options, handleError, isTTY),
   );
 
 /**

--- a/packages/dbt-tools/cli/src/status-action.test.ts
+++ b/packages/dbt-tools/cli/src/status-action.test.ts
@@ -24,11 +24,11 @@ describe("statusAction", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("reports manifest-only readiness when only manifest exists", () => {
+  it("reports manifest-only readiness when only manifest exists", async () => {
     // Create a manifest.json but no run_results.json in tmpDir
     fs.writeFileSync(path.join(tmpDir, "manifest.json"), "{}");
 
-    statusAction({ targetDir: tmpDir, json: true }, handleError, isTTY);
+    await statusAction({ targetDir: tmpDir, json: true }, handleError, isTTY);
 
     const output = consoleLogSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(output) as StatusResult;
@@ -39,11 +39,11 @@ describe("statusAction", () => {
     expect(parsed.readiness).toBe("manifest-only");
   });
 
-  it("reports full readiness when both artifacts exist", () => {
+  it("reports full readiness when both artifacts exist", async () => {
     fs.writeFileSync(path.join(tmpDir, "manifest.json"), "{}");
     fs.writeFileSync(path.join(tmpDir, "run_results.json"), "{}");
 
-    statusAction({ targetDir: tmpDir, json: true }, handleError, isTTY);
+    await statusAction({ targetDir: tmpDir, json: true }, handleError, isTTY);
 
     const output = consoleLogSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(output) as StatusResult;
@@ -54,8 +54,8 @@ describe("statusAction", () => {
     expect(parsed.readiness).toBe("full");
   });
 
-  it("outputs required JSON fields", () => {
-    statusAction({ json: true }, handleError, isTTY);
+  it("outputs required JSON fields", async () => {
+    await statusAction({ json: true }, handleError, isTTY);
 
     const output = consoleLogSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(output) as StatusResult;
@@ -77,12 +77,12 @@ describe("statusAction", () => {
     expect(parsed.sources).toHaveProperty("exists");
   });
 
-  it("reports unavailable when target dir has no artifacts", () => {
+  it("reports unavailable when target dir has no artifacts", async () => {
     const nonexistentTarget = path.join(
       os.tmpdir(),
       `dbt-tools-status-missing-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
     );
-    statusAction(
+    await statusAction(
       { targetDir: nonexistentTarget, json: true },
       handleError,
       isTTY,
@@ -97,8 +97,12 @@ describe("statusAction", () => {
     expect(parsed.sources.exists).toBe(false);
   });
 
-  it("outputs human-readable format", () => {
-    statusAction({ targetDir: tmpDir, noJson: true }, handleError, () => true);
+  it("outputs human-readable format", async () => {
+    await statusAction(
+      { targetDir: tmpDir, noJson: true },
+      handleError,
+      () => true,
+    );
 
     const output = consoleLogSpy.mock.calls[0][0] as string;
     expect(output).toContain("dbt Artifact Status");
@@ -109,16 +113,16 @@ describe("statusAction", () => {
     expect(output).toContain("Readiness:");
   });
 
-  it("rejects path traversal in targetDir", () => {
-    expect(() =>
+  it("rejects path traversal in targetDir", async () => {
+    await expect(
       statusAction({ targetDir: "../../etc" }, handleError, isTTY),
-    ).toThrow();
+    ).rejects.toThrow(/Path traversal detected/);
   });
 
-  it("includes modification time when artifact exists", () => {
+  it("includes modification time when artifact exists", async () => {
     fs.writeFileSync(path.join(tmpDir, "manifest.json"), "{}");
 
-    statusAction({ targetDir: tmpDir, json: true }, handleError, isTTY);
+    await statusAction({ targetDir: tmpDir, json: true }, handleError, isTTY);
 
     const output = consoleLogSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(output) as StatusResult;

--- a/packages/dbt-tools/cli/src/status-action.ts
+++ b/packages/dbt-tools/cli/src/status-action.ts
@@ -5,7 +5,11 @@
 import * as fs from "fs";
 import * as path from "path";
 import {
+  discoverArtifactCandidateSets,
+  discoverLocalArtifactFiles,
   resolveArtifactPaths,
+  selectArtifactCandidate,
+  validateRequiredArtifacts,
   validateSafePath,
   formatOutput,
   shouldOutputJSON,
@@ -13,6 +17,9 @@ import {
 
 export type StatusOptions = {
   targetDir?: string;
+  sourceType?: "local" | "s3" | "gcs";
+  location?: string;
+  candidate?: string;
   json?: boolean;
   noJson?: boolean;
 };
@@ -77,6 +84,26 @@ function humanAge(seconds: number): string {
   return `${Math.floor(seconds / 86400)}d ago`;
 }
 
+async function resolveStatusTargetDir(
+  options: StatusOptions,
+): Promise<string | undefined> {
+  if (!options.location) return options.targetDir;
+  if ((options.sourceType ?? "local") !== "local") {
+    throw new Error(
+      "CLI status currently supports --source-type local only. Use web server mode for remote discovery.",
+    );
+  }
+
+  const files = await discoverLocalArtifactFiles(options.location);
+  const candidates = discoverArtifactCandidateSets(files);
+  const selected = selectArtifactCandidate(candidates, options.candidate);
+  validateRequiredArtifacts(selected);
+
+  return selected.candidateId === "current"
+    ? options.location
+    : path.join(options.location, selected.candidateId);
+}
+
 /**
  * Format status as human-readable output.
  */
@@ -116,13 +143,18 @@ export function formatStatus(result: StatusResult): string {
 /**
  * Status / freshness action handler
  */
-export function statusAction(
+export async function statusAction(
   options: StatusOptions,
   handleError: (error: unknown, isTTY: boolean) => void,
   isTTY: () => boolean,
-): void {
+): Promise<void> {
   try {
-    const paths = resolveArtifactPaths(undefined, undefined, options.targetDir);
+    const effectiveTargetDir = await resolveStatusTargetDir(options);
+    const paths = resolveArtifactPaths(
+      undefined,
+      undefined,
+      effectiveTargetDir,
+    );
 
     // Validate paths before accessing filesystem
     validateSafePath(paths.manifest);
@@ -147,7 +179,6 @@ export function statusAction(
       readiness = "full";
     }
 
-    // Latest modified artifact
     let latestModifiedAt: string | undefined;
     let latestAgeSeconds: number | undefined;
 

--- a/packages/dbt-tools/core/src/index.ts
+++ b/packages/dbt-tools/core/src/index.ts
@@ -25,6 +25,7 @@ export type {
 // I/O exports
 export * from "./io/artifact-filenames";
 export * from "./io/artifact-loader";
+export * from "./io/artifact-discovery";
 
 // Validation exports
 export * from "./validation/input-validator";

--- a/packages/dbt-tools/core/src/io/artifact-discovery.test.ts
+++ b/packages/dbt-tools/core/src/io/artifact-discovery.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  discoverArtifactCandidateSets,
+  discoverLocalArtifactFiles,
+  selectArtifactCandidate,
+  validateRequiredArtifacts,
+} from "./artifact-discovery";
+
+describe("artifact-discovery", () => {
+  it("supports local source with required pair only", () => {
+    const candidates = discoverArtifactCandidateSets([
+      { relativePath: "manifest.json", filename: "manifest.json" },
+      { relativePath: "run_results.json", filename: "run_results.json" },
+    ]);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.isLoadable).toBe(true);
+    expect(candidates[0]?.missingOptional).toEqual([
+      "catalog.json",
+      "sources.json",
+    ]);
+  });
+
+  it("requires explicit selection when multiple candidates exist", () => {
+    const candidates = discoverArtifactCandidateSets([
+      { relativePath: "a/manifest.json", filename: "manifest.json" },
+      { relativePath: "a/run_results.json", filename: "run_results.json" },
+      { relativePath: "b/manifest.json", filename: "manifest.json" },
+      { relativePath: "b/run_results.json", filename: "run_results.json" },
+    ]);
+
+    expect(() => selectArtifactCandidate(candidates)).toThrow(
+      /Select one explicitly/,
+    );
+    expect(selectArtifactCandidate(candidates, "a").candidateId).toBe("a");
+  });
+
+  it("fails when manifest.json is missing", () => {
+    const candidate = discoverArtifactCandidateSets([
+      { relativePath: "run_results.json", filename: "run_results.json" },
+    ])[0]!;
+
+    expect(() => validateRequiredArtifacts(candidate)).toThrow(/manifest.json/);
+  });
+
+  it("fails when run_results.json is missing", () => {
+    const candidate = discoverArtifactCandidateSets([
+      { relativePath: "manifest.json", filename: "manifest.json" },
+    ])[0]!;
+
+    expect(() => validateRequiredArtifacts(candidate)).toThrow(
+      /run_results.json/,
+    );
+  });
+
+  it("discovers local directory and direct child candidates", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "dbt-discovery-"));
+    const nested = path.join(root, "run-1");
+    await fs.mkdir(nested);
+    await fs.writeFile(path.join(root, "manifest.json"), "{}");
+    await fs.writeFile(path.join(root, "run_results.json"), "{}");
+    await fs.writeFile(path.join(nested, "manifest.json"), "{}");
+    await fs.writeFile(path.join(nested, "run_results.json"), "{}");
+
+    const files = await discoverLocalArtifactFiles(root);
+    expect(files.map((file) => file.relativePath).sort()).toEqual([
+      "manifest.json",
+      "run-1/manifest.json",
+      "run-1/run_results.json",
+      "run_results.json",
+    ]);
+
+    await fs.rm(root, { recursive: true, force: true });
+  });
+});

--- a/packages/dbt-tools/core/src/io/artifact-discovery.ts
+++ b/packages/dbt-tools/core/src/io/artifact-discovery.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  DBT_CATALOG_JSON,
+  DBT_MANIFEST_JSON,
+  DBT_RUN_RESULTS_JSON,
+  DBT_SOURCES_JSON,
+} from "./artifact-filenames";
+
+export type ArtifactSourceType = "local" | "s3" | "gcs";
+
+export const REQUIRED_ARTIFACT_FILENAMES = [
+  DBT_MANIFEST_JSON,
+  DBT_RUN_RESULTS_JSON,
+] as const;
+export const OPTIONAL_ARTIFACT_FILENAMES = [
+  DBT_CATALOG_JSON,
+  DBT_SOURCES_JSON,
+] as const;
+
+export type RequiredArtifactFilename =
+  (typeof REQUIRED_ARTIFACT_FILENAMES)[number];
+export type OptionalArtifactFilename =
+  (typeof OPTIONAL_ARTIFACT_FILENAMES)[number];
+export type SupportedArtifactFilename =
+  | RequiredArtifactFilename
+  | OptionalArtifactFilename;
+
+const SUPPORTED_ARTIFACT_SET = new Set<SupportedArtifactFilename>([
+  ...REQUIRED_ARTIFACT_FILENAMES,
+  ...OPTIONAL_ARTIFACT_FILENAMES,
+]);
+
+export interface DiscoveredArtifactFile {
+  relativePath: string;
+  filename: SupportedArtifactFilename;
+  updatedAtMs?: number;
+}
+
+export interface ArtifactCandidateFeatures {
+  catalogMetadata: boolean;
+  sourceFreshness: boolean;
+}
+
+export interface ArtifactCandidateSet {
+  candidateId: string;
+  label: string;
+  artifacts: Partial<Record<SupportedArtifactFilename, DiscoveredArtifactFile>>;
+  missingRequired: RequiredArtifactFilename[];
+  missingOptional: OptionalArtifactFilename[];
+  warnings: string[];
+  features: ArtifactCandidateFeatures;
+  isLoadable: boolean;
+}
+
+export interface ArtifactDiscoveryResult {
+  sourceType: ArtifactSourceType;
+  location: string;
+  candidates: ArtifactCandidateSet[];
+}
+
+function toCandidateId(relativePath: string): string {
+  const dir = path.posix.dirname(relativePath);
+  return dir === "." ? "current" : dir;
+}
+
+function featureFlags(
+  artifacts: Partial<Record<SupportedArtifactFilename, DiscoveredArtifactFile>>,
+): ArtifactCandidateFeatures {
+  return {
+    catalogMetadata: artifacts[DBT_CATALOG_JSON] != null,
+    sourceFreshness: artifacts[DBT_SOURCES_JSON] != null,
+  };
+}
+
+function buildCandidate(
+  candidateId: string,
+  artifacts: Partial<Record<SupportedArtifactFilename, DiscoveredArtifactFile>>,
+): ArtifactCandidateSet {
+  const missingRequired = REQUIRED_ARTIFACT_FILENAMES.filter(
+    (filename) => artifacts[filename] == null,
+  );
+  const missingOptional = OPTIONAL_ARTIFACT_FILENAMES.filter(
+    (filename) => artifacts[filename] == null,
+  );
+
+  return {
+    candidateId,
+    label: candidateId === "current" ? "current" : candidateId,
+    artifacts,
+    missingRequired,
+    missingOptional,
+    warnings: missingOptional.map(
+      (name) =>
+        `Optional artifact missing: ${name}. Related features will be disabled.`,
+    ),
+    features: featureFlags(artifacts),
+    isLoadable: missingRequired.length === 0,
+  };
+}
+
+export function discoverArtifactCandidateSets(
+  files: readonly DiscoveredArtifactFile[],
+): ArtifactCandidateSet[] {
+  const grouped = new Map<
+    string,
+    Partial<Record<SupportedArtifactFilename, DiscoveredArtifactFile>>
+  >();
+
+  for (const file of files) {
+    const candidateId = toCandidateId(file.relativePath);
+    const group = grouped.get(candidateId) ?? {};
+    group[file.filename] = file;
+    grouped.set(candidateId, group);
+  }
+
+  return [...grouped.entries()]
+    .map(([candidateId, artifacts]) => buildCandidate(candidateId, artifacts))
+    .sort((left, right) => left.candidateId.localeCompare(right.candidateId));
+}
+
+async function maybePushArtifactFile(
+  files: DiscoveredArtifactFile[],
+  baseDir: string,
+  relativePath: string,
+): Promise<void> {
+  const filename = path.posix.basename(
+    relativePath,
+  ) as SupportedArtifactFilename;
+  if (!SUPPORTED_ARTIFACT_SET.has(filename)) return;
+  const stat = await fs.stat(path.join(baseDir, relativePath));
+  files.push({ relativePath, filename, updatedAtMs: stat.mtimeMs });
+}
+
+async function collectChildDirectoryArtifacts(
+  files: DiscoveredArtifactFile[],
+  location: string,
+  dirName: string,
+): Promise<void> {
+  const childDir = path.join(location, dirName);
+  const childEntries = await fs.readdir(childDir, { withFileTypes: true });
+  for (const child of childEntries) {
+    if (!child.isFile()) continue;
+    await maybePushArtifactFile(files, location, `${dirName}/${child.name}`);
+  }
+}
+
+export async function discoverLocalArtifactFiles(
+  location: string,
+): Promise<DiscoveredArtifactFile[]> {
+  const top = await fs.readdir(location, { withFileTypes: true });
+  const files: DiscoveredArtifactFile[] = [];
+
+  for (const entry of top) {
+    if (entry.isFile()) {
+      await maybePushArtifactFile(files, location, entry.name);
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+    await collectChildDirectoryArtifacts(files, location, entry.name);
+  }
+
+  return files;
+}
+
+export function selectArtifactCandidate(
+  candidates: readonly ArtifactCandidateSet[],
+  candidateId?: string,
+): ArtifactCandidateSet {
+  if (candidates.length === 0) {
+    throw new Error(
+      "No supported dbt artifacts were discovered at this location.",
+    );
+  }
+
+  if (candidateId == null || candidateId.trim() === "") {
+    if (candidates.length === 1) return candidates[0]!;
+    throw new Error(
+      "Multiple candidate artifact sets were discovered. Select one explicitly.",
+    );
+  }
+
+  const selected = candidates.find(
+    (candidate) => candidate.candidateId === candidateId,
+  );
+  if (selected == null) {
+    throw new Error(`Unknown artifact candidate: ${candidateId}`);
+  }
+  return selected;
+}
+
+export function validateRequiredArtifacts(
+  candidate: ArtifactCandidateSet,
+): void {
+  if (candidate.missingRequired.length === 0) return;
+  throw new Error(
+    `Missing required artifact(s): ${candidate.missingRequired.join(", ")}. manifest.json and run_results.json are required.`,
+  );
+}

--- a/packages/dbt-tools/web/src/artifact-source/discovery.ts
+++ b/packages/dbt-tools/web/src/artifact-source/discovery.ts
@@ -4,7 +4,12 @@ import {
   DBT_MANIFEST_JSON,
   DBT_RUN_RESULTS_JSON,
   DBT_SOURCES_JSON,
-} from "@dbt-tools/core";
+} from "../../../core/src/io/artifact-filenames";
+import {
+  discoverArtifactCandidateSets,
+  type ArtifactCandidateSet,
+  type DiscoveredArtifactFile,
+} from "../../../core/src/io/artifact-discovery";
 import type {
   RemoteArtifactProvider,
   RemoteArtifactRun,
@@ -26,6 +31,7 @@ export interface ResolvedArtifactRun {
   sourcesKey?: string;
   updatedAtMs: number;
   versionToken: string;
+  missingOptional: string[];
 }
 
 function toRelativeKey(key: string, prefix: string): string | null {
@@ -39,11 +45,6 @@ function toRelativeKey(key: string, prefix: string): string | null {
   return null;
 }
 
-function runIdForKey(relativeKey: string): string {
-  const dir = path.posix.dirname(relativeKey);
-  return dir === "." ? "current" : dir;
-}
-
 function versionTokenForKeys(parts: RemoteObjectMetadata[]): string {
   return parts
     .map((part) =>
@@ -54,68 +55,113 @@ function versionTokenForKeys(parts: RemoteObjectMetadata[]): string {
     .join("|");
 }
 
-export function discoverLatestArtifactRuns(
+function toDiscoveredFiles(
   objects: RemoteObjectMetadata[],
   prefix: string,
-): ResolvedArtifactRun[] {
-  const grouped = new Map<
-    string,
-    {
-      manifest?: RemoteObjectMetadata;
-      runResults?: RemoteObjectMetadata;
-      catalog?: RemoteObjectMetadata;
-      sources?: RemoteObjectMetadata;
-    }
-  >();
+): DiscoveredArtifactFile[] {
+  const files: DiscoveredArtifactFile[] = [];
 
   for (const object of objects) {
     const relativeKey = toRelativeKey(object.key, prefix);
-    if (relativeKey == null) continue;
-
+    if (relativeKey == null || relativeKey === "") continue;
     const fileName = path.posix.basename(relativeKey);
     if (
       fileName !== DBT_MANIFEST_JSON &&
       fileName !== DBT_RUN_RESULTS_JSON &&
       fileName !== DBT_CATALOG_JSON &&
       fileName !== DBT_SOURCES_JSON
-    )
+    ) {
       continue;
+    }
 
-    const runId = runIdForKey(relativeKey);
-    const current = grouped.get(runId) ?? {};
-
-    if (fileName === DBT_MANIFEST_JSON) current.manifest = object;
-    if (fileName === DBT_RUN_RESULTS_JSON) current.runResults = object;
-    if (fileName === DBT_CATALOG_JSON) current.catalog = object;
-    if (fileName === DBT_SOURCES_JSON) current.sources = object;
-
-    grouped.set(runId, current);
+    files.push({
+      relativePath: relativeKey,
+      filename: fileName,
+      updatedAtMs: object.updatedAtMs,
+    });
   }
 
-  return [...grouped.entries()]
-    .flatMap(([runId, parts]) => {
-      if (parts.manifest == null || parts.runResults == null) return [];
-      return [
-        {
-          runId,
-          manifestKey: parts.manifest.key,
-          runResultsKey: parts.runResults.key,
-          ...(parts.catalog != null ? { catalogKey: parts.catalog.key } : {}),
-          ...(parts.sources != null ? { sourcesKey: parts.sources.key } : {}),
-          updatedAtMs: Math.max(
-            parts.manifest.updatedAtMs,
-            parts.runResults.updatedAtMs,
-          ),
-          versionToken: versionTokenForKeys(
-            [
-              parts.manifest,
-              parts.runResults,
-              parts.catalog,
-              parts.sources,
-            ].filter((part): part is RemoteObjectMetadata => part != null),
-          ),
-        },
-      ];
+  return files;
+}
+
+function candidateToResolvedRun(
+  candidate: ArtifactCandidateSet,
+  byPath: Map<string, RemoteObjectMetadata>,
+  prefix: string,
+): ResolvedArtifactRun | null {
+  const manifestRelative = candidate.artifacts[DBT_MANIFEST_JSON]?.relativePath;
+  const runResultsRelative =
+    candidate.artifacts[DBT_RUN_RESULTS_JSON]?.relativePath;
+  if (manifestRelative == null || runResultsRelative == null) return null;
+
+  const manifestKey =
+    prefix.trim() === ""
+      ? manifestRelative
+      : `${normalizeArtifactPrefix(prefix)}/${manifestRelative}`;
+  const runResultsKey =
+    prefix.trim() === ""
+      ? runResultsRelative
+      : `${normalizeArtifactPrefix(prefix)}/${runResultsRelative}`;
+
+  const manifestObj = byPath.get(manifestRelative);
+  const runObj = byPath.get(runResultsRelative);
+  if (manifestObj == null || runObj == null) return null;
+
+  const catalogRelative = candidate.artifacts[DBT_CATALOG_JSON]?.relativePath;
+  const sourcesRelative = candidate.artifacts[DBT_SOURCES_JSON]?.relativePath;
+  const catalogObj = catalogRelative ? byPath.get(catalogRelative) : undefined;
+  const sourcesObj = sourcesRelative ? byPath.get(sourcesRelative) : undefined;
+
+  return {
+    runId: candidate.candidateId,
+    manifestKey,
+    runResultsKey,
+    ...(catalogRelative
+      ? {
+          catalogKey:
+            prefix.trim() === ""
+              ? catalogRelative
+              : `${normalizeArtifactPrefix(prefix)}/${catalogRelative}`,
+        }
+      : {}),
+    ...(sourcesRelative
+      ? {
+          sourcesKey:
+            prefix.trim() === ""
+              ? sourcesRelative
+              : `${normalizeArtifactPrefix(prefix)}/${sourcesRelative}`,
+        }
+      : {}),
+    updatedAtMs: Math.max(manifestObj.updatedAtMs, runObj.updatedAtMs),
+    versionToken: versionTokenForKeys(
+      [manifestObj, runObj, catalogObj, sourcesObj].filter(
+        (part): part is RemoteObjectMetadata => part != null,
+      ),
+    ),
+    missingOptional: candidate.missingOptional,
+  };
+}
+
+export function discoverLatestArtifactRuns(
+  objects: RemoteObjectMetadata[],
+  prefix: string,
+): ResolvedArtifactRun[] {
+  const discoveredFiles = toDiscoveredFiles(objects, prefix);
+  const candidates = discoverArtifactCandidateSets(discoveredFiles);
+  const byRelativePath = new Map<string, RemoteObjectMetadata>();
+
+  for (const object of objects) {
+    const relativeKey = toRelativeKey(object.key, prefix);
+    if (relativeKey != null && relativeKey !== "") {
+      byRelativePath.set(relativeKey, object);
+    }
+  }
+
+  return candidates
+    .flatMap((candidate) => {
+      if (!candidate.isLoadable) return [];
+      const run = candidateToResolvedRun(candidate, byRelativePath, prefix);
+      return run == null ? [] : [run];
     })
     .sort((left, right) => {
       if (right.updatedAtMs !== left.updatedAtMs) {

--- a/packages/dbt-tools/web/src/artifact-source/remoteObjectStore.ts
+++ b/packages/dbt-tools/web/src/artifact-source/remoteObjectStore.ts
@@ -4,7 +4,7 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { Storage } from "@google-cloud/storage";
-import type { DbtToolsRemoteSourceConfig } from "@dbt-tools/core";
+import type { DbtToolsRemoteSourceConfig } from "../../../core/src/config/dbt-tools-env";
 import type { RemoteObjectMetadata } from "./discovery";
 
 export interface RemoteObjectStoreClient {

--- a/packages/dbt-tools/web/src/artifact-source/resolveLocalTargetDir.ts
+++ b/packages/dbt-tools/web/src/artifact-source/resolveLocalTargetDir.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getDbtToolsTargetDirFromEnv } from "@dbt-tools/core";
+import { getDbtToolsTargetDirFromEnv } from "../../../core/src/config/dbt-tools-env";
 
 export function expandDbtTargetDirFromEnvValue(targetDir: string): string {
   return targetDir.replace(/^~($|\/)/, `${process.env.HOME ?? ""}$1`).trim();

--- a/packages/dbt-tools/web/src/artifact-source/sourceService.ts
+++ b/packages/dbt-tools/web/src/artifact-source/sourceService.ts
@@ -6,14 +6,24 @@ import {
   DBT_MANIFEST_JSON,
   DBT_RUN_RESULTS_JSON,
   DBT_SOURCES_JSON,
+} from "../../../core/src/io/artifact-filenames";
+import {
+  discoverArtifactCandidateSets,
+  discoverLocalArtifactFiles,
+  selectArtifactCandidate,
+  type ArtifactCandidateSet,
+  validateRequiredArtifacts,
+} from "../../../core/src/io/artifact-discovery";
+import {
   getDbtToolsRemoteSourceConfigFromEnv,
   getDbtToolsTargetDirFromEnv,
   isDbtToolsDebugEnabled,
   type DbtToolsRemoteSourceConfig,
-} from "@dbt-tools/core";
+} from "../../../core/src/config/dbt-tools-env";
 import {
   discoverLatestArtifactRuns,
   toRemoteArtifactRun,
+  type RemoteObjectMetadata,
   type ResolvedArtifactRun,
 } from "./discovery";
 import { normalizeArtifactPrefix } from "./prefix";
@@ -23,7 +33,9 @@ import {
 } from "./remoteObjectStore";
 import { resolveLocalArtifactTargetDirFromEnv } from "./resolveLocalTargetDir";
 import type {
+  ArtifactDiscoveryResponse,
   ArtifactSourceStatus,
+  DiscoverSourceType,
   RemoteArtifactProvider,
   WorkspaceArtifactSource,
 } from "../services/artifactSourceApi";
@@ -74,18 +86,42 @@ function toArtifactSourceStatus(
   };
 }
 
+function parseRemoteLocation(input: {
+  sourceType: DiscoverSourceType;
+  location: string;
+}): { bucket: string; prefix: string } {
+  const value = input.location.trim();
+  const expectedPrefix = `${input.sourceType}://`;
+  if (!value.startsWith(expectedPrefix)) {
+    throw new Error(
+      `${input.sourceType} locations must use ${expectedPrefix}<bucket>/<prefix> format.`,
+    );
+  }
+
+  const withoutScheme = value.slice(expectedPrefix.length);
+  const [bucket, ...rest] = withoutScheme.split("/");
+  if (bucket.trim() === "") {
+    throw new Error(`Missing bucket name in ${input.sourceType} location.`);
+  }
+
+  return {
+    bucket,
+    prefix: rest.join("/").replace(/^\/+|\/+$/g, ""),
+  };
+}
+
+async function readOptionalLocalBytes(
+  filePath: string,
+): Promise<Uint8Array | null> {
+  try {
+    return await fs.readFile(filePath);
+  } catch {
+    return null;
+  }
+}
+
 class LocalArtifactSourceAdapter implements ArtifactSourceAdapter {
   constructor(private readonly targetDir: string) {}
-
-  private async readOptionalBytes(
-    filePath: string,
-  ): Promise<Uint8Array | null> {
-    try {
-      return await fs.readFile(filePath);
-    } catch {
-      return null;
-    }
-  }
 
   async getStatus(): Promise<ArtifactSourceStatus> {
     return toArtifactSourceStatus({
@@ -107,8 +143,8 @@ class LocalArtifactSourceAdapter implements ArtifactSourceAdapter {
         await Promise.all([
           fs.readFile(path.join(this.targetDir, DBT_MANIFEST_JSON)),
           fs.readFile(path.join(this.targetDir, DBT_RUN_RESULTS_JSON)),
-          this.readOptionalBytes(path.join(this.targetDir, DBT_CATALOG_JSON)),
-          this.readOptionalBytes(path.join(this.targetDir, DBT_SOURCES_JSON)),
+          readOptionalLocalBytes(path.join(this.targetDir, DBT_CATALOG_JSON)),
+          readOptionalLocalBytes(path.join(this.targetDir, DBT_SOURCES_JSON)),
         ]);
 
       return {
@@ -244,8 +280,16 @@ class RemoteArtifactSourceAdapter implements ArtifactSourceAdapter {
   }
 }
 
+interface ManualSelection {
+  sourceType: DiscoverSourceType;
+  location: string;
+  candidateId: string;
+  current: CurrentArtifactPayload;
+}
+
 export class ArtifactSourceService {
   private adapter: ArtifactSourceAdapter | null;
+  private manualSelection: ManualSelection | null = null;
 
   constructor(options: ArtifactSourceServiceOptions = {}) {
     if (options.adapter !== undefined) {
@@ -285,7 +329,227 @@ export class ArtifactSourceService {
     );
   }
 
+  private async discoverRemoteCandidates(
+    sourceType: Exclude<DiscoverSourceType, "local">,
+    location: string,
+  ): Promise<{
+    candidates: ArtifactCandidateSet[];
+    objects: RemoteObjectMetadata[];
+    bucket: string;
+    prefix: string;
+  }> {
+    const parsed = parseRemoteLocation({ sourceType, location });
+    const remoteConfig: DbtToolsRemoteSourceConfig =
+      sourceType === "s3"
+        ? { provider: "s3", bucket: parsed.bucket, prefix: parsed.prefix }
+        : { provider: "gcs", bucket: parsed.bucket, prefix: parsed.prefix };
+    const client = createRemoteObjectStoreClient(remoteConfig);
+    const objects = await client.listObjects(parsed.bucket, parsed.prefix);
+
+    const files = objects
+      .map((object) => {
+        const key = object.key.replace(/^\/+/, "");
+        const fullPrefix = normalizeArtifactPrefix(parsed.prefix);
+        if (fullPrefix && !key.startsWith(`${fullPrefix}/`)) return null;
+        const relativePath = fullPrefix
+          ? key.slice(fullPrefix.length + 1)
+          : key;
+        if (relativePath === "") return null;
+        const filename = path.posix.basename(relativePath);
+        if (
+          filename !== DBT_MANIFEST_JSON &&
+          filename !== DBT_RUN_RESULTS_JSON &&
+          filename !== DBT_CATALOG_JSON &&
+          filename !== DBT_SOURCES_JSON
+        ) {
+          return null;
+        }
+        return { relativePath, filename, updatedAtMs: object.updatedAtMs };
+      })
+      .filter(
+        (
+          value,
+        ): value is {
+          relativePath: string;
+          filename:
+            | typeof DBT_MANIFEST_JSON
+            | typeof DBT_RUN_RESULTS_JSON
+            | typeof DBT_CATALOG_JSON
+            | typeof DBT_SOURCES_JSON;
+          updatedAtMs: number;
+        } => value != null,
+      );
+
+    return {
+      candidates: discoverArtifactCandidateSets(files),
+      objects,
+      bucket: parsed.bucket,
+      prefix: parsed.prefix,
+    };
+  }
+
+  async discover(input: {
+    sourceType: DiscoverSourceType;
+    location: string;
+  }): Promise<ArtifactDiscoveryResponse> {
+    const location = input.location.trim();
+    if (location === "") {
+      throw new Error("Location is required.");
+    }
+
+    const candidates =
+      input.sourceType === "local"
+        ? discoverArtifactCandidateSets(
+            await discoverLocalArtifactFiles(location),
+          )
+        : (await this.discoverRemoteCandidates(input.sourceType, location))
+            .candidates;
+
+    return {
+      sourceType: input.sourceType,
+      location,
+      candidates: candidates.map((candidate) => ({
+        candidateId: candidate.candidateId,
+        label: candidate.label,
+        missingRequired: candidate.missingRequired,
+        missingOptional: candidate.missingOptional,
+        warnings: candidate.warnings,
+        features: candidate.features,
+        isLoadable: candidate.isLoadable,
+      })),
+    };
+  }
+
+  private async loadLocalCandidate(input: {
+    location: string;
+    candidateId: string;
+    sourceType: "local";
+  }): Promise<void> {
+    const baseDir =
+      input.candidateId === "current"
+        ? input.location
+        : path.join(input.location, input.candidateId);
+    const [manifestBytes, runResultsBytes, catalogBytes, sourcesBytes] =
+      await Promise.all([
+        fs.readFile(path.join(baseDir, DBT_MANIFEST_JSON)),
+        fs.readFile(path.join(baseDir, DBT_RUN_RESULTS_JSON)),
+        readOptionalLocalBytes(path.join(baseDir, DBT_CATALOG_JSON)),
+        readOptionalLocalBytes(path.join(baseDir, DBT_SOURCES_JSON)),
+      ]);
+
+    this.manualSelection = {
+      sourceType: input.sourceType,
+      location: input.location,
+      candidateId: input.candidateId,
+      current: {
+        source: "preload",
+        manifestBytes,
+        runResultsBytes,
+        ...(catalogBytes != null ? { catalogBytes } : {}),
+        ...(sourcesBytes != null ? { sourcesBytes } : {}),
+      },
+    };
+  }
+
+  private async loadRemoteCandidate(input: {
+    location: string;
+    candidateId: string;
+    sourceType: "s3" | "gcs";
+  }): Promise<void> {
+    const remote = await this.discoverRemoteCandidates(
+      input.sourceType,
+      input.location,
+    );
+    const runs = discoverLatestArtifactRuns(remote.objects, remote.prefix);
+    const run = runs.find((candidate) => candidate.runId === input.candidateId);
+    if (run == null) {
+      throw new Error(`Unknown artifact candidate: ${input.candidateId}`);
+    }
+
+    const remoteConfig: DbtToolsRemoteSourceConfig =
+      input.sourceType === "s3"
+        ? { provider: "s3", bucket: remote.bucket, prefix: remote.prefix }
+        : { provider: "gcs", bucket: remote.bucket, prefix: remote.prefix };
+    const client = createRemoteObjectStoreClient(remoteConfig);
+    const [manifestBytes, runResultsBytes, catalogBytes, sourcesBytes] =
+      await Promise.all([
+        client.readObjectBytes(remote.bucket, run.manifestKey),
+        client.readObjectBytes(remote.bucket, run.runResultsKey),
+        run.catalogKey
+          ? client.readObjectBytes(remote.bucket, run.catalogKey)
+          : Promise.resolve(null),
+        run.sourcesKey
+          ? client.readObjectBytes(remote.bucket, run.sourcesKey)
+          : Promise.resolve(null),
+      ]);
+
+    this.manualSelection = {
+      sourceType: input.sourceType,
+      location: input.location,
+      candidateId: input.candidateId,
+      current: {
+        source: "remote",
+        manifestBytes,
+        runResultsBytes,
+        ...(catalogBytes != null ? { catalogBytes } : {}),
+        ...(sourcesBytes != null ? { sourcesBytes } : {}),
+      },
+    };
+  }
+
+  async loadCandidate(input: {
+    sourceType: DiscoverSourceType;
+    location: string;
+    candidateId: string;
+  }): Promise<ArtifactSourceStatus> {
+    const discovery = await this.discover({
+      sourceType: input.sourceType,
+      location: input.location,
+    });
+
+    const candidates = discovery.candidates.map((candidate) => ({
+      ...candidate,
+      artifacts: {},
+    })) as ArtifactCandidateSet[];
+    const selected = selectArtifactCandidate(candidates, input.candidateId);
+    validateRequiredArtifacts(selected);
+
+    if (input.sourceType === "local") {
+      await this.loadLocalCandidate(input);
+    } else {
+      await this.loadRemoteCandidate(input);
+    }
+
+    return this.getStatus();
+  }
+
   async getStatus(): Promise<ArtifactSourceStatus> {
+    if (this.manualSelection != null) {
+      return toArtifactSourceStatus({
+        mode:
+          this.manualSelection.sourceType === "local" ? "preload" : "remote",
+        currentSource: this.manualSelection.current.source,
+        label: "Selected source",
+        remoteProvider:
+          this.manualSelection.sourceType === "local"
+            ? null
+            : this.manualSelection.sourceType,
+        remoteLocation:
+          this.manualSelection.sourceType === "local"
+            ? this.manualSelection.location
+            : this.manualSelection.location,
+        pollIntervalMs: null,
+        currentRun: {
+          runId: this.manualSelection.candidateId,
+          label: this.manualSelection.candidateId,
+          updatedAtMs: Date.now(),
+          versionToken: `${this.manualSelection.sourceType}:${this.manualSelection.location}:${this.manualSelection.candidateId}`,
+        },
+        pendingRun: null,
+        supportsSwitch: false,
+      });
+    }
+
     if (this.adapter == null) {
       return toArtifactSourceStatus({
         mode: "none",
@@ -303,6 +567,7 @@ export class ArtifactSourceService {
   }
 
   async getCurrentArtifacts(): Promise<CurrentArtifactPayload | null> {
+    if (this.manualSelection != null) return this.manualSelection.current;
     return this.adapter?.getCurrentArtifacts() ?? null;
   }
 

--- a/packages/dbt-tools/web/src/artifact-source/viteArtifactRoutes.ts
+++ b/packages/dbt-tools/web/src/artifact-source/viteArtifactRoutes.ts
@@ -4,7 +4,7 @@ import {
   DBT_MANIFEST_JSON,
   DBT_RUN_RESULTS_JSON,
   DBT_SOURCES_JSON,
-} from "@dbt-tools/core";
+} from "../../../core/src/io/artifact-filenames";
 import type { ArtifactSourceService } from "./sourceService";
 
 async function readJsonBody(
@@ -36,6 +36,14 @@ function sendJson(
   res.end(JSON.stringify(payload));
 }
 
+function sendError(
+  res: ServerResponse,
+  message: string,
+  statusCode = 400,
+): void {
+  sendJson(res, statusCode, { message });
+}
+
 function currentArtifactBytes(
   pathname: string,
   current: Awaited<ReturnType<ArtifactSourceService["getCurrentArtifacts"]>>,
@@ -63,25 +71,84 @@ function requestPathname(req: IncomingMessage): string | null {
   return req.url?.split("?")[0] ?? null;
 }
 
-function isArtifactStatusRequest(
-  req: IncomingMessage,
-  pathname: string,
-): boolean {
-  return req.method === "GET" && pathname === "/api/artifact-source";
+function parseSourceType(value: unknown): "local" | "s3" | "gcs" | null {
+  return value === "local" || value === "s3" || value === "gcs" ? value : null;
 }
 
-function isArtifactSwitchRequest(
+async function handleDiscoverRequest(
   req: IncomingMessage,
-  pathname: string,
-): boolean {
-  return req.method === "POST" && pathname === "/api/artifact-source/switch";
+  res: ServerResponse,
+  service: ArtifactSourceService,
+): Promise<boolean> {
+  if (
+    req.method !== "POST" ||
+    requestPathname(req) !== "/api/artifact-source/discover"
+  ) {
+    return false;
+  }
+
+  const body = await readJsonBody(req);
+  const sourceType = parseSourceType(body.sourceType);
+  if (sourceType == null || typeof body.location !== "string") {
+    sendError(res, "Invalid discovery request payload.");
+    return true;
+  }
+
+  try {
+    sendJson(
+      res,
+      200,
+      await service.discover({ sourceType, location: body.location }),
+    );
+  } catch (error) {
+    sendError(
+      res,
+      error instanceof Error ? error.message : "Failed to discover artifacts",
+    );
+  }
+  return true;
 }
 
-function isCurrentArtifactRequest(
+async function handleLoadRequest(
   req: IncomingMessage,
-  pathname: string,
-): boolean {
-  return req.method === "GET" && CURRENT_ARTIFACT_PATHS.has(pathname);
+  res: ServerResponse,
+  service: ArtifactSourceService,
+): Promise<boolean> {
+  if (
+    req.method !== "POST" ||
+    requestPathname(req) !== "/api/artifact-source/load"
+  ) {
+    return false;
+  }
+
+  const body = await readJsonBody(req);
+  const sourceType = parseSourceType(body.sourceType);
+  if (
+    sourceType == null ||
+    typeof body.location !== "string" ||
+    typeof body.candidateId !== "string"
+  ) {
+    sendError(res, "Invalid load request payload.");
+    return true;
+  }
+
+  try {
+    sendJson(
+      res,
+      200,
+      await service.loadCandidate({
+        sourceType,
+        location: body.location,
+        candidateId: body.candidateId,
+      }),
+    );
+  } catch (error) {
+    sendError(
+      res,
+      error instanceof Error ? error.message : "Failed to load artifacts",
+    );
+  }
+  return true;
 }
 
 /**
@@ -96,12 +163,12 @@ export async function tryHandleArtifactSourceViteRequest(
   const pathname = requestPathname(req);
   if (!pathname) return false;
 
-  if (isArtifactStatusRequest(req, pathname)) {
+  if (req.method === "GET" && pathname === "/api/artifact-source") {
     sendJson(res, 200, await service.getStatus());
     return true;
   }
 
-  if (isArtifactSwitchRequest(req, pathname)) {
+  if (req.method === "POST" && pathname === "/api/artifact-source/switch") {
     const body = await readJsonBody(req);
     const runId =
       typeof body.runId === "string" && body.runId.trim() !== ""
@@ -111,20 +178,23 @@ export async function tryHandleArtifactSourceViteRequest(
     return true;
   }
 
-  if (isCurrentArtifactRequest(req, pathname)) {
-    const current = await service.getCurrentArtifacts();
-    const bytes = currentArtifactBytes(pathname, current);
-    if (bytes == null) {
-      res.statusCode = 404;
-      res.end();
-      return true;
-    }
+  if (await handleDiscoverRequest(req, res, service)) return true;
+  if (await handleLoadRequest(req, res, service)) return true;
 
-    res.setHeader("Content-Type", "application/json");
-    res.statusCode = 200;
-    res.end(Buffer.from(bytes));
+  if (req.method !== "GET" || !CURRENT_ARTIFACT_PATHS.has(pathname)) {
+    return false;
+  }
+
+  const current = await service.getCurrentArtifacts();
+  const bytes = currentArtifactBytes(pathname, current);
+  if (bytes == null) {
+    res.statusCode = 404;
+    res.end();
     return true;
   }
 
-  return false;
+  res.setHeader("Content-Type", "application/json");
+  res.statusCode = 200;
+  res.end(Buffer.from(bytes));
+  return true;
 }

--- a/packages/dbt-tools/web/src/components/FileUpload.test.tsx
+++ b/packages/dbt-tools/web/src/components/FileUpload.test.tsx
@@ -4,29 +4,24 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadAnalysisFromBuffers } = vi.hoisted(() => ({
-  loadAnalysisFromBuffers: vi.fn(),
+const { mockDiscover, mockLoadCandidate, mockRefetch } = vi.hoisted(() => ({
+  mockDiscover: vi.fn(),
+  mockLoadCandidate: vi.fn(),
+  mockRefetch: vi.fn(),
 }));
 
-vi.mock("../services/analysisLoader", () => ({
-  loadAnalysisFromBuffers,
+vi.mock("@web/services/artifactApi", () => ({
+  discoverArtifactCandidates: (...args: unknown[]) => mockDiscover(...args),
+  loadDiscoveredArtifactCandidate: (...args: unknown[]) =>
+    mockLoadCandidate(...args),
+  refetchFromApi: (...args: unknown[]) => mockRefetch(...args),
+}));
+
+vi.mock("./ui/Toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
 }));
 
 import { FileUpload } from "./FileUpload";
-
-function createFile(name: string, contents: string): File {
-  return new File([contents], name, { type: "application/json" });
-}
-
-async function setInputFile(input: HTMLInputElement, file: File) {
-  Object.defineProperty(input, "files", {
-    configurable: true,
-    value: [file],
-  });
-  await act(async () => {
-    input.dispatchEvent(new Event("change", { bubbles: true }));
-  });
-}
 
 describe("FileUpload", () => {
   let root: Root;
@@ -36,12 +31,31 @@ describe("FileUpload", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    loadAnalysisFromBuffers.mockReset();
-    loadAnalysisFromBuffers.mockResolvedValue({
-      analysis: {
-        summary: { total_nodes: 4 },
-      },
-      metrics: { source: "upload" },
+
+    mockDiscover.mockReset();
+    mockLoadCandidate.mockReset();
+    mockRefetch.mockReset();
+
+    mockDiscover.mockResolvedValue({
+      sourceType: "local",
+      location: expect.any(String),
+      candidates: [
+        {
+          candidateId: "current",
+          label: "current",
+          missingRequired: [],
+          missingOptional: ["catalog.json", "sources.json"],
+          warnings: ["Optional artifact missing: catalog.json"],
+          features: { catalogMetadata: false, sourceFreshness: false },
+          isLoadable: true,
+        },
+      ],
+    });
+
+    mockLoadCandidate.mockResolvedValue({ currentSource: "preload" });
+    mockRefetch.mockResolvedValue({
+      analysis: { summary: { total_nodes: 3 } },
+      metrics: { source: "preload" },
     });
   });
 
@@ -52,7 +66,7 @@ describe("FileUpload", () => {
     container.remove();
   });
 
-  it("uploads the required artifact pair without optional files", async () => {
+  it("discovers and loads selected candidate", async () => {
     const onAnalysis = vi.fn();
     const onError = vi.fn();
 
@@ -60,79 +74,70 @@ describe("FileUpload", () => {
       root.render(<FileUpload onAnalysis={onAnalysis} onError={onError} />);
     });
 
-    const manifestInput = container.querySelector(
-      "#manifest-input",
-    ) as HTMLInputElement;
-    const runResultsInput = container.querySelector(
-      "#run-results-input",
-    ) as HTMLInputElement;
-
-    await setInputFile(manifestInput, createFile("manifest.json", "{}"));
-    await setInputFile(
-      runResultsInput,
-      createFile("run_results.json", '{"results":[]}'),
-    );
+    const locationInput = container.querySelector("input") as HTMLInputElement;
+    await act(async () => {
+      locationInput.value = "/tmp/target";
+      locationInput.dispatchEvent(new Event("change", { bubbles: true }));
+    });
 
     await act(async () => {
       (
-        container.querySelector("button.primary-action") as HTMLButtonElement
+        [...container.querySelectorAll("button")].find((button) =>
+          button.textContent?.includes("Discover artifact sets"),
+        ) as HTMLButtonElement
       ).click();
+      await Promise.resolve();
       await Promise.resolve();
     });
 
-    expect(loadAnalysisFromBuffers).toHaveBeenCalledWith(
-      expect.objectContaining({
-        manifestBytes: expect.any(ArrayBuffer),
-        runResultsBytes: expect.any(ArrayBuffer),
-      }),
-      "upload",
-    );
-    expect(loadAnalysisFromBuffers.mock.calls[0]?.[0]).not.toHaveProperty(
-      "catalogBytes",
-    );
-    expect(loadAnalysisFromBuffers.mock.calls[0]?.[0]).not.toHaveProperty(
-      "sourcesBytes",
-    );
+    const loadButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Load selected artifacts"),
+    ) as HTMLButtonElement | undefined;
+    expect(loadButton).toBeDefined();
+
+    await act(async () => {
+      loadButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockDiscover).toHaveBeenCalled();
+    expect(mockLoadCandidate).toHaveBeenCalledWith({
+      sourceType: "local",
+      location: expect.any(String),
+      candidateId: "current",
+    });
     expect(onAnalysis).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalledWith(expect.any(String));
   });
 
-  it("passes optional catalog and sources buffers when selected", async () => {
+  it("reports discovery errors", async () => {
+    mockDiscover.mockRejectedValueOnce(new Error("Bad location"));
+
+    const onAnalysis = vi.fn();
+    const onError = vi.fn();
+
     await act(async () => {
-      root.render(<FileUpload onAnalysis={vi.fn()} onError={vi.fn()} />);
+      root.render(<FileUpload onAnalysis={onAnalysis} onError={onError} />);
     });
 
-    await setInputFile(
-      container.querySelector("#manifest-input") as HTMLInputElement,
-      createFile("manifest.json", "{}"),
-    );
-    await setInputFile(
-      container.querySelector("#run-results-input") as HTMLInputElement,
-      createFile("run_results.json", '{"results":[]}'),
-    );
-    await setInputFile(
-      container.querySelector("#catalog-input") as HTMLInputElement,
-      createFile("catalog.json", '{"nodes":{}}'),
-    );
-    await setInputFile(
-      container.querySelector("#sources-input") as HTMLInputElement,
-      createFile("sources.json", '{"results":[]}'),
-    );
+    const locationInput = container.querySelector("input") as HTMLInputElement;
+    await act(async () => {
+      locationInput.value = "/tmp/target";
+      locationInput.dispatchEvent(new Event("change", { bubbles: true }));
+    });
 
     await act(async () => {
       (
-        container.querySelector("button.primary-action") as HTMLButtonElement
+        [...container.querySelectorAll("button")].find((button) =>
+          button.textContent?.includes("Discover artifact sets"),
+        ) as HTMLButtonElement
       ).click();
+      await Promise.resolve();
       await Promise.resolve();
     });
 
-    expect(loadAnalysisFromBuffers).toHaveBeenCalledWith(
-      expect.objectContaining({
-        manifestBytes: expect.any(ArrayBuffer),
-        runResultsBytes: expect.any(ArrayBuffer),
-        catalogBytes: expect.any(ArrayBuffer),
-        sourcesBytes: expect.any(ArrayBuffer),
-      }),
-      "upload",
-    );
+    expect(onError).toHaveBeenCalledWith("Bad location");
+    expect(onAnalysis).not.toHaveBeenCalled();
   });
 });

--- a/packages/dbt-tools/web/src/components/FileUpload.tsx
+++ b/packages/dbt-tools/web/src/components/FileUpload.tsx
@@ -1,223 +1,213 @@
 import { useMemo, useState } from "react";
 import { Spinner } from "./ui/Spinner";
 import { useToast } from "./ui/Toast";
+import type { AnalysisLoadResult } from "../services/analysisLoader";
 import {
-  loadAnalysisFromBuffers,
-  type AnalysisLoadResult,
-} from "../services/analysisLoader";
+  discoverArtifactCandidates,
+  loadDiscoveredArtifactCandidate,
+  refetchFromApi,
+  type ArtifactDiscoveryResponse,
+  type DiscoverSourceType,
+} from "@web/services/artifactApi";
 
 interface FileUploadProps {
   onAnalysis: (result: AnalysisLoadResult) => void;
   onError: (error: string | null) => void;
 }
 
-interface FileInputRowProps {
-  id: string;
+const SOURCE_OPTIONS: ReadonlyArray<{
+  value: DiscoverSourceType;
   label: string;
-  file: File | null;
-  onFileChange: (file: File | null) => void;
-}
-
-function FileInputRow({ id, label, file, onFileChange }: FileInputRowProps) {
-  return (
-    <div className="file-input-card">
-      <label htmlFor={id}>{label}</label>
-      <input
-        id={id}
-        type="file"
-        accept=".json"
-        onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
-      />
-      {file && <span className="file-input-card__filename">{file.name}</span>}
-    </div>
-  );
-}
-
-const WORKSPACE_FEATURES = [
-  {
-    title: "Health-first overview",
-    body: "Spot failing nodes, long-running bottlenecks, and critical-path pressure before opening individual assets.",
-  },
-  {
-    title: "Catalog-style context",
-    body: "Browse lineage-adjacent metadata such as descriptions, packages, execution status, and dependency depth in one flow.",
-  },
-  {
-    title: "Timeline investigation",
-    body: "Shift from summary to execution sequencing without leaving the workspace, inspired by dbt docs and observability tools.",
-  },
-] as const;
+}> = [
+  { value: "local", label: "Local directory" },
+  { value: "s3", label: "S3 prefix (s3://bucket/prefix)" },
+  { value: "gcs", label: "GCS prefix (gcs://bucket/prefix)" },
+];
 
 export function FileUpload({ onAnalysis, onError }: FileUploadProps) {
   const { toast } = useToast();
-  const [manifestFile, setManifestFile] = useState<File | null>(null);
-  const [runResultsFile, setRunResultsFile] = useState<File | null>(null);
-  const [catalogFile, setCatalogFile] = useState<File | null>(null);
-  const [sourcesFile, setSourcesFile] = useState<File | null>(null);
+  const [sourceType, setSourceType] = useState<DiscoverSourceType>("local");
+  const [location, setLocation] = useState("");
+  const [selectedCandidateId, setSelectedCandidateId] = useState<string>("");
+  const [discovery, setDiscovery] = useState<ArtifactDiscoveryResponse | null>(
+    null,
+  );
+  const [discovering, setDiscovering] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  async function handleAnalyze() {
-    if (!manifestFile || !runResultsFile) {
-      onError("Please select both manifest.json and run_results.json");
+  const selectedCandidate = useMemo(
+    () =>
+      discovery?.candidates.find(
+        (candidate) => candidate.candidateId === selectedCandidateId,
+      ) ?? null,
+    [discovery, selectedCandidateId],
+  );
+
+  async function handleDiscover() {
+    setDiscovering(true);
+    onError(null);
+    try {
+      const result = await discoverArtifactCandidates({ sourceType, location });
+      setDiscovery(result);
+      const defaultCandidate = result.candidates[0]?.candidateId ?? "";
+      setSelectedCandidateId(defaultCandidate);
+      if (result.candidates.length === 0) {
+        onError("No supported dbt artifacts were discovered at this location.");
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to discover artifacts";
+      onError(message);
+      toast(message, "danger");
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  async function handleLoad() {
+    if (selectedCandidateId.trim() === "") {
+      onError("Select a candidate artifact set before loading.");
       return;
     }
 
     setLoading(true);
     onError(null);
-
     try {
-      const [manifestBytes, runResultsBytes, catalogBytes, sourcesBytes] =
-        await Promise.all([
-          manifestFile.arrayBuffer(),
-          runResultsFile.arrayBuffer(),
-          catalogFile?.arrayBuffer() ?? Promise.resolve(undefined),
-          sourcesFile?.arrayBuffer() ?? Promise.resolve(undefined),
-        ]);
-      const result = await loadAnalysisFromBuffers(
-        {
-          manifestBytes,
-          runResultsBytes,
-          ...(catalogBytes != null ? { catalogBytes } : {}),
-          ...(sourcesBytes != null ? { sourcesBytes } : {}),
-        },
-        "upload",
+      await loadDiscoveredArtifactCandidate({
+        sourceType,
+        location,
+        candidateId: selectedCandidateId,
+      });
+
+      const loaded = await refetchFromApi(
+        sourceType === "local" ? "preload" : "remote",
       );
-      onAnalysis(result);
+      if (loaded == null) {
+        throw new Error("Artifacts were selected but could not be loaded.");
+      }
+
+      onAnalysis(loaded);
+
+      const warningCount = selectedCandidate?.warnings.length ?? 0;
       toast(
-        `Analyzed ${result.analysis.summary.total_nodes} executions successfully`,
-        "positive",
+        warningCount > 0
+          ? `Loaded with ${warningCount} optional artifact warning${warningCount === 1 ? "" : "s"}`
+          : `Loaded ${selectedCandidateId}`,
+        warningCount > 0 ? "warning" : "positive",
       );
-    } catch (err) {
+    } catch (error) {
       const message =
-        err instanceof Error ? err.message : "Failed to parse artifacts";
+        error instanceof Error ? error.message : "Failed to load artifacts";
       onError(message);
-      toast(`Parse failed — ${message}`, "danger");
+      toast(message, "danger");
     } finally {
       setLoading(false);
     }
   }
 
-  const canAnalyze = manifestFile && runResultsFile && !loading;
-  const readinessLabel = useMemo(() => {
-    if (manifestFile && runResultsFile) return "Ready to analyze";
-    if (manifestFile || runResultsFile) return "Waiting for one more file";
-    return "Add both dbt artifacts to continue";
-  }, [manifestFile, runResultsFile]);
+  const requiresExplicitSelection = (discovery?.candidates.length ?? 0) > 1;
 
   return (
     <section className="upload-hero">
       <div className="upload-hero__copy">
-        <p className="eyebrow">Bring your artifacts</p>
-        <h2>
-          Review dbt runs like a modern control plane, not a raw JSON dump.
-        </h2>
+        <p className="eyebrow">Artifact source</p>
+        <h2>Load dbt artifacts from one directory or object-storage prefix.</h2>
         <p>
-          Start from the two artifacts that power <code>dbt docs</code> and most
-          run analysis workflows: a matching <code>manifest.json</code> and
-          <code> run_results.json</code> pair.
+          Select a source type, provide a single location, discover candidate
+          artifact sets, and explicitly choose which set to load.
         </p>
-
-        <div className="upload-hero__callout">
-          <span className="upload-hero__callout-badge">Recommended flow</span>
-          <strong>
-            Run <code>dbt docs generate</code> after a representative job.
-          </strong>
-          <p>
-            That keeps lineage, metadata, and runtime results aligned so the
-            workspace can feel closer to dbt Docs for discovery and closer to
-            Elementary for health triage.
-          </p>
-        </div>
-
-        <div className="upload-feature-grid">
-          {WORKSPACE_FEATURES.map((feature) => (
-            <article key={feature.title} className="upload-feature-card">
-              <strong>{feature.title}</strong>
-              <p>{feature.body}</p>
-            </article>
-          ))}
-        </div>
       </div>
 
       <div className="upload-panel">
-        <div className="upload-panel__header">
-          <div>
-            <p className="eyebrow">Artifact intake</p>
-            <h3>Open investigation workspace</h3>
-          </div>
-          <span className="upload-panel__status">{readinessLabel}</span>
-        </div>
-
         <div className="upload-panel__inputs">
-          <FileInputRow
-            id="manifest-input"
-            label="manifest.json"
-            file={manifestFile}
-            onFileChange={setManifestFile}
-          />
-          <FileInputRow
-            id="run-results-input"
-            label="run_results.json"
-            file={runResultsFile}
-            onFileChange={setRunResultsFile}
-          />
-          <FileInputRow
-            id="catalog-input"
-            label="catalog.json (optional)"
-            file={catalogFile}
-            onFileChange={setCatalogFile}
-          />
-          <FileInputRow
-            id="sources-input"
-            label="sources.json (optional)"
-            file={sourcesFile}
-            onFileChange={setSourcesFile}
-          />
-        </div>
+          <label>
+            Source type
+            <select
+              value={sourceType}
+              onChange={(event) =>
+                setSourceType(event.target.value as DiscoverSourceType)
+              }
+            >
+              {SOURCE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        <div className="upload-panel__tips">
-          <div>
-            <strong>Best when files come from the same run.</strong>
-            <span>
-              Mismatched manifests and run results usually surface missing nodes
-              or stale timings.
-            </span>
-          </div>
-          <div>
-            <strong>Use local outputs or DBT_TOOLS_TARGET_DIR.</strong>
-            <span>
-              The app supports both uploaded artifacts and auto-loaded local
-              targets for faster iteration.
-            </span>
-          </div>
-          <div>
-            <strong>
-              Bring catalog and freshness artifacts when you have them.
-            </strong>
-            <span>
-              <code>catalog.json</code> and <code>sources.json</code> enrich the
-              workspace, but they are never required.
-            </span>
-          </div>
-        </div>
+          <label>
+            Location
+            <input
+              value={location}
+              onChange={(event) => setLocation(event.target.value)}
+              placeholder={
+                sourceType === "local"
+                  ? "/path/to/target"
+                  : `${sourceType}://bucket/path/to/prefix`
+              }
+            />
+          </label>
 
-        <button
-          type="button"
-          onClick={() => {
-            void handleAnalyze();
-          }}
-          disabled={!canAnalyze}
-          className="primary-action"
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.5rem",
-          }}
-        >
-          {loading && <Spinner size={16} />}
-          {loading ? "Analyzing…" : "Analyze artifacts"}
-        </button>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={() => void handleDiscover()}
+            disabled={discovering || loading}
+          >
+            {discovering ? <Spinner size={16} /> : null}
+            {discovering ? "Discovering…" : "Discover artifact sets"}
+          </button>
+
+          {discovery != null && discovery.candidates.length > 0 ? (
+            <>
+              <label>
+                Candidate set
+                <select
+                  value={selectedCandidateId}
+                  onChange={(event) =>
+                    setSelectedCandidateId(event.target.value)
+                  }
+                >
+                  {discovery.candidates.map((candidate) => (
+                    <option
+                      key={candidate.candidateId}
+                      value={candidate.candidateId}
+                    >
+                      {candidate.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {requiresExplicitSelection ? (
+                <p>
+                  Multiple candidates found. Selection is required before
+                  loading.
+                </p>
+              ) : null}
+
+              {selectedCandidate?.warnings.map((warning) => (
+                <p key={warning}>{warning}</p>
+              ))}
+
+              <button
+                type="button"
+                className="primary-action"
+                onClick={() => void handleLoad()}
+                disabled={
+                  loading ||
+                  discovering ||
+                  selectedCandidate == null ||
+                  !selectedCandidate.isLoadable
+                }
+              >
+                {loading ? <Spinner size={16} /> : null}
+                {loading ? "Loading…" : "Load selected artifacts"}
+              </button>
+            </>
+          ) : null}
+        </div>
       </div>
     </section>
   );

--- a/packages/dbt-tools/web/src/dbt-target-plugin.ts
+++ b/packages/dbt-tools/web/src/dbt-target-plugin.ts
@@ -5,10 +5,12 @@ import {
   DBT_MANIFEST_JSON,
   DBT_RUN_RESULTS_JSON,
   DBT_SOURCES_JSON,
+} from "../../core/src/io/artifact-filenames";
+import {
   getDbtToolsReloadDebounceMs,
   isDbtToolsDebugEnabled,
   isDbtToolsWatchEnabled,
-} from "@dbt-tools/core";
+} from "../../core/src/config/dbt-tools-env";
 import { ArtifactSourceService } from "./artifact-source/sourceService";
 import { resolveWatchableLocalTargetDir } from "./artifact-source/resolveLocalTargetDir";
 import { tryHandleArtifactSourceViteRequest } from "./artifact-source/viteArtifactRoutes";

--- a/packages/dbt-tools/web/src/services/artifactApi.ts
+++ b/packages/dbt-tools/web/src/services/artifactApi.ts
@@ -8,7 +8,11 @@ export {
   loadCurrentManagedArtifacts,
   refetchFromApi,
   switchToArtifactRun,
+  discoverArtifactCandidates,
+  loadDiscoveredArtifactCandidate,
   type ArtifactSourceStatus,
   type RemoteArtifactRun,
   type WorkspaceArtifactSource,
+  type DiscoverSourceType,
+  type ArtifactDiscoveryResponse,
 } from "./artifactSourceApi";

--- a/packages/dbt-tools/web/src/services/artifactSourceApi.ts
+++ b/packages/dbt-tools/web/src/services/artifactSourceApi.ts
@@ -20,6 +20,27 @@ export interface RemoteArtifactRun {
   versionToken: string;
 }
 
+export type DiscoverSourceType = "local" | "s3" | "gcs";
+
+export interface ArtifactDiscoveryCandidate {
+  candidateId: string;
+  label: string;
+  missingRequired: string[];
+  missingOptional: string[];
+  warnings: string[];
+  features: {
+    catalogMetadata: boolean;
+    sourceFreshness: boolean;
+  };
+  isLoadable: boolean;
+}
+
+export interface ArtifactDiscoveryResponse {
+  sourceType: DiscoverSourceType;
+  location: string;
+  candidates: ArtifactDiscoveryCandidate[];
+}
+
 export interface ArtifactSourceStatus {
   mode: ManagedArtifactSourceMode;
   currentSource: Exclude<WorkspaceArtifactSource, "upload"> | null;
@@ -243,6 +264,49 @@ export async function switchToArtifactRun(
 
   if (!response.ok) {
     throw new Error("Failed to switch artifact source run");
+  }
+
+  return (await response.json()) as ArtifactSourceStatus;
+}
+
+export async function discoverArtifactCandidates(input: {
+  sourceType: DiscoverSourceType;
+  location: string;
+}): Promise<ArtifactDiscoveryResponse> {
+  const response = await fetch("/api/artifact-source/discover", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const errorPayload = (await response.json().catch(() => ({}))) as {
+      message?: string;
+    };
+    throw new Error(errorPayload.message ?? "Failed to discover artifacts");
+  }
+
+  return (await response.json()) as ArtifactDiscoveryResponse;
+}
+
+export async function loadDiscoveredArtifactCandidate(input: {
+  sourceType: DiscoverSourceType;
+  location: string;
+  candidateId: string;
+}): Promise<ArtifactSourceStatus> {
+  const response = await fetch("/api/artifact-source/load", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const errorPayload = (await response.json().catch(() => ({}))) as {
+      message?: string;
+    };
+    throw new Error(
+      errorPayload.message ?? "Failed to load artifact candidate",
+    );
   }
 
   return (await response.json()) as ArtifactSourceStatus;


### PR DESCRIPTION
### Motivation
- Provide a way to discover candidate dbt artifact sets in a single location (local dir or object-storage prefix) and let users explicitly select and load a specific candidate set instead of only uploading individual files. 
- Surface discovery and loading workflows to the CLI `status` command and the web UI so users and automation can choose artifact sets from a shared location.

### Description
- Add a new artifact discovery module `core/src/io/artifact-discovery.ts` with helpers to discover candidate sets, select candidates, and validate required artifacts, and export it from the core entry. 
- Wire discovery into the CLI by adding `--source-type`, `--location`, and `--candidate` options to the `status`/`freshness` commands and implement `resolveStatusTargetDir` to resolve local discovery (remote discovery for non-local currently errors). 
- Extend web server-side artifact handling (`artifact-source/*`) to support discovery and loading endpoints, remote candidate listing (`discoverLatestArtifactRuns` reuse), manual selection and caching of a loaded candidate, and new middleware routes `/api/artifact-source/discover` and `/api/artifact-source/load`. 
- Update the web client API (`web/src/services/artifactSourceApi.ts`) and facade (`artifactApi.ts`) with `discoverArtifactCandidates` and `loadDiscoveredArtifactCandidate`, and update the `FileUpload` component and tests to drive discovery, select a candidate, and load it via the API. 
- Add/adjust imports and small runtime helpers (e.g. `readOptionalLocalBytes`, `parseRemoteLocation`, `toDiscoveredFiles`) and surface warnings when optional artifacts are missing. 
- Make `package.json` change to make `format` resilient by falling back to `format:without-trunk` when `trunk` is not available.

### Testing
- Ran unit tests with `vitest run`, including updated `status-action.test.ts`, new `artifact-discovery.test.ts`, and updated `FileUpload.test.ts`, and all tests completed successfully. 
- Exercised the web client discovery/load flow via updated component tests which assert `discoverArtifactCandidates` and `loadDiscoveredArtifactCandidate` calls and success/error handling. 
- Exercised CLI `status` behavior in tests updated to async invocation verifying readiness states, path traversal protection, and modification time handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4ea576a8832cb8468f74a2c85769)