### PR TITLE
feat(discovery): add Phase 1 shared discovery layer and discover CLI command

### DIFF
--- a/packages/dbt-tools/cli/src/cli-actions.ts
+++ b/packages/dbt-tools/cli/src/cli-actions.ts
@@ -3,4 +3,5 @@ export { depsAction } from "./deps-action";
 export { inventoryAction } from "./inventory-action";
 export { timelineAction } from "./timeline-action";
 export { searchAction } from "./search-action";
+export { discoverAction } from "./discover-action";
 export { statusAction } from "./status-action";

--- a/packages/dbt-tools/cli/src/cli.ts
+++ b/packages/dbt-tools/cli/src/cli.ts
@@ -25,6 +25,7 @@ import {
   inventoryAction,
   timelineAction,
   searchAction,
+  discoverAction,
   statusAction,
 } from "./cli-actions";
 import { resolveCliArtifactPaths } from "./cli-artifact-resolve";
@@ -49,6 +50,8 @@ const DEFAULT_GRAPH_FORMAT = "json";
 const OPT_FIELDS = "--fields <fields>";
 const DESC_FIELDS = "Comma-separated list of fields to include";
 const OPT_FORMAT = "--format <format>";
+const OPT_TYPE = "--type <type>";
+const DESC_TYPE_FILTER = "Filter by resource type(s), comma-separated";
 
 program
   .name("dbt-tools")
@@ -461,7 +464,7 @@ program
 program
   .command("inventory")
   .description("List and filter dbt resources from manifest")
-  .option("--type <type>", "Filter by resource type(s), comma-separated")
+  .option(OPT_TYPE, DESC_TYPE_FILTER)
   .option("--package <package>", "Filter by package name")
   .option("--tag <tag>", "Filter by tag(s), comma-separated")
   .option("--path <path>", "Filter by file path substring")
@@ -542,7 +545,7 @@ program
     "[query]",
     "Search query; supports key:value tokens like type:model tag:finance",
   )
-  .option("--type <type>", "Filter by resource type(s), comma-separated")
+  .option(OPT_TYPE, DESC_TYPE_FILTER)
   .option("--package <package>", "Filter by package name")
   .option("--tag <tag>", "Filter by tag(s), comma-separated")
   .option("--path <path>", "Filter by file path substring")
@@ -564,6 +567,39 @@ program
       } & ArtifactRootFlags,
     ) => {
       await searchAction(query, options, handleCliError);
+    },
+  );
+
+/**
+ * Discover command: Ranked, explainable discovery from an ambiguous query
+ */
+program
+  .command("discover")
+  .description(
+    "Resolve an ambiguous query to ranked dbt resources with scores, reasons, related nodes, and next-action suggestions",
+  )
+  .argument(
+    "<query>",
+    "Free-text query; supports inline tokens like type:model tag:finance",
+  )
+  .option(OPT_TYPE, DESC_TYPE_FILTER)
+  .option("--limit <n>", "Maximum number of matches to return (default: 10)")
+  .option(OPT_FIELDS, DESC_FIELDS)
+  .option(OPT_DBT_TARGET, DESC_DBT_TARGET)
+  .option(OPT_JSON, DESC_JSON)
+  .option(OPT_NO_JSON, DESC_NO_JSON)
+  .action(
+    async (
+      query: string,
+      options: {
+        type?: string;
+        limit?: string;
+        fields?: string;
+        json?: boolean;
+        noJson?: boolean;
+      } & ArtifactRootFlags,
+    ) => {
+      await discoverAction(query, options, handleCliError);
     },
   );
 

--- a/packages/dbt-tools/cli/src/discover-action.ts
+++ b/packages/dbt-tools/cli/src/discover-action.ts
@@ -33,9 +33,7 @@ function formatConfidenceBadge(confidence: string): string {
   return `[${confidence.toUpperCase()}]`;
 }
 
-function formatRelatedSummary(
-  related: DiscoveryMatch["related"],
-): string {
+function formatRelatedSummary(related: DiscoveryMatch["related"]): string {
   const upstream = related.filter((r) => r.relation === "upstream").length;
   const downstream = related.filter((r) => r.relation === "downstream").length;
   const tests = related.filter((r) => r.relation === "test").length;
@@ -62,7 +60,9 @@ function formatDiscovery(output: DiscoveryOutput): string {
     lines.push(
       `  ${m.unique_id}  ${formatConfidenceBadge(m.confidence)}  score: ${m.score}`,
     );
-    lines.push(`    type: ${m.resource_type}  package: ${m.unique_id.split(".")[1] ?? ""}`);
+    lines.push(
+      `    type: ${m.resource_type}  package: ${m.unique_id.split(".")[1] ?? ""}`,
+    );
     lines.push(`    reasons: ${m.reasons.join(", ")}`);
     lines.push(`    next: ${m.next_actions.join(", ")}`);
     lines.push(`    related: ${formatRelatedSummary(m.related)}`);

--- a/packages/dbt-tools/cli/src/discover-action.ts
+++ b/packages/dbt-tools/cli/src/discover-action.ts
@@ -1,0 +1,123 @@
+/**
+ * Discover CLI action handler – ranked, explainable dbt resource discovery.
+ */
+import {
+  ManifestGraph,
+  loadManifest,
+  validateSafePath,
+  validateNoControlChars,
+  FieldFilter,
+  formatOutput,
+  shouldOutputJSON,
+  DiscoveryService,
+  type DiscoveryOutput,
+  type DiscoveryMatch,
+} from "@dbt-tools/core";
+import {
+  resolveCliArtifactPaths,
+  type ArtifactRootCliOptions,
+} from "./cli-artifact-resolve";
+
+export type DiscoverOptions = {
+  type?: string;
+  limit?: string;
+  fields?: string;
+  json?: boolean;
+  noJson?: boolean;
+} & ArtifactRootCliOptions;
+
+// ---------------------------------------------------------------------------
+// Human-readable formatting
+// ---------------------------------------------------------------------------
+function formatConfidenceBadge(confidence: string): string {
+  return `[${confidence.toUpperCase()}]`;
+}
+
+function formatRelatedSummary(
+  related: DiscoveryMatch["related"],
+): string {
+  const upstream = related.filter((r) => r.relation === "upstream").length;
+  const downstream = related.filter((r) => r.relation === "downstream").length;
+  const tests = related.filter((r) => r.relation === "test").length;
+  const parts: string[] = [];
+  if (upstream > 0) parts.push(`${upstream} upstream`);
+  if (downstream > 0) parts.push(`${downstream} downstream`);
+  if (tests > 0) parts.push(`${tests} test${tests !== 1 ? "s" : ""}`);
+  return parts.length > 0 ? parts.join(", ") : "none";
+}
+
+function formatDiscovery(output: DiscoveryOutput): string {
+  const lines: string[] = [];
+  const header = `Discovery results for "${output.query}"`;
+  lines.push(header);
+  lines.push("=".repeat(header.length));
+  lines.push(`${output.total} match${output.total !== 1 ? "es" : ""} found`);
+
+  if (output.matches.length === 0) {
+    return lines.join("\n");
+  }
+
+  for (const m of output.matches) {
+    lines.push("");
+    lines.push(
+      `  ${m.unique_id}  ${formatConfidenceBadge(m.confidence)}  score: ${m.score}`,
+    );
+    lines.push(`    type: ${m.resource_type}  package: ${m.unique_id.split(".")[1] ?? ""}`);
+    lines.push(`    reasons: ${m.reasons.join(", ")}`);
+    lines.push(`    next: ${m.next_actions.join(", ")}`);
+    lines.push(`    related: ${formatRelatedSummary(m.related)}`);
+
+    if (m.disambiguation.length > 0) {
+      lines.push(
+        `    disambiguation: ${m.disambiguation.map((d) => d.unique_id).join(", ")}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Action handler
+// ---------------------------------------------------------------------------
+export async function discoverAction(
+  query: string,
+  options: DiscoverOptions,
+  handleError: (error: unknown, preferStructuredErrors: boolean) => void,
+): Promise<void> {
+  try {
+    validateNoControlChars(query);
+
+    const paths = await resolveCliArtifactPaths(
+      { dbtTarget: options.dbtTarget },
+      { manifest: true, runResults: false },
+    );
+    validateSafePath(paths.manifest);
+
+    const manifest = loadManifest(paths.manifest);
+    const graph = new ManifestGraph(manifest);
+
+    const limitNum =
+      options.limit !== undefined ? parseInt(options.limit, 10) : 10;
+    const safeLimit = Number.isFinite(limitNum) && limitNum > 0 ? limitNum : 10;
+
+    const result = DiscoveryService.query(graph, query, {
+      type: options.type,
+      limit: safeLimit,
+    });
+
+    const useJson = shouldOutputJSON(options.json, options.noJson);
+
+    if (useJson) {
+      let out: unknown = result;
+      if (options.fields) {
+        out = FieldFilter.filterFields(result, options.fields);
+      }
+      console.log(formatOutput(out, true));
+    } else {
+      console.log(formatDiscovery(result));
+    }
+  } catch (error) {
+    handleError(error, shouldOutputJSON(options.json, options.noJson));
+  }
+}

--- a/packages/dbt-tools/core/src/browser.ts
+++ b/packages/dbt-tools/core/src/browser.ts
@@ -89,3 +89,7 @@ export {
   normalizeDbtResourceTypeKey,
   normalizeMaterializationKind,
 } from "./analysis/analysis-snapshot";
+
+// Discovery layer (browser-safe: no Node.js fs/path imports)
+export * from "./discovery/discovery-types";
+export { DiscoveryService } from "./discovery/discovery-service";

--- a/packages/dbt-tools/core/src/discovery/discovery-service.test.ts
+++ b/packages/dbt-tools/core/src/discovery/discovery-service.test.ts
@@ -119,11 +119,9 @@ describe("DiscoveryService", () => {
       const result = DiscoveryService.query(graph, hubAttrs.name);
       const topMatch = result.matches.find((m) => m.unique_id === hubId);
       if (topMatch) {
-        expect(
-          topMatch.reasons.some((r) =>
-            r.includes("centrality"),
-          ),
-        ).toBe(true);
+        expect(topMatch.reasons.some((r) => r.includes("centrality"))).toBe(
+          true,
+        );
       }
     }
   });
@@ -131,7 +129,9 @@ describe("DiscoveryService", () => {
   // 10. Inline token parsing — type:model qualifier narrows results
   it("parses inline type: token from query string", () => {
     const withToken = DiscoveryService.query(graph, "type:model orders");
-    const withOption = DiscoveryService.query(graph, "orders", { type: "model" });
+    const withOption = DiscoveryService.query(graph, "orders", {
+      type: "model",
+    });
     // Both approaches should produce the same top result
     expect(withToken.matches[0]?.unique_id).toBe(
       withOption.matches[0]?.unique_id,

--- a/packages/dbt-tools/core/src/discovery/discovery-service.test.ts
+++ b/packages/dbt-tools/core/src/discovery/discovery-service.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeAll } from "vitest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { parseManifest } from "dbt-artifacts-parser/manifest";
+// @ts-expect-error - workspace package, TypeScript resolves via package.json
+import { loadTestManifest } from "dbt-artifacts-parser/test-utils";
+import { ManifestGraph } from "../analysis/manifest-graph";
+import { DiscoveryService } from "./discovery-service";
+
+describe("DiscoveryService", () => {
+  let graph: ManifestGraph;
+
+  beforeAll(() => {
+    const manifestJson = loadTestManifest("v12", "manifest_1.10.json");
+    const manifest = parseManifest(manifestJson as Record<string, unknown>);
+    graph = new ManifestGraph(manifest);
+  });
+
+  // 1. Exact name match
+  it("returns exact name match with high confidence", () => {
+    const result = DiscoveryService.query(graph, "orders");
+    expect(result.query).toBe("orders");
+    expect(result.matches.length).toBeGreaterThan(0);
+    const top = result.matches[0];
+    expect(top.unique_id).toBe("model.jaffle_shop.orders");
+    expect(top.confidence).toBe("high");
+    expect(top.reasons).toContain("exact_name_match");
+    expect(top.score).toBe(100);
+  });
+
+  // 2. Prefix match
+  it("matches nodes whose names start with the query term", () => {
+    const result = DiscoveryService.query(graph, "stg_ord");
+    expect(result.matches.length).toBeGreaterThan(0);
+    const top = result.matches[0];
+    expect(top.display_name).toMatch(/^stg_ord/);
+    expect(top.reasons).toContain("name_prefix_match");
+  });
+
+  // 3. Fuzzy match (typo tolerance)
+  it("matches via fuzzy scoring when query has a small typo", () => {
+    // "ordes" is 1 edit away from "orders"
+    const result = DiscoveryService.query(graph, "ordes");
+    expect(result.matches.length).toBeGreaterThan(0);
+    const top = result.matches[0];
+    expect(top.unique_id).toBe("model.jaffle_shop.orders");
+    expect(top.reasons).toContain("fuzzy_name_match");
+  });
+
+  // 4. Type filter
+  it("filters results to the requested resource type", () => {
+    const result = DiscoveryService.query(graph, "orders", { type: "model" });
+    for (const match of result.matches) {
+      expect(match.resource_type).toBe("model");
+    }
+  });
+
+  // 5. No match
+  it("returns empty matches for an unrecognisable query", () => {
+    const result = DiscoveryService.query(graph, "zzznomatch_xyzzy_12345");
+    expect(result.total).toBe(0);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  // 6. Disambiguation
+  it("populates disambiguation when multiple candidates score closely", () => {
+    // "stg_" prefix will match many staging models at similar scores
+    const result = DiscoveryService.query(graph, "stg_");
+    expect(result.matches.length).toBeGreaterThan(0);
+    const top = result.matches[0];
+    // If there are close competitors their scores are within 20 pts of top
+    if (top.disambiguation.length > 0) {
+      for (const d of top.disambiguation) {
+        expect(top.score - d.score).toBeLessThanOrEqual(20);
+      }
+    }
+    // Also sanity-check disambiguation entries do not have nested disambiguation
+    for (const d of top.disambiguation) {
+      expect(d).not.toHaveProperty("disambiguation");
+    }
+  });
+
+  // 7. Related resources populated
+  it("includes depth-1 upstream and downstream in related", () => {
+    const result = DiscoveryService.query(graph, "orders", { type: "model" });
+    expect(result.matches.length).toBeGreaterThan(0);
+    const top = result.matches[0];
+    expect(top.related.length).toBeGreaterThan(0);
+    const relations = top.related.map((r) => r.relation);
+    expect(relations).toEqual(
+      expect.arrayContaining(["upstream", "downstream"]),
+    );
+  });
+
+  // 8. Next actions for a model
+  it("includes correct next_actions for a model result", () => {
+    const result = DiscoveryService.query(graph, "orders", { type: "model" });
+    expect(result.matches.length).toBeGreaterThan(0);
+    const top = result.matches[0];
+    expect(top.next_actions).toEqual(["explain", "impact", "diagnose"]);
+  });
+
+  // 9. Centrality bonus — hub node scores higher than leaf for the same term
+  it("applies centrality bonus to highly-connected nodes", () => {
+    // Find the node with highest degree in the graph
+    const g = graph.getGraph();
+    let hubId = "";
+    let maxDegree = 0;
+    g.forEachNode((nodeId, attrs) => {
+      if (attrs.resource_type === "field") return;
+      const d =
+        g.inboundNeighbors(nodeId).length + g.outboundNeighbors(nodeId).length;
+      if (d > maxDegree) {
+        maxDegree = d;
+        hubId = nodeId;
+      }
+    });
+    if (maxDegree > 10 && hubId) {
+      const hubAttrs = g.getNodeAttributes(hubId);
+      const result = DiscoveryService.query(graph, hubAttrs.name);
+      const topMatch = result.matches.find((m) => m.unique_id === hubId);
+      if (topMatch) {
+        expect(
+          topMatch.reasons.some((r) =>
+            r.includes("centrality"),
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  // 10. Inline token parsing — type:model qualifier narrows results
+  it("parses inline type: token from query string", () => {
+    const withToken = DiscoveryService.query(graph, "type:model orders");
+    const withOption = DiscoveryService.query(graph, "orders", { type: "model" });
+    // Both approaches should produce the same top result
+    expect(withToken.matches[0]?.unique_id).toBe(
+      withOption.matches[0]?.unique_id,
+    );
+    for (const match of withToken.matches) {
+      expect(match.resource_type).toBe("model");
+    }
+  });
+
+  // Structural: DiscoveryOutput shape
+  it("output matches the DiscoveryOutput schema", () => {
+    const result = DiscoveryService.query(graph, "customers");
+    expect(result).toHaveProperty("query");
+    expect(result).toHaveProperty("total");
+    expect(result).toHaveProperty("matches");
+    expect(typeof result.total).toBe("number");
+    if (result.matches.length > 0) {
+      const m = result.matches[0];
+      expect(m).toHaveProperty("resource_type");
+      expect(m).toHaveProperty("unique_id");
+      expect(m).toHaveProperty("display_name");
+      expect(m).toHaveProperty("score");
+      expect(m).toHaveProperty("confidence");
+      expect(m).toHaveProperty("reasons");
+      expect(m).toHaveProperty("disambiguation");
+      expect(m).toHaveProperty("related");
+      expect(m).toHaveProperty("next_actions");
+      expect(typeof m.score).toBe("number");
+      expect(m.score).toBeGreaterThanOrEqual(0);
+      expect(m.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  // Limit option
+  it("respects the limit option", () => {
+    const result = DiscoveryService.query(graph, "stg_", { limit: 3 });
+    expect(result.matches.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/packages/dbt-tools/core/src/discovery/discovery-service.ts
+++ b/packages/dbt-tools/core/src/discovery/discovery-service.ts
@@ -1,0 +1,426 @@
+/**
+ * Shared discovery layer — weighted ranking, fuzzy matching, disambiguation,
+ * related-resource suggestions, and next-action hints.
+ *
+ * Browser-safe: no Node.js fs/path imports.
+ */
+import type { ManifestGraph } from "../analysis/manifest-graph";
+import type { GraphNodeAttributes } from "../types";
+import type {
+  DiscoveryConfidence,
+  DiscoveryMatch,
+  DiscoveryOptions,
+  DiscoveryOutput,
+  DiscoveryRelated,
+} from "./discovery-types";
+
+// ---------------------------------------------------------------------------
+// Internal scoring reason codes
+// ---------------------------------------------------------------------------
+type ReasonCode =
+  | "exact_name_match"
+  | "name_prefix_match"
+  | "name_contains"
+  | "unique_id_match"
+  | "unique_id_contains"
+  | "tag_match"
+  | "tag_contains"
+  | "path_match"
+  | "description_match"
+  | "fuzzy_name_match"
+  | "high_dependency_centrality"
+  | "medium_dependency_centrality";
+
+// ---------------------------------------------------------------------------
+// Token parsing (inline key:value filters, e.g. "type:model orders")
+// ---------------------------------------------------------------------------
+interface ParsedTokens {
+  terms: string[];
+  type?: string;
+  package?: string;
+  tag?: string;
+}
+
+function parseQueryTokens(query: string): ParsedTokens {
+  const tokens = query.split(/\s+/).filter(Boolean);
+  const terms: string[] = [];
+  let type: string | undefined;
+  let pkg: string | undefined;
+  let tag: string | undefined;
+
+  for (const token of tokens) {
+    if (token.startsWith("type:")) {
+      type = token.slice(5);
+    } else if (token.startsWith("package:")) {
+      pkg = token.slice(8);
+    } else if (token.startsWith("tag:")) {
+      tag = token.slice(4);
+    } else {
+      terms.push(token);
+    }
+  }
+
+  return { terms, type, package: pkg, tag };
+}
+
+// ---------------------------------------------------------------------------
+// Levenshtein distance (no external dependencies)
+// ---------------------------------------------------------------------------
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  // Use a flat array for the DP matrix
+  const dp = new Array<number>((m + 1) * (n + 1));
+  for (let i = 0; i <= m; i++) dp[i * (n + 1)] = i;
+  for (let j = 0; j <= n; j++) dp[j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i * (n + 1) + j] = Math.min(
+        dp[(i - 1) * (n + 1) + j] + 1,
+        dp[i * (n + 1) + (j - 1)] + 1,
+        dp[(i - 1) * (n + 1) + (j - 1)] + cost,
+      );
+    }
+  }
+  return dp[m * (n + 1) + n];
+}
+
+// ---------------------------------------------------------------------------
+// Next-action mapping by resource type
+// ---------------------------------------------------------------------------
+const NEXT_ACTIONS_BY_TYPE: Record<string, string[]> = {
+  model: ["explain", "impact", "diagnose"],
+  seed: ["explain", "impact", "diagnose"],
+  snapshot: ["explain", "impact", "diagnose"],
+  source: ["explain", "impact"],
+  test: ["diagnose"],
+  unit_test: ["diagnose"],
+  exposure: ["explain", "impact"],
+  metric: ["explain", "impact"],
+  semantic_model: ["explain", "impact"],
+};
+
+function nextActionsFor(resourceType: string): string[] {
+  return NEXT_ACTIONS_BY_TYPE[resourceType] ?? ["explain"];
+}
+
+// ---------------------------------------------------------------------------
+// Confidence from normalized score
+// ---------------------------------------------------------------------------
+function confidenceFor(normalizedScore: number): DiscoveryConfidence {
+  if (normalizedScore >= 75) return "high";
+  if (normalizedScore >= 40) return "medium";
+  return "low";
+}
+
+// ---------------------------------------------------------------------------
+// Raw scoring
+// ---------------------------------------------------------------------------
+interface ScoredNode {
+  attrs: GraphNodeAttributes;
+  rawScore: number;
+  reasons: ReasonCode[];
+}
+
+interface NodeFields {
+  lName: string;
+  lId: string;
+  lPath: string;
+  lDesc: string;
+  lTags: string[];
+}
+
+function extractNodeFields(attrs: GraphNodeAttributes): NodeFields {
+  return {
+    lName: (attrs.name || "").toLowerCase(),
+    lId: (attrs.unique_id || "").toLowerCase(),
+    lPath: ((attrs.path as string | undefined) || "").toLowerCase(),
+    lDesc: ((attrs.description as string | undefined) || "").toLowerCase(),
+    lTags: ((attrs.tags as string[] | undefined) || []).map((t) =>
+      t.toLowerCase(),
+    ),
+  };
+}
+
+function scoreNameSignal(
+  term: string,
+  lName: string,
+  lId: string,
+  reasons: Set<ReasonCode>,
+): number {
+  if (lName === term || lId === term) {
+    reasons.add("exact_name_match");
+    return 50;
+  }
+  if (lName.startsWith(term)) {
+    reasons.add("name_prefix_match");
+    return 35;
+  }
+  if (lName.includes(term)) {
+    reasons.add("name_contains");
+    return 25;
+  }
+  return 0;
+}
+
+function scoreIdSignal(
+  term: string,
+  lId: string,
+  alreadyMatched: boolean,
+  reasons: Set<ReasonCode>,
+): number {
+  if (lId === term) {
+    reasons.add("unique_id_match");
+    return alreadyMatched ? 0 : 45;
+  }
+  if (lId.includes(term)) {
+    reasons.add("unique_id_contains");
+    return alreadyMatched ? 0 : 20;
+  }
+  return 0;
+}
+
+function scoreTagSignal(
+  term: string,
+  lTags: string[],
+  reasons: Set<ReasonCode>,
+): number {
+  if (lTags.some((t) => t === term)) {
+    reasons.add("tag_match");
+    return 20;
+  }
+  if (lTags.some((t) => t.includes(term))) {
+    reasons.add("tag_contains");
+    return 10;
+  }
+  return 0;
+}
+
+/** Score a single term against pre-lowercased node fields; returns 0 if no match. */
+function scoreOneTerm(
+  term: string,
+  fields: NodeFields,
+  reasons: Set<ReasonCode>,
+): number {
+  const namePoints = scoreNameSignal(term, fields.lName, fields.lId, reasons);
+  const idPoints = scoreIdSignal(term, fields.lId, namePoints > 0, reasons);
+  const tagPoints = scoreTagSignal(term, fields.lTags, reasons);
+
+  let points = namePoints + idPoints + tagPoints;
+
+  if (fields.lPath.includes(term)) {
+    points += 8;
+    reasons.add("path_match");
+  }
+
+  if (fields.lDesc.includes(term)) {
+    points += 5;
+    reasons.add("description_match");
+  }
+
+  if (points === 0 && term.length >= 4 && fields.lName.length >= 4) {
+    if (levenshtein(fields.lName, term) <= 2) {
+      points += 15;
+      reasons.add("fuzzy_name_match");
+    }
+  }
+
+  return points;
+}
+
+function applyCentralityBonus(
+  inOutDegree: number,
+  rawScore: number,
+  reasons: Set<ReasonCode>,
+): number {
+  if (inOutDegree > 10) {
+    reasons.add("high_dependency_centrality");
+    return rawScore + 10;
+  }
+  if (inOutDegree > 3) {
+    reasons.add("medium_dependency_centrality");
+    return rawScore + 5;
+  }
+  return rawScore;
+}
+
+function scoreNodeAgainstTerms(
+  attrs: GraphNodeAttributes,
+  terms: string[],
+  inOutDegree: number,
+): ScoredNode {
+  const reasons = new Set<ReasonCode>();
+  const fields = extractNodeFields(attrs);
+  let rawScore = 0;
+
+  for (const rawTerm of terms) {
+    const termPoints = scoreOneTerm(rawTerm.toLowerCase(), fields, reasons);
+    if (termPoints === 0) {
+      return { attrs, rawScore: 0, reasons: [] };
+    }
+    rawScore += termPoints;
+  }
+
+  rawScore = applyCentralityBonus(inOutDegree, rawScore, reasons);
+  return { attrs, rawScore, reasons: Array.from(reasons) };
+}
+
+// ---------------------------------------------------------------------------
+// Related resources
+// ---------------------------------------------------------------------------
+function buildRelated(
+  graph: ManifestGraph,
+  nodeId: string,
+): DiscoveryRelated[] {
+  const related: DiscoveryRelated[] = [];
+  const seen = new Set<string>();
+
+  // Depth-1 upstream
+  for (const { nodeId: upId } of graph.getUpstream(nodeId, 1)) {
+    if (!seen.has(upId)) {
+      seen.add(upId);
+      related.push({ unique_id: upId, relation: "upstream" });
+    }
+  }
+
+  // Depth-1 downstream
+  for (const { nodeId: downId } of graph.getDownstream(nodeId, 1)) {
+    if (!seen.has(downId)) {
+      seen.add(downId);
+      const attrs = graph.getGraph().getNodeAttributes(downId);
+      const relation =
+        attrs.resource_type === "exposure"
+          ? "exposure"
+          : attrs.resource_type === "test" || attrs.resource_type === "unit_test"
+            ? "test"
+            : "downstream";
+      related.push({ unique_id: downId, relation });
+    }
+  }
+
+  return related.slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+export class DiscoveryService {
+  /**
+   * Query the manifest graph and return ranked, explainable discovery results.
+   *
+   * @param graph - A ManifestGraph built from the project manifest
+   * @param queryString - Free-text query; supports `type:`, `tag:`, `package:` inline tokens
+   * @param options - Optional type filter and result limit
+   */
+  static query(
+    graph: ManifestGraph,
+    queryString: string,
+    options: DiscoveryOptions = {},
+  ): DiscoveryOutput {
+    const parsed = parseQueryTokens(queryString.trim());
+    const effectiveType = options.type ?? parsed.type;
+    const limit = options.limit ?? 10;
+
+    const g = graph.getGraph();
+
+    // Build centrality index (in+out degree) once
+    const degreeMap = new Map<string, number>();
+    g.forEachNode((nodeId) => {
+      degreeMap.set(
+        nodeId,
+        g.inboundNeighbors(nodeId).length + g.outboundNeighbors(nodeId).length,
+      );
+    });
+
+    const candidates: ScoredNode[] = [];
+
+    g.forEachNode((_nodeId, attrs) => {
+      // Skip field-level nodes (column lineage internals)
+      if (attrs.resource_type === "field") return;
+
+      // Apply type filter
+      if (
+        effectiveType &&
+        attrs.resource_type.toLowerCase() !==
+          effectiveType.toLowerCase()
+      ) {
+        return;
+      }
+
+      // Apply package filter from inline token
+      if (
+        parsed.package &&
+        (attrs.package_name || "") !== parsed.package
+      ) {
+        return;
+      }
+
+      // Apply tag filter from inline token
+      if (parsed.tag) {
+        const nodeTags = ((attrs.tags as string[] | undefined) || []).map((t) =>
+          t.toLowerCase(),
+        );
+        if (!nodeTags.includes(parsed.tag.toLowerCase())) return;
+      }
+
+      const degree = degreeMap.get(attrs.unique_id) ?? 0;
+      const scored = scoreNodeAgainstTerms(attrs, parsed.terms, degree);
+      if (scored.rawScore > 0 || parsed.terms.length === 0) {
+        candidates.push(scored);
+      }
+    });
+
+    if (candidates.length === 0) {
+      return { query: queryString, total: 0, matches: [] };
+    }
+
+    // Sort: higher rawScore first, then alphabetical for stability
+    candidates.sort((a, b) => {
+      if (b.rawScore !== a.rawScore) return b.rawScore - a.rawScore;
+      return a.attrs.unique_id.localeCompare(b.attrs.unique_id);
+    });
+
+    // Normalize scores to 0–100 relative to best candidate
+    const maxRaw = candidates[0].rawScore;
+    const normalize = (raw: number) =>
+      maxRaw === 0 ? 0 : Math.round((raw / maxRaw) * 100);
+
+    const topNormalized = normalize(candidates[0].rawScore);
+
+    // Collect disambiguation set (score within 20 pts of top, beyond index 0)
+    const disambiguationCandidates = candidates
+      .slice(1)
+      .filter((c) => topNormalized - normalize(c.rawScore) <= 20);
+
+    const matches: DiscoveryMatch[] = candidates
+      .slice(0, limit)
+      .map((c, idx) => {
+        const score = normalize(c.rawScore);
+        const match: DiscoveryMatch = {
+          resource_type: c.attrs.resource_type,
+          unique_id: c.attrs.unique_id,
+          display_name: c.attrs.name,
+          score,
+          confidence: confidenceFor(score),
+          reasons: c.reasons as string[],
+          disambiguation:
+            idx === 0
+              ? disambiguationCandidates.slice(0, 5).map((d) => ({
+                  resource_type: d.attrs.resource_type,
+                  unique_id: d.attrs.unique_id,
+                  display_name: d.attrs.name,
+                  score: normalize(d.rawScore),
+                  confidence: confidenceFor(normalize(d.rawScore)),
+                  reasons: d.reasons as string[],
+                }))
+              : [],
+          related: buildRelated(graph, c.attrs.unique_id),
+          next_actions: nextActionsFor(c.attrs.resource_type),
+        };
+        return match;
+      });
+
+    return { query: queryString, total: matches.length, matches };
+  }
+}

--- a/packages/dbt-tools/core/src/discovery/discovery-service.ts
+++ b/packages/dbt-tools/core/src/discovery/discovery-service.ts
@@ -292,7 +292,8 @@ function buildRelated(
       const relation =
         attrs.resource_type === "exposure"
           ? "exposure"
-          : attrs.resource_type === "test" || attrs.resource_type === "unit_test"
+          : attrs.resource_type === "test" ||
+              attrs.resource_type === "unit_test"
             ? "test"
             : "downstream";
       related.push({ unique_id: downId, relation });
@@ -342,17 +343,13 @@ export class DiscoveryService {
       // Apply type filter
       if (
         effectiveType &&
-        attrs.resource_type.toLowerCase() !==
-          effectiveType.toLowerCase()
+        attrs.resource_type.toLowerCase() !== effectiveType.toLowerCase()
       ) {
         return;
       }
 
       // Apply package filter from inline token
-      if (
-        parsed.package &&
-        (attrs.package_name || "") !== parsed.package
-      ) {
+      if (parsed.package && (attrs.package_name || "") !== parsed.package) {
         return;
       }
 

--- a/packages/dbt-tools/core/src/discovery/discovery-types.ts
+++ b/packages/dbt-tools/core/src/discovery/discovery-types.ts
@@ -21,7 +21,10 @@ export interface DiscoveryMatch {
   /** Machine-readable codes explaining why this node ranked here. */
   reasons: string[];
   /** Other close candidates (score within 20 pts of top); shallow — no nested disambiguation. */
-  disambiguation: Omit<DiscoveryMatch, "disambiguation" | "related" | "next_actions">[];
+  disambiguation: Omit<
+    DiscoveryMatch,
+    "disambiguation" | "related" | "next_actions"
+  >[];
   /** Depth-1 neighbors and related tests/exposures. */
   related: DiscoveryRelated[];
   /** Suggested follow-up operations based on resource type. */

--- a/packages/dbt-tools/core/src/discovery/discovery-types.ts
+++ b/packages/dbt-tools/core/src/discovery/discovery-types.ts
@@ -1,0 +1,42 @@
+/**
+ * Output types for the shared discovery layer.
+ * Consumed by both the CLI `discover` command and the web search worker.
+ */
+
+export type DiscoveryConfidence = "high" | "medium" | "low";
+
+export interface DiscoveryRelated {
+  unique_id: string;
+  /** Structural relationship from the queried node's perspective. */
+  relation: "upstream" | "downstream" | "test" | "exposure";
+}
+
+export interface DiscoveryMatch {
+  resource_type: string;
+  unique_id: string;
+  display_name: string;
+  /** Normalized 0–100 score relative to the best match in this result set. */
+  score: number;
+  confidence: DiscoveryConfidence;
+  /** Machine-readable codes explaining why this node ranked here. */
+  reasons: string[];
+  /** Other close candidates (score within 20 pts of top); shallow — no nested disambiguation. */
+  disambiguation: Omit<DiscoveryMatch, "disambiguation" | "related" | "next_actions">[];
+  /** Depth-1 neighbors and related tests/exposures. */
+  related: DiscoveryRelated[];
+  /** Suggested follow-up operations based on resource type. */
+  next_actions: string[];
+}
+
+export interface DiscoveryOutput {
+  query: string;
+  total: number;
+  matches: DiscoveryMatch[];
+}
+
+export interface DiscoveryOptions {
+  /** Filter to a single resource type (e.g. "model", "source"). */
+  type?: string;
+  /** Maximum number of matches to return (default 10). */
+  limit?: number;
+}

--- a/packages/dbt-tools/core/src/index.ts
+++ b/packages/dbt-tools/core/src/index.ts
@@ -45,6 +45,10 @@ export * from "./errors/error-handler";
 // Introspection exports
 export * from "./introspection/schema-generator";
 
+// Discovery layer (shared by CLI and web)
+export * from "./discovery/discovery-types";
+export { DiscoveryService } from "./discovery/discovery-service";
+
 // Shared types and utilities
 export * from "./types";
 export * from "./version";

--- a/packages/dbt-tools/core/src/introspection/schema-generator.ts
+++ b/packages/dbt-tools/core/src/introspection/schema-generator.ts
@@ -454,6 +454,45 @@ function getStatusSchema(): CommandSchema {
   };
 }
 
+function getDiscoverSchema(): CommandSchema {
+  return {
+    command: "discover",
+    description:
+      "Resolve an ambiguous query to ranked dbt resources with scores, reasons, related nodes, and next-action suggestions",
+    arguments: [
+      {
+        name: "query",
+        required: true,
+        description:
+          "Free-text query; supports inline tokens like type:model tag:finance",
+      },
+    ],
+    options: [
+      {
+        name: "--type",
+        type: TYPE_STRING,
+        description: "Filter results to a single resource type",
+      },
+      {
+        name: "--limit",
+        type: "number",
+        default: "10",
+        description: "Maximum number of matches to return",
+      },
+      {
+        name: "--fields",
+        type: TYPE_STRING,
+        description: DESC_FIELDS,
+      },
+      { name: OPT_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_JSON },
+      { name: OPT_NO_JSON, type: TYPE_BOOLEAN, description: DESC_FORCE_HUMAN },
+      ...getArtifactRootCliSchemaOptions(),
+    ],
+    output_format: OUTPUT_JSON_OR_HUMAN,
+    example: 'dbt-tools discover "orders" --dbt-target ./target --json',
+  };
+}
+
 /**
  * Get all command schemas
  */
@@ -466,6 +505,7 @@ export function getAllSchemas(): Record<string, CommandSchema> {
     inventory: getInventorySchema(),
     timeline: getTimelineSchema(),
     search: getSearchSchema(),
+    discover: getDiscoverSchema(),
     status: getStatusSchema(),
     freshness: {
       ...getStatusSchema(),


### PR DESCRIPTION
Implements the discovery/query layer from the product Phase 1 strategy.

Changes:
- core/src/discovery/discovery-types.ts: New DiscoveryOutput schema with
  scored matches, confidence, reasons, disambiguation, related resources,
  and next_actions fields
- core/src/discovery/discovery-service.ts: DiscoveryService.query() — weighted
  ranking (exact/prefix/contains/tag/path/description/fuzzy), Levenshtein
  tolerance (edit distance ≤ 2), dependency centrality bonus, disambiguation
  for close candidates, depth-1 related resources, next-action suggestions
- core/src/discovery/discovery-service.test.ts: 12 fixture-based tests covering
  exact match, prefix, typo tolerance, type filter, no-match, disambiguation,
  related resources, next_actions, centrality bonus, inline token parsing
- core/src/index.ts + browser.ts: Export discovery types and DiscoveryService
- core/src/introspection/schema-generator.ts: Register discover command schema
- cli/src/discover-action.ts: New CLI action with human and JSON output
- cli/src/cli-actions.ts: Export discoverAction
- cli/src/cli.ts: Register `dbt-tools discover "<query>"` command with --type,
  --limit, --fields, --json, --no-json, --dbt-target flags

Quality gates: lint score 100, all 409 tests pass, coverage above thresholds,
knip clean.

https://claude.ai/code/session_01B9YSAvBqrwo9Ber77Dp7Zp