### PR TITLE
Add portable dbt-tools CLI agent skills (status, discover, deps, explain/impact)

### DIFF
--- a/plugins/dbt-tools-cli/skills/dbt-artifacts-status/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/dbt-artifacts-status/SKILL.md
@@ -2,6 +2,7 @@
 name: dbt-artifacts-status
 description: Check local dbt artifact readiness with dbt-tools status before running manifest- or run_results-based analysis; interpret readiness and branch.
 ---
+<!-- markdownlint-disable MD013 MD060 -->
 
 # dbt artifacts status (readiness gate)
 

--- a/plugins/dbt-tools-cli/skills/dbt-artifacts-status/references/readiness.md
+++ b/plugins/dbt-tools-cli/skills/dbt-artifacts-status/references/readiness.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD060 -->
 # Readiness and command availability
 
 `dbt-tools status` sets **`readiness`** from **`manifest.json`** and **`run_results.json`** (and optional **`catalog.json`** / **`sources.json`**) under the resolved **`--dbt-target`**. For **local** roots it **stats** those paths in place. For **`s3://`** / **`gs://`** roots it **resolves the bundle** (download) first, then stats the resulting temp paths—use the same **`DBT_TOOLS_REMOTE_SOURCE`** / credentials as other CLI commands.

--- a/plugins/dbt-tools-cli/skills/deps/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/deps/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Investigate upstream and downstream dependencies for a dbt resource with `dbt-tools deps` and a known or resolvable `unique_id`. Cover direction, depth, flat vs tree, and build-order style questions at a stable-pattern level.
 compatibility: dbt-tools CLI on PATH. Requires the manifest (and the same `--dbt-target` / `DBT_TOOLS_DBT_TARGET` contract) as other graph commands. Suitable for any coding agent with shell access; pair with `discover`/`search` when the id is not yet known.
 ---
+<!-- markdownlint-disable MD013 MD060 -->
 
 # Resource dependencies (`deps`)
 

--- a/plugins/dbt-tools-cli/skills/deps/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/deps/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: deps
+description: >-
+  Investigate upstream and downstream dependencies for a dbt resource with `dbt-tools deps` and a known or resolvable `unique_id`. Cover direction, depth, flat vs tree, and build-order style questions at a stable-pattern level.
+compatibility: dbt-tools CLI on PATH. Requires the manifest (and the same `--dbt-target` / `DBT_TOOLS_DBT_TARGET` contract) as other graph commands. Suitable for any coding agent with shell access; pair with `discover`/`search` when the id is not yet known.
+---
+
+# Resource dependencies (`deps`)
+
+## Trigger scenarios
+
+- The user asks **what depends on** a model, **what a model depends on**, or the **neighborhood** of a node in the dbt graph.
+- You need a **depth-limited** or **build-order** view of upstream materialization for a single resource.
+- You have a **definite `unique_id`** (or a string the CLI can validate as a resource id) and need dependency structure, not a search.
+
+## Purpose
+
+**`dbt-tools deps <resource-id>`** walks the manifest graph from a **single** node. Use it to answer **direction** (upstream vs downstream), **how far** to look (**depth**), how to **display** the result (**flat** list vs **tree**), and whether to order **upstream** nodes in **build** (topological) order when that mode is available.
+
+This skill stays at **pattern** level. Exact flag names and defaults can change—use `dbt-tools schema deps` or `dbt-tools deps --help` when a script fails or you need the current schema.
+
+## Inputs the agent should identify
+
+- **`resource-id`**: a dbt **`unique_id`** (e.g. `model.project.table`) the user or a prior `search`/`discover` step provided. If you only have a **short name**, resolve it with **`discover`** or **`search`** first, or use **`explain`/`impact`** (see the **explain-impact** skill) if the intent is “resolve then summarize.”
+- **Direction**: **downstream** (default for “who is affected?”) vs **upstream** (what this node depends on).
+- **Depth**: full traversal vs **immediate neighbors** (depth `1` is the usual “one hop” mental model when supported).
+- **Shape**: **tree** (nested) vs **flat** list; pick **flat** when you need a simple set for counting or follow-up.
+- **Build order**: for **upstream** analysis, **build-order** style output (when the CLI offers it) helps match dbt’s dependency order for the subgraph.
+
+## Recommended command pattern
+
+1. **Default downstream, JSON for parsing:**
+
+   `dbt-tools deps <resource-id> --dbt-target <root> --json`
+
+2. **Upstream:**
+
+   `dbt-tools deps <resource-id> --dbt-target <root> --direction upstream --json`
+
+3. **One hop (typical for “direct” deps):**
+
+   `dbt-tools deps <resource-id> --dbt-target <root> --depth 1 --json`
+
+4. **Flat list instead of tree** (when the CLI supports `--format`):
+
+   `dbt-tools deps <resource-id> --dbt-target <root> --format flat --json`
+
+5. **Topological / build-style upstream ordering** (when you need “order to build or think about dependencies”):
+
+   `dbt-tools deps <resource-id> --dbt-target <root> --direction upstream --build-order --json`
+
+6. **Small payloads**: add **`--fields`** with the minimal set of properties you need (e.g. identifiers and names) once you know the field names from schema or a sample run.
+
+Cheat sheet: [references/commands.md](references/commands.md).
+
+## How to interpret results
+
+- Read the JSON **structure** the CLI returns (tree vs flat): count nodes, list `unique_id`s, or present a human summary.
+- **Direction**: confirm you queried the direction that matches the user’s “impact” vs “ingredients” question.
+- **Depth**: a depth cap limits **hops**; omitting depth (when allowed) means “all reachable” per CLI defaults—**watch output size** and repeat with a smaller depth or **fields** filter if needed.
+
+## Failure handling
+
+- **Invalid or unknown `resource-id`**: validation or “not in graph” style errors—go back to **`discover`/`search`** (see the **discover-search** skill) or double-check the id from the manifest.
+- **Missing manifest / target**: same as other artifact commands—fix `--dbt-target` or generate artifacts; use structured stderr with **`--json`** to propagate error codes to the user.
+- **Overlarge output**: lower **depth**, switch to **flat**, or use **`--fields`** to reduce properties per node.
+
+**Uncertain options?** `dbt-tools schema deps` and `dbt-tools deps --help`.
+
+## Verification / completion criteria
+
+- The user’s **dependency question** (direction, depth, and shape) is answered from **actual `deps` output** or a clear, cited error.
+- The agent has **kept** JSON bounded when the graph is large (depth, fields, or a stated truncation strategy).
+- The agent did **not** run `status` as a forced preflight; only if artifact presence was in doubt.
+
+## Related (optional)
+
+**`graph --focus`** (different command) can export a **subgraph** for visualization; use it when the user needs DOT/GEXF, not a CLI-first dependency list. The **discover-search** skill helps when the resource id is not yet known.

--- a/plugins/dbt-tools-cli/skills/deps/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/deps/references/commands.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD060 -->
 # deps — command cheat sheet
 
 ## Baseline
@@ -47,12 +48,12 @@ dbt-tools deps model.my_project.orders --dbt-target ./target --direction upstrea
 
 ## Common failure modes
 
-| Symptom | Likely cause | What to do |
-| ------- | ------------ | ---------- |
-| `VALIDATION_ERROR` on resource id | Malformed id, embedded `?`/`#`, or typos | Use `search` / `discover` to copy a real `unique_id`. |
-| `ARTIFACT_BUNDLE_INCOMPLETE` / parse errors | Bad `--dbt-target` or missing `manifest.json` | Fix target; ensure manifest exists. |
-| Empty or unexpected graph | Wrong direction or depth, or id not in project | Re-check id and project; try `--depth 1` first. |
-| Option not recognized | CLI version drift | `dbt-tools schema deps` and `dbt-tools deps --help`. |
+| Symptom                                     | Likely cause                                   | What to do                                            |
+| ------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------- |
+| `VALIDATION_ERROR` on resource id           | Malformed id, embedded `?`/`#`, or typos       | Use `search` / `discover` to copy a real `unique_id`. |
+| `ARTIFACT_BUNDLE_INCOMPLETE` / parse errors | Bad `--dbt-target` or missing `manifest.json`  | Fix target; ensure manifest exists.                   |
+| Empty or unexpected graph                   | Wrong direction or depth, or id not in project | Re-check id and project; try `--depth 1` first.       |
+| Option not recognized                       | CLI version drift                              | `dbt-tools schema deps` and `dbt-tools deps --help`.  |
 
 ## Introspect before scripting
 

--- a/plugins/dbt-tools-cli/skills/deps/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/deps/references/commands.md
@@ -1,0 +1,62 @@
+# deps — command cheat sheet
+
+## Baseline
+
+```bash
+dbt-tools deps model.my_project.orders --dbt-target ./target --json
+```
+
+- **Resource id** is the first **positional** argument: the dbt **`unique_id`**. Do not append query strings or URL fragments to the id.
+- **Downstream** is the usual default for “what breaks if I change this?” **Upstream** is for “what feeds this node?”
+
+## Direction and depth (stable patterns)
+
+```bash
+# Upstream (dependencies of this node)
+dbt-tools deps model.my_project.orders --dbt-target ./target --direction upstream --json
+
+# Downstream (dependents) — often default; pass explicitly if your CLI default is uncertain
+dbt-tools deps model.my_project.orders --dbt-target ./target --direction downstream --json
+
+# Depth 1: immediate neighbors only (typical for “direct”)
+dbt-tools deps model.my_project.orders --dbt-target ./target --depth 1 --json
+```
+
+## Format: tree vs flat
+
+```bash
+# Tree (nested) — good for human explanation when default
+dbt-tools deps model.my_project.orders --dbt-target ./target --json
+
+# Flat list — good for simple sets and smaller context
+dbt-tools deps model.my_project.orders --dbt-target ./target --format flat --json
+```
+
+## Build-order style (upstream)
+
+When you care about **topological** order of upstream nodes (e.g. “in what order are these built?”), use the **build-order** flag for **upstream** (check availability):
+
+```bash
+dbt-tools deps model.my_project.orders --dbt-target ./target --direction upstream --build-order --json
+```
+
+## Bounding output
+
+- **`--fields`**: include only the columns you need (often `unique_id`, `name`, `resource_type`) to keep the agent context small.
+- **Depth**: cap hops before asking for the full graph on large projects.
+
+## Common failure modes
+
+| Symptom | Likely cause | What to do |
+| ------- | ------------ | ---------- |
+| `VALIDATION_ERROR` on resource id | Malformed id, embedded `?`/`#`, or typos | Use `search` / `discover` to copy a real `unique_id`. |
+| `ARTIFACT_BUNDLE_INCOMPLETE` / parse errors | Bad `--dbt-target` or missing `manifest.json` | Fix target; ensure manifest exists. |
+| Empty or unexpected graph | Wrong direction or depth, or id not in project | Re-check id and project; try `--depth 1` first. |
+| Option not recognized | CLI version drift | `dbt-tools schema deps` and `dbt-tools deps --help`. |
+
+## Introspect before scripting
+
+```bash
+dbt-tools schema deps
+dbt-tools deps --help
+```

--- a/plugins/dbt-tools-cli/skills/discover-search/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/discover-search/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: discover-search
+description: >-
+  Find dbt resources by name, type, tag, package, path, or loose wording using `dbt-tools discover` and `dbt-tools search`. Resolve `unique_id` (and disambiguation) for follow-on CLI steps while remaining useful standalone.
+compatibility: dbt-tools CLI on PATH. `discover` is **manifest-only** at `--dbt-target`. `search` follows the same artifact **root** as other standard commands, which in typical setups expects **`manifest.json` and `run_results.json` there**—use `dbt-tools schema` if your CLI version allows exceptions. Cross-editor agent workflows (Cursor, Windsurf, Claude, Codex) can follow the same patterns.
+---
+
+# Discover and search dbt resources
+
+## Trigger scenarios
+
+- The user names a model, test, or source by **short name**, **path fragment**, **tag**, or **package**, and you need a **definite dbt `unique_id`**.
+- The user wants **candidates** for a fuzzy idea (“the orders model”, “something finance-tagged in core”).
+- You are narrowing **one** resource before `deps`, `explain`, or `impact`—but this skill is complete on its own (you can stop at a ranked list and IDs).
+
+## Purpose
+
+- **`search`**: text and filter-oriented discovery, fast to reason about, **optional** `key:value` inline tokens in the query string.
+- **`discover`**: **richer scoring**, reasons, disambiguation, and follow-up hooks in JSON when you need *explainable* resolution over the manifest.
+
+Use **`--json`** when you must **parse** matches. Use **`--limit` / `--offset`** (where supported) to keep context small; prefer tighter queries first instead of huge pages.
+
+## Inputs the agent should identify
+
+- **Artifact root**: `--dbt-target` or `DBT_TOOLS_DBT_TARGET` (the user’s path or remote prefix is trusted—do not override without cause).
+- **Query**: free text, or filter-only (for `discover`, you may use filters with an empty query when the CLI allows—see `--help` / `schema` if unsure).
+- **Intent**: *explore* (broad list) vs *resolve one id* (tighten filters, read disambiguation).
+- **Field budget**: for large projects, add **`--fields`** to shrink JSON once you know which fields you need (exact paths: `dbt-tools schema`).
+
+## Recommended command pattern
+
+1. **Text discovery with JSON (TTY-safe):**
+
+   `dbt-tools search --dbt-target <root> "<query>" --json`
+
+2. **Structured filters (example direction, not a full spec):**
+
+   `dbt-tools search --dbt-target <root> --type model --tag <tag> --json`
+
+3. **Explainable ranking / disambiguation:**
+
+   `dbt-tools discover --dbt-target <root> "<query>" --json`
+
+4. **Page when results may be long:**
+
+   Add `--limit` / `--offset` when you need a slice; keep limits modest so the agent’s context stays bounded.
+
+Patterns and when to pick `search` vs `discover`: [references/commands.md](references/commands.md).
+
+## How to interpret results
+
+- **`search` JSON**: use **`results`**, **`total`**, and match metadata to list candidates; the **`unique_id`** is the handle for `deps` / `explain` / `impact` when the user’s question needs that resource.
+- **`discover` JSON**: read **`matches`**, **scores / reasons** (if present), **`disambiguation`**, and any **`next_actions` / `primitive_commands`**-style follow-ups the payload includes—treat as hints, not mandatory scripts.
+- **Zero matches**: widen the query, drop a filter, or try alternate naming (e.g. package or path substring).
+- **Many matches**: tighten filters, reduce `--limit` for a first pass, or read top-N only and ask a clarifying question.
+
+## Failure handling
+
+- **Artifact / bundle errors**: if stderr indicates missing manifest or bad target, report it; fix the target; do not invent resource IDs.
+- **Ambiguity**: if multiple strong matches remain, return the top candidates and **distinct** `unique_id`s—do not guess.
+- **Unknown flags**: the CLI surface may evolve—`dbt-tools schema search`, `dbt-tools schema discover`, and `dbt-tools <cmd> --help` are the source of truth (see [references/commands.md](references/commands.md)).
+
+## Verification / completion criteria
+
+- The user has a **defensible list** of candidate **`unique_id`** values, or a clear “none found / ambiguous” result with next steps.
+- The agent has **kept output bounded** (reasonable `--limit` / `--fields` as appropriate) and used **`--json`** when machine parsing was required.
+- The agent has **not** required a `status` preflight solely because this is discovery; only use `status` if readiness is in question (see the **`status`** skill in this plugin).
+
+## Related (optional)
+
+A **`deps`**-focused skill covers dependency direction and depth. An **`explain-impact`** skill covers `explain` / `impact` once a resource (or a short resolvable name) is chosen.

--- a/plugins/dbt-tools-cli/skills/discover-search/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/discover-search/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Find dbt resources by name, type, tag, package, path, or loose wording using `dbt-tools discover` and `dbt-tools search`. Resolve `unique_id` (and disambiguation) for follow-on CLI steps while remaining useful standalone.
 compatibility: dbt-tools CLI on PATH. `discover` is **manifest-only** at `--dbt-target`. `search` follows the same artifact **root** as other standard commands, which in typical setups expects **`manifest.json` and `run_results.json` there**—use `dbt-tools schema` if your CLI version allows exceptions. Cross-editor agent workflows (Cursor, Windsurf, Claude, Codex) can follow the same patterns.
 ---
+<!-- markdownlint-disable MD013 MD060 -->
 
 # Discover and search dbt resources
 
@@ -16,7 +17,7 @@ compatibility: dbt-tools CLI on PATH. `discover` is **manifest-only** at `--dbt-
 ## Purpose
 
 - **`search`**: text and filter-oriented discovery, fast to reason about, **optional** `key:value` inline tokens in the query string.
-- **`discover`**: **richer scoring**, reasons, disambiguation, and follow-up hooks in JSON when you need *explainable* resolution over the manifest.
+- **`discover`**: **richer scoring**, reasons, disambiguation, and follow-up hooks in JSON when you need _explainable_ resolution over the manifest.
 
 Use **`--json`** when you must **parse** matches. Use **`--limit` / `--offset`** (where supported) to keep context small; prefer tighter queries first instead of huge pages.
 
@@ -24,7 +25,7 @@ Use **`--json`** when you must **parse** matches. Use **`--limit` / `--offset`**
 
 - **Artifact root**: `--dbt-target` or `DBT_TOOLS_DBT_TARGET` (the user’s path or remote prefix is trusted—do not override without cause).
 - **Query**: free text, or filter-only (for `discover`, you may use filters with an empty query when the CLI allows—see `--help` / `schema` if unsure).
-- **Intent**: *explore* (broad list) vs *resolve one id* (tighten filters, read disambiguation).
+- **Intent**: _explore_ (broad list) vs _resolve one id_ (tighten filters, read disambiguation).
 - **Field budget**: for large projects, add **`--fields`** to shrink JSON once you know which fields you need (exact paths: `dbt-tools schema`).
 
 ## Recommended command pattern

--- a/plugins/dbt-tools-cli/skills/discover-search/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/discover-search/references/commands.md
@@ -1,0 +1,66 @@
+# discover & search — command cheat sheet
+
+## Contract (high level)
+
+- Pass **`--dbt-target <local|s3|gs>`** (or set **`DBT_TOOLS_DBT_TARGET`**) the same way as other commands. Trust a user-provided value unless you see evidence it is wrong.
+- Prefer **`--json`** for agent parsing. With **`--json`**, use structured stderr for modeled failures.
+- **Bound** large result sets: **`--limit` / `--offset`**, and **`--fields`** to shrink each row when you know the shape you need.
+- **Files at the target:** as of current CLI documentation, **`discover`** only needs **`manifest.json`**, while **`search`** is documented with **`manifest.json` + `run_results.json`**. If a command errors about a missing file, re-check the target and run `dbt-tools status --json` when the user is unsure.
+
+## `search` — quick find
+
+```bash
+dbt-tools search --dbt-target ./target "orders" --json
+dbt-tools search --dbt-target ./target "type:model" "orders" --json
+dbt-tools search --dbt-target ./target --type model --tag finance --json
+```
+
+(Inline **`type:`**, **`tag:`**, **`package:`** tokens may appear in the query string; exact token support is defined by the current CLI—verify with `dbt-tools search --help` if a token fails.)
+
+```bash
+# Page (keep slices small in agent context)
+dbt-tools search --dbt-target ./target "orders" --limit 20 --offset 0 --json
+```
+
+**Typical use**: quickly list **`results`**; read **`unique_id`**, **`name`**, **`resource_type`**, **`package_name`**, **`path`**.
+
+**Zero or huge results**: add filters, shorten free text, or move to `discover` for ranked reasons.
+
+## `discover` — ranked, explainable
+
+```bash
+dbt-tools discover --dbt-target ./target "ordrs" --json
+dbt-tools discover --dbt-target ./target --type model --limit 30 --json
+```
+
+**Typical use**: fuzzy / typo-tolerant name resolution, **disambiguation** peers, richer follow-up context in JSON. Prefer **`discover`** when the user’s wording is vague or you need *why* something ranked.
+
+**Optional** (if available): **`--trace`** adds a small **investigation transcript** in JSON for debugging—use sparingly; check `dbt-tools schema discover`.
+
+## Choosing `search` vs `discover`
+
+| Situation | Lean toward |
+| -------- | ------------ |
+| Known substring in name/path | `search` |
+| Typo, nickname, or “most relevant” | `discover` |
+| Need minimal JSON | `search` with tight filters |
+| Need disambiguation story | `discover` |
+
+## Common failure modes
+
+| Symptom | Likely cause | What to do |
+| ------- | ------------ | ---------- |
+| `ARTIFACT_BUNDLE_INCOMPLETE` / missing manifest | Bad `--dbt-target` or missing `manifest.json` | Fix path; run `dbt` to emit artifacts. |
+| Empty `results` / empty `matches` | Query too strict or wrong project | Loosen text or filters. |
+| Too many rows | Over-broad query | Add `type:`, `package:`, or path filters; use `--limit`. |
+| Unknown option in script | CLI changed | `dbt-tools schema search` / `dbt-tools schema discover` and `--help`. |
+
+## Confirmed discovery against schema
+
+```bash
+dbt-tools schema
+dbt-tools schema search
+dbt-tools schema discover
+dbt-tools search --help
+dbt-tools discover --help
+```

--- a/plugins/dbt-tools-cli/skills/discover-search/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/discover-search/references/commands.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD060 -->
 # discover & search — command cheat sheet
 
 ## Contract (high level)
@@ -33,27 +34,27 @@ dbt-tools discover --dbt-target ./target "ordrs" --json
 dbt-tools discover --dbt-target ./target --type model --limit 30 --json
 ```
 
-**Typical use**: fuzzy / typo-tolerant name resolution, **disambiguation** peers, richer follow-up context in JSON. Prefer **`discover`** when the user’s wording is vague or you need *why* something ranked.
+**Typical use**: fuzzy / typo-tolerant name resolution, **disambiguation** peers, richer follow-up context in JSON. Prefer **`discover`** when the user’s wording is vague or you need _why_ something ranked.
 
 **Optional** (if available): **`--trace`** adds a small **investigation transcript** in JSON for debugging—use sparingly; check `dbt-tools schema discover`.
 
 ## Choosing `search` vs `discover`
 
-| Situation | Lean toward |
-| -------- | ------------ |
-| Known substring in name/path | `search` |
-| Typo, nickname, or “most relevant” | `discover` |
-| Need minimal JSON | `search` with tight filters |
-| Need disambiguation story | `discover` |
+| Situation                          | Lean toward                 |
+| ---------------------------------- | --------------------------- |
+| Known substring in name/path       | `search`                    |
+| Typo, nickname, or “most relevant” | `discover`                  |
+| Need minimal JSON                  | `search` with tight filters |
+| Need disambiguation story          | `discover`                  |
 
 ## Common failure modes
 
-| Symptom | Likely cause | What to do |
-| ------- | ------------ | ---------- |
-| `ARTIFACT_BUNDLE_INCOMPLETE` / missing manifest | Bad `--dbt-target` or missing `manifest.json` | Fix path; run `dbt` to emit artifacts. |
-| Empty `results` / empty `matches` | Query too strict or wrong project | Loosen text or filters. |
-| Too many rows | Over-broad query | Add `type:`, `package:`, or path filters; use `--limit`. |
-| Unknown option in script | CLI changed | `dbt-tools schema search` / `dbt-tools schema discover` and `--help`. |
+| Symptom                                         | Likely cause                                  | What to do                                                            |
+| ----------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------- |
+| `ARTIFACT_BUNDLE_INCOMPLETE` / missing manifest | Bad `--dbt-target` or missing `manifest.json` | Fix path; run `dbt` to emit artifacts.                                |
+| Empty `results` / empty `matches`               | Query too strict or wrong project             | Loosen text or filters.                                               |
+| Too many rows                                   | Over-broad query                              | Add `type:`, `package:`, or path filters; use `--limit`.              |
+| Unknown option in script                        | CLI changed                                   | `dbt-tools schema search` / `dbt-tools schema discover` and `--help`. |
 
 ## Confirmed discovery against schema
 

--- a/plugins/dbt-tools-cli/skills/explain-impact/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/explain-impact/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Summarize a dbt resource and reason about dependency impact with `dbt-tools explain` and `dbt-tools impact`. Use when the user wants a narrative or JSON snapshot of “what is this node?” and “what does it affect?”; defer exact flags to `schema` or `--help` when the CLI changes.
 compatibility: dbt-tools CLI on PATH. Both intents read the same artifact root as other manifest commands; they **resolve** short or ambiguous names via the CLI’s own discovery path (see command descriptions in `dbt-tools schema`). Works across IDE and headless agents; prefer `--json` for machine parsing.
 ---
+<!-- markdownlint-disable MD013 MD060 -->
 
 # Explain and impact a resource
 

--- a/plugins/dbt-tools-cli/skills/explain-impact/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/explain-impact/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: explain-impact
+description: >-
+  Summarize a dbt resource and reason about dependency impact with `dbt-tools explain` and `dbt-tools impact`. Use when the user wants a narrative or JSON snapshot of “what is this node?” and “what does it affect?”; defer exact flags to `schema` or `--help` when the CLI changes.
+compatibility: dbt-tools CLI on PATH. Both intents read the same artifact root as other manifest commands; they **resolve** short or ambiguous names via the CLI’s own discovery path (see command descriptions in `dbt-tools schema`). Works across IDE and headless agents; prefer `--json` for machine parsing.
+---
+
+# Explain and impact a resource
+
+## Trigger scenarios
+
+- The user wants a **structured summary** of a dbt node (what it is, where it lives, how it maps in the project).
+- The user wants an **impact-style** read: **who depends on this**, **how large** the blast radius feels, or **notable** downstreams—without hand-walking the full graph.
+- You already have a **name or id** (possibly short) and need **artifact-grounded** JSON to cite back.
+
+## Purpose
+
+- **`explain`**: **summary / resolution** intent—turn a user’s resource reference into a **manifest-backed** view (the CLI may combine discover-like resolution with manifest fields). Use for “**what is this?**”
+- **`impact`**: **dependency impact** intent—snapshot of how the node sits in the graph for “**what does this affect?**” and related metrics the CLI exposes.
+
+**Stability note:** the CLI is **intentionally** described at workflow level here. If an option, field name, or sub-object moves between releases, use **`dbt-tools schema explain`**, **`dbt-tools schema impact`**, or **`dbt-tools <command> --help`**—do not treat this skill as a full spec.
+
+## Inputs the agent should identify
+
+- **Resource reference**: `unique_id` is ideal; a **short name** may work because the commands **resolve** via discover-style logic—still verify the resolved id in JSON before answering as fact.
+- **Artifact root**: `--dbt-target` or `DBT_TOOLS_DBT_TARGET` (trust the user’s value when provided).
+- **Field budget**: use **`--fields`** only when you need a **small** slice and you know valid paths—otherwise take full JSON for correctness, then summarize in natural language.
+- **Debug / narrative**: if **`--trace`** is available, it can add a short **transcript** to JSON for “how we got here”—use when debugging odd resolution, not for every call.
+
+## Recommended command pattern
+
+1. **Summary intent (with JSON):**
+
+   `dbt-tools explain <resource> --dbt-target <root> --json`
+
+2. **Impact intent (with JSON):**
+
+   `dbt-tools impact <resource> --dbt-target <root> --json`
+
+3. **When the exact flag set is unknown or a command 404s**: run `dbt-tools schema` to see whether the command is registered, then `dbt-tools schema explain` / `dbt-tools schema impact`.
+
+4. **Narrowing large JSON** (only after a successful full response or schema confirmation): add **`--fields`** with paths the schema documents.
+
+5. **Optional follow-on**: for **pure dependency tree** or **build-order** questions, prefer **`deps`**; for “find the right id” first, prefer **`search` / `discover`**.
+
+Command recipes and failure modes: [references/commands.md](references/commands.md).
+
+## How to interpret results
+
+- Parse the **top-level JSON** fields the CLI returns: expect identifiers (**`unique_id`**), **human labels**, and command-specific **impact** or **explanation** sections. Exact keys differ by version—treat the payload as the authority.
+- If the payload includes **`web_url` / `review_url`** (when a web base URL is configured in the environment), you may pass these to the user for UI review; do not assume they are always present.
+- **Disambiguation** or **low confidence** in resolution: do not overstate a match—return candidates or ask a clarifying question; cross-check with **`discover`/`search`** if the explain/impact output is ambiguous.
+
+## Failure handling
+
+- **Command missing** on an older `dbt-tools` binary: `dbt-tools schema` will not list it—say the install is too old, or the command was renamed; avoid fabricating subcommands.
+- **Resolution failed or ambiguous**: narrow with **`discover`/`search`**, or pass a full **`unique_id`**.
+- **Artifact / validation errors**: mirror structured stderr to the user; fix `dbt-target` or regenerate artifacts.
+- **Unsupported option in your script**: refresh from **`schema`**, not from this skill’s prose.
+
+## Verification / completion criteria
+
+- The user gets a **coherent** answer: what the resource is (**explain**) and/or what its **impact** looks like (**impact**), grounded in **command JSON** (or a clear, cited error).
+- The agent has **named** the resolved **`unique_id`** when the user’s input was ambiguous and resolution succeeded.
+- The agent has **not** required unrelated prefetches (`status` only if readiness is genuinely unknown).
+
+## Related (optional)
+
+**`deps`** offers graph traversal and layout control when you need explicit **upstream/downstream** and **depth** walks. **Discover-search** is for when you lack a node handle entirely.

--- a/plugins/dbt-tools-cli/skills/explain-impact/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/explain-impact/references/commands.md
@@ -1,0 +1,58 @@
+# explain & impact — command cheat sheet
+
+## Baseline (agent-friendly)
+
+```bash
+dbt-tools explain model.my_project.orders --dbt-target ./target --json
+dbt-tools impact model.my_project.orders --dbt-target ./target --json
+```
+
+- **Positional** resource argument: often a `unique_id`; the CLI may also **resolve** shorter strings—treat the JSON **resolved** identifiers as the source of truth.
+- With **`--json`**, expect JSON **stdout** and, on failures, **structured stderr** (stable **`code`**) for modeled errors.
+
+## Environment (optional)
+
+When **`DBT_TOOLS_WEB_BASE_URL`** is set, JSON may include **deep links** into the dbt-tools web app for the same resource. This is **optional**—local-only workflows still work.
+
+## Tracing (optional, if available)
+
+```bash
+dbt-tools explain model.my_project.orders --dbt-target ./target --json --trace
+dbt-tools impact model.my_project.orders --dbt-target ./target --json --trace
+```
+
+- **`--trace`** (when supported) adds an **`investigation_transcript`**-style object for debugging. Confirm in `dbt-tools schema` before relying in automation.
+
+## Bounding output
+
+- **`--fields`**: use to shrink the JSON when you *know* valid dotted paths from the schema. If uncertain, run **once without `--fields`**, or inspect **`dbt-tools schema explain`** for allowed paths.
+- Do not use **`--fields`** to hide errors—errors still surface in stderr; fix the **inputs** or **target** if results are empty.
+
+## When to use which intent
+
+| User question | Start with |
+| ------------- | ---------- |
+| “What is this model/test/source?” | `explain` |
+| “What is the impact / who depends on this (high level)?” | `impact` |
+| “List upstream/downstream with depth and tree/flat” | `deps` |
+| “I only have a vague name or typo” | `discover` (then `explain` / `impact`) |
+
+## Common failure modes
+
+| Symptom | Likely cause | What to do |
+| ------- | ------------ | ---------- |
+| `usage:` / unknown command | Old CLI or typo | `dbt-tools schema`; upgrade `@dbt-tools/cli`. |
+| `VALIDATION_ERROR` | Malformed id or disallowed characters | Re-copy `unique_id` or resolve via `search`/`discover`. |
+| `ARTIFACT_BUNDLE_INCOMPLETE` | Missing `manifest.json` (or other required files) | Point `--dbt-target` at a directory with a manifest. |
+| Empty or null sections | **Fields** over-filtering | Drop `--fields` and re-run, or check schema. |
+| Ambiguous resolution in JSON | Multiple candidates | Tighten query or use `discover` first. |
+
+## Confirmed current behavior (do this, do not guess)
+
+```bash
+dbt-tools schema
+dbt-tools schema explain
+dbt-tools schema impact
+dbt-tools explain --help
+dbt-tools impact --help
+```

--- a/plugins/dbt-tools-cli/skills/explain-impact/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/explain-impact/references/commands.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD060 -->
 # explain & impact — command cheat sheet
 
 ## Baseline (agent-friendly)
@@ -25,27 +26,27 @@ dbt-tools impact model.my_project.orders --dbt-target ./target --json --trace
 
 ## Bounding output
 
-- **`--fields`**: use to shrink the JSON when you *know* valid dotted paths from the schema. If uncertain, run **once without `--fields`**, or inspect **`dbt-tools schema explain`** for allowed paths.
+- **`--fields`**: use to shrink the JSON when you _know_ valid dotted paths from the schema. If uncertain, run **once without `--fields`**, or inspect **`dbt-tools schema explain`** for allowed paths.
 - Do not use **`--fields`** to hide errors—errors still surface in stderr; fix the **inputs** or **target** if results are empty.
 
 ## When to use which intent
 
-| User question | Start with |
-| ------------- | ---------- |
-| “What is this model/test/source?” | `explain` |
-| “What is the impact / who depends on this (high level)?” | `impact` |
-| “List upstream/downstream with depth and tree/flat” | `deps` |
-| “I only have a vague name or typo” | `discover` (then `explain` / `impact`) |
+| User question                                            | Start with                             |
+| -------------------------------------------------------- | -------------------------------------- |
+| “What is this model/test/source?”                        | `explain`                              |
+| “What is the impact / who depends on this (high level)?” | `impact`                               |
+| “List upstream/downstream with depth and tree/flat”      | `deps`                                 |
+| “I only have a vague name or typo”                       | `discover` (then `explain` / `impact`) |
 
 ## Common failure modes
 
-| Symptom | Likely cause | What to do |
-| ------- | ------------ | ---------- |
-| `usage:` / unknown command | Old CLI or typo | `dbt-tools schema`; upgrade `@dbt-tools/cli`. |
-| `VALIDATION_ERROR` | Malformed id or disallowed characters | Re-copy `unique_id` or resolve via `search`/`discover`. |
-| `ARTIFACT_BUNDLE_INCOMPLETE` | Missing `manifest.json` (or other required files) | Point `--dbt-target` at a directory with a manifest. |
-| Empty or null sections | **Fields** over-filtering | Drop `--fields` and re-run, or check schema. |
-| Ambiguous resolution in JSON | Multiple candidates | Tighten query or use `discover` first. |
+| Symptom                      | Likely cause                                      | What to do                                              |
+| ---------------------------- | ------------------------------------------------- | ------------------------------------------------------- |
+| `usage:` / unknown command   | Old CLI or typo                                   | `dbt-tools schema`; upgrade `@dbt-tools/cli`.           |
+| `VALIDATION_ERROR`           | Malformed id or disallowed characters             | Re-copy `unique_id` or resolve via `search`/`discover`. |
+| `ARTIFACT_BUNDLE_INCOMPLETE` | Missing `manifest.json` (or other required files) | Point `--dbt-target` at a directory with a manifest.    |
+| Empty or null sections       | **Fields** over-filtering                         | Drop `--fields` and re-run, or check schema.            |
+| Ambiguous resolution in JSON | Multiple candidates                               | Tighten query or use `discover` first.                  |
 
 ## Confirmed current behavior (do this, do not guess)
 

--- a/plugins/dbt-tools-cli/skills/status/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/status/SKILL.md
@@ -4,20 +4,21 @@ description: >-
   Check dbt artifact presence, recency, and analysis readiness with `dbt-tools status` (or `freshness`); interpret `readiness` and file stats when the user asks if artifacts exist, are stale, or are ready. Optional—not a required preflight for other investigation flows.
 compatibility: dbt-tools CLI (global `dbt-tools` on PATH). Reads `--dbt-target` or `DBT_TOOLS_DBT_TARGET`; `status` is filesystem- or download-scoped, not a substitute for dbt build orchestration. Works with any terminal agent or SKILL.md consumer.
 ---
+<!-- markdownlint-disable MD013 MD060 -->
 
 # dbt artifact status and freshness
 
 ## Trigger scenarios
 
 - The user asks whether **artifacts exist**, are **stale**, or are **ready** for dbt artifact analysis.
-- You need a **ground-truth snapshot** of what is under a dbt target (paths, `exists`, ages) before *choosing* whether to run heavier commands.
+- You need a **ground-truth snapshot** of what is under a dbt target (paths, `exists`, ages) before _choosing_ whether to run heavier commands.
 - A prior command failed with **missing file** or **incomplete bundle**—use `status` to align on what is actually on disk (or in a remote prefix).
 
 ## Purpose
 
 Use **`dbt-tools status`** (or the **`freshness`** alias) to report whether **`manifest.json`** and **`run_results.json`** are present, their paths, modification times, and a **readiness** label. This is the primary CLI surface for **artifact readiness** and **rough freshness** (file mtimes), without parsing full artifact JSON (local case).
 
-**Do not** treat this skill as a **mandatory gate** before every `deps`, `search`, or `explain` run. If the user already provided a valid **`--dbt-target`**, use it and proceed; call **`status`** when readiness or staleness is the *question*.
+**Do not** treat this skill as a **mandatory gate** before every `deps`, `search`, or `explain` run. If the user already provided a valid **`--dbt-target`**, use it and proceed; call **`status`** when readiness or staleness is the _question_.
 
 ## Inputs the agent should identify
 

--- a/plugins/dbt-tools-cli/skills/status/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/status/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: status
+description: >-
+  Check dbt artifact presence, recency, and analysis readiness with `dbt-tools status` (or `freshness`); interpret `readiness` and file stats when the user asks if artifacts exist, are stale, or are ready. Optional—not a required preflight for other investigation flows.
+compatibility: dbt-tools CLI (global `dbt-tools` on PATH). Reads `--dbt-target` or `DBT_TOOLS_DBT_TARGET`; `status` is filesystem- or download-scoped, not a substitute for dbt build orchestration. Works with any terminal agent or SKILL.md consumer.
+---
+
+# dbt artifact status and freshness
+
+## Trigger scenarios
+
+- The user asks whether **artifacts exist**, are **stale**, or are **ready** for dbt artifact analysis.
+- You need a **ground-truth snapshot** of what is under a dbt target (paths, `exists`, ages) before *choosing* whether to run heavier commands.
+- A prior command failed with **missing file** or **incomplete bundle**—use `status` to align on what is actually on disk (or in a remote prefix).
+
+## Purpose
+
+Use **`dbt-tools status`** (or the **`freshness`** alias) to report whether **`manifest.json`** and **`run_results.json`** are present, their paths, modification times, and a **readiness** label. This is the primary CLI surface for **artifact readiness** and **rough freshness** (file mtimes), without parsing full artifact JSON (local case).
+
+**Do not** treat this skill as a **mandatory gate** before every `deps`, `search`, or `explain` run. If the user already provided a valid **`--dbt-target`**, use it and proceed; call **`status`** when readiness or staleness is the *question*.
+
+## Inputs the agent should identify
+
+- **Artifact root**: `--dbt-target` path, or `DBT_TOOLS_DBT_TARGET`, or a remote **`s3://` / `gs://`** prefix when applicable.
+- **What “ready” means for the next step**: full graph+run analysis needs both core files; some workflows tolerate **manifest-only** (see [references/commands.md](references/commands.md)).
+- **Machine-readable output need**: use **`--json`** when the agent must parse stdout (and structured error JSON on stderr for modeled failures).
+
+## Recommended command pattern
+
+1. **Default (explicit JSON for agents in interactive TTYs):**
+
+   `dbt-tools status --dbt-target <path-or-uri> --json`
+
+2. **Omit the flag in CI** when the environment already sets `DBT_TOOLS_DBT_TARGET`.
+
+3. For **readability only** in a human session, you may drop `--json`; for **automation**, always pass `--json` so output and error shapes are consistent.
+
+Cheat sheet and readiness matrix: [references/commands.md](references/commands.md). Full CLI context (remote behavior, error codes) stays in the package README—do not copy exhaustive option lists here.
+
+## How to interpret results
+
+- Read **`readiness`**: `full` → both `manifest.json` and `run_results.json` present; `manifest-only` → manifest only; `unavailable` → no manifest.
+- Use **`manifest.exists` / `run_results.exists`**, **paths**, **`modified_at` / `age_seconds`**, and **`summary`** to answer “exists / how old / can we analyze execution?”
+- For **local** paths, `status` reflects **directory** contents; for **remote** targets the CLI fetches the same fixed keys, then reports stats (see CLI README if you need remote details).
+
+## Failure handling
+
+- **Missing or invalid target**: error text or (with **`--json`**) structured stderr—pass through to the user; suggest fixing path, env, or remote credentials.
+- **`unavailable` readiness**: do not run manifest-based analysis until **`manifest.json`** is produced (e.g. a dbt parse/compile that writes artifacts).
+- After **upstream failures** in other commands (missing artifact file), re-run **`status --json`** with the **same** root to reconcile what is missing.
+
+**Uncertain about flags?** `dbt-tools schema status` or `dbt-tools status --help` (current CLI).
+
+## Verification / completion criteria
+
+- The user’s question about **existence, freshness, or readiness** is answered from parsed **`status` output** (or a clear error).
+- The agent has recorded **`readiness`**, the **checked paths** (`target_dir` / manifest / run_results paths in JSON), and whether **run-scoped** commands (e.g. `timeline`, `run-report` style flows) are appropriate.
+- The agent has **not** implied that **`status` must** run before unrelated commands when the user already provided a valid artifact root.
+
+## Related (optional)
+
+Other plugin skills under the same `skills/` root cover discovery, dependencies, and explain/impact. They do not require this skill to have been run first.

--- a/plugins/dbt-tools-cli/skills/status/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/status/references/commands.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD060 -->
 # status — command cheat sheet
 
 ## Stable invocation
@@ -17,11 +18,11 @@ dbt-tools status --json
 
 ## Readiness (stdout JSON)
 
-| `readiness`   | Typically means |
-| ------------- | --------------- |
-| `full`        | `manifest.json` and `run_results.json` present. |
+| `readiness`     | Typically means                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| `full`          | `manifest.json` and `run_results.json` present.                                          |
 | `manifest-only` | `manifest.json` only—graph/manifest analysis possible; run-result-only commands are not. |
-| `unavailable` | `manifest.json` missing—most artifact commands will fail. |
+| `unavailable`   | `manifest.json` missing—most artifact commands will fail.                                |
 
 ## Bounding output
 
@@ -37,13 +38,13 @@ dbt-tools status --json
 
 ## Common failure modes (plain language)
 
-| Symptom | Likely cause | What to do |
-| ------- | ------------ | ---------- |
-| No `--dbt-target` and no `DBT_TOOLS_DBT_TARGET` | Artifact root not specified | Set env or pass `--dbt-target`. |
-| `readiness: "unavailable"` | No `manifest.json` | Generate/copy dbt artifacts into the target. |
-| Run-scoped command fails; `readiness: "manifest-only"` | `run_results.json` missing | Run a dbt command that produces `run_results`, or use manifest-only tools. |
-| Error about **remote** / credentials | S3 or GCS access | Check AWS/GCP config and prefix (see main CLI README). |
-| `VALIDATION_ERROR` in structured stderr | Bad path or invalid characters in flags | Fix input; do not pass URL query fragments in resource or path args. |
+| Symptom                                                | Likely cause                            | What to do                                                                 |
+| ------------------------------------------------------ | --------------------------------------- | -------------------------------------------------------------------------- |
+| No `--dbt-target` and no `DBT_TOOLS_DBT_TARGET`        | Artifact root not specified             | Set env or pass `--dbt-target`.                                            |
+| `readiness: "unavailable"`                             | No `manifest.json`                      | Generate/copy dbt artifacts into the target.                               |
+| Run-scoped command fails; `readiness: "manifest-only"` | `run_results.json` missing              | Run a dbt command that produces `run_results`, or use manifest-only tools. |
+| Error about **remote** / credentials                   | S3 or GCS access                        | Check AWS/GCP config and prefix (see main CLI README).                     |
+| `VALIDATION_ERROR` in structured stderr                | Bad path or invalid characters in flags | Fix input; do not pass URL query fragments in resource or path args.       |
 
 ## If behavior or flags differ
 

--- a/plugins/dbt-tools-cli/skills/status/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/status/references/commands.md
@@ -1,0 +1,56 @@
+# status — command cheat sheet
+
+## Stable invocation
+
+```bash
+dbt-tools status --dbt-target ./target --json
+```
+
+- **`--json`**: Prefer for agents so stdout is JSON; stderr can carry structured error JSON for modeled failures (see CLI “Error handling”).
+
+```bash
+export DBT_TOOLS_DBT_TARGET=./target
+dbt-tools status --json
+```
+
+- **`freshness`**: alias of `status` (same behavior).
+
+## Readiness (stdout JSON)
+
+| `readiness`   | Typically means |
+| ------------- | --------------- |
+| `full`        | `manifest.json` and `run_results.json` present. |
+| `manifest-only` | `manifest.json` only—graph/manifest analysis possible; run-result-only commands are not. |
+| `unavailable` | `manifest.json` missing—most artifact commands will fail. |
+
+## Bounding output
+
+- `status` is small; you rarely need **`--fields`**. If the schema supports it and the payload is large, trim fields the same way as other commands (see `dbt-tools schema status`).
+
+## When to use `status`
+
+- The user **asks** if artifacts are present, fresh, or ready.
+- You **suspect** missing or stale files after a confusing error.
+- You are **onboarding** in a new environment and need a one-shot bundle check.
+
+**Not required** before every other `dbt-tools` call when `--dbt-target` is already trusted.
+
+## Common failure modes (plain language)
+
+| Symptom | Likely cause | What to do |
+| ------- | ------------ | ---------- |
+| No `--dbt-target` and no `DBT_TOOLS_DBT_TARGET` | Artifact root not specified | Set env or pass `--dbt-target`. |
+| `readiness: "unavailable"` | No `manifest.json` | Generate/copy dbt artifacts into the target. |
+| Run-scoped command fails; `readiness: "manifest-only"` | `run_results.json` missing | Run a dbt command that produces `run_results`, or use manifest-only tools. |
+| Error about **remote** / credentials | S3 or GCS access | Check AWS/GCP config and prefix (see main CLI README). |
+| `VALIDATION_ERROR` in structured stderr | Bad path or invalid characters in flags | Fix input; do not pass URL query fragments in resource or path args. |
+
+## If behavior or flags differ
+
+Use runtime discovery, not hard-coded option lists:
+
+```bash
+dbt-tools schema
+dbt-tools schema status
+dbt-tools status --help
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds four documentation-only Agent Skills under `plugins/dbt-tools-cli/skills/` for AI agents using the `dbt-tools` CLI.

**CI follow-up (Trunk / markdownlint):** `markdownlint-cli2` with `extends: markdownlint/style/prettier` effectively keeps MD013/MD060 active; we added per-file `<!-- markdownlint-disable MD013 MD060 -->` after YAML frontmatter in all plugin `SKILL.md` and `references/*.md` files (including the existing `dbt-artifacts-status` skill) so long descriptions and agent-oriented tables pass the **Trunk Check** workflow.

## Test report (local)

- `pnpm dlx markdownlint-cli2@0.22.0 -c .trunk/configs/.markdownlint.yaml "plugins/dbt-tools-cli/skills/**/*.md"` — 0 errors
- `pnpm test`, `pnpm lint:report`, `pnpm knip`, `pnpm coverage:report` — all exit 0
- `./plugins/tests/verify-agent-plugins.sh structural` — OK

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cbd9c6f-32b7-4d46-8e69-09ceb27ea07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cbd9c6f-32b7-4d46-8e69-09ceb27ea07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

