### PR TITLE
Add portable dbt-tools CLI investigation skills (status, discover-search, deps, explain-impact)

### DIFF
--- a/plugins/dbt-tools-cli/README.md
+++ b/plugins/dbt-tools-cli/README.md
@@ -5,5 +5,9 @@ First-party plugin wrapping the **[`@dbt-tools/cli`](../../packages/dbt-tools/cl
 | Skill                                                          | Purpose                                                                        |
 | -------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | [`dbt-artifacts-status`](skills/dbt-artifacts-status/SKILL.md) | Run `dbt-tools status` first; interpret `readiness` before other CLI commands. |
+| [`status`](skills/status/SKILL.md)                             | Check artifact readiness/freshness when users ask whether targets are analyzable. |
+| [`discover-search`](skills/discover-search/SKILL.md)           | Resolve dbt resources and candidate `unique_id` values from names, tags, and fuzzy wording. |
+| [`deps`](skills/deps/SKILL.md)                                 | Traverse upstream/downstream dependencies from a known `unique_id`. |
+| [`explain-impact`](skills/explain-impact/SKILL.md)             | Explain resource behavior and summarize likely downstream impact. |
 
 See [plugins/README.md](../README.md) for marketplace layout and discovery. For verification, CI commands, and per-engine manifest maintenance, see [plugins/CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/plugins/dbt-tools-cli/README.md
+++ b/plugins/dbt-tools-cli/README.md
@@ -2,12 +2,12 @@
 
 First-party plugin wrapping the **[`@dbt-tools/cli`](../../packages/dbt-tools/cli/README.md)** **structured interface** (JSON, `schema`, `status`) so coding agents and skills can orchestrate artifact analysis alongside other tools. Skills live under [`skills/`](skills/).
 
-| Skill                                                          | Purpose                                                                        |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| [`dbt-artifacts-status`](skills/dbt-artifacts-status/SKILL.md) | Run `dbt-tools status` first; interpret `readiness` before other CLI commands. |
-| [`status`](skills/status/SKILL.md)                             | Check artifact readiness/freshness when users ask whether targets are analyzable. |
+| Skill                                                          | Purpose                                                                                     |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [`dbt-artifacts-status`](skills/dbt-artifacts-status/SKILL.md) | Run `dbt-tools status` first; interpret `readiness` before other CLI commands.              |
+| [`status`](skills/status/SKILL.md)                             | Check artifact readiness/freshness when users ask whether targets are analyzable.           |
 | [`discover-search`](skills/discover-search/SKILL.md)           | Resolve dbt resources and candidate `unique_id` values from names, tags, and fuzzy wording. |
-| [`deps`](skills/deps/SKILL.md)                                 | Traverse upstream/downstream dependencies from a known `unique_id`. |
-| [`explain-impact`](skills/explain-impact/SKILL.md)             | Explain resource behavior and summarize likely downstream impact. |
+| [`deps`](skills/deps/SKILL.md)                                 | Traverse upstream/downstream dependencies from a known `unique_id`.                         |
+| [`explain-impact`](skills/explain-impact/SKILL.md)             | Explain resource behavior and summarize likely downstream impact.                           |
 
 See [plugins/README.md](../README.md) for marketplace layout and discovery. For verification, CI commands, and per-engine manifest maintenance, see [plugins/CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/plugins/dbt-tools-cli/skills/deps/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/deps/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: deps
+description: Investigate upstream/downstream dependencies for a known dbt resource id, including depth-limited, flat/tree, and build-order views.
+compatibility: dbt-tools CLI on PATH; requires a valid resource unique_id in the target manifest.
+---
+
+# deps
+
+## Trigger scenarios
+
+Activate this skill when the user asks:
+
+- what depends on a resource,
+- what a resource depends on,
+- how far dependency impact propagates,
+- what build order to follow upstream.
+
+## Purpose
+
+Use `dbt-tools deps` to traverse lineage from a known `unique_id` and summarize dependency shape for planning, debugging, and impact review.
+
+## Inputs the agent should identify
+
+- Resource `unique_id` (or first resolve it via discovery/search).
+- Target direction (`upstream` or `downstream`).
+- Desired depth (immediate neighbors vs wider graph).
+- Output style needed by the user (`flat`, `tree`, build-order style where supported).
+- Need for machine-readable output (`--json`).
+
+## Recommended command pattern
+
+Default to parse-friendly output:
+
+```bash
+dbt-tools deps <unique_id> --dbt-target <target> --json
+```
+
+Adjust direction/depth/shape at a high level to match the question. Use bounded output (`--limit`/`--fields` when available) if results are large.
+
+For stable command recipes, see [references/commands.md](references/commands.md).
+
+## How to interpret results
+
+- Confirm the root node matches the requested resource.
+- Separate immediate neighbors from deeper dependencies when depth > 1.
+- Highlight critical downstream blast radius or key upstream prerequisites.
+- When build-order output is available, use it as execution guidance rather than as full scheduling truth.
+
+## Failure handling
+
+- Invalid resource id: re-run discovery/search and retry with a confirmed `unique_id`.
+- Missing target artifacts: request/correct `--dbt-target` and ensure manifest exists.
+- Excessively large graph: reduce depth or fields, or switch to a flat summary.
+- Option mismatch: check `dbt-tools schema` or `dbt-tools deps --help`.
+
+## Verification / completion criteria
+
+Consider this skill complete when the agent has:
+
+1. Run `deps` with the requested direction and reasonable depth.
+2. Returned dependency results in the user’s preferred shape (flat/tree/build-order where available).
+3. Summarized key upstream/downstream findings clearly.
+4. Identified next analysis steps (for example `impact` or focused explanation on critical nodes).

--- a/plugins/dbt-tools-cli/skills/deps/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/deps/references/commands.md
@@ -1,0 +1,53 @@
+# deps command cheat sheet
+
+Use these stable patterns for lineage investigation from a known `unique_id`.
+
+## Baseline JSON query
+
+```bash
+dbt-tools deps model.my_project.orders --dbt-target ./target --json
+```
+
+## Direction patterns
+
+```bash
+dbt-tools deps model.my_project.orders --dbt-target ./target --direction upstream --json
+
+dbt-tools deps model.my_project.orders --dbt-target ./target --direction downstream --json
+```
+
+## Depth-limited traversal
+
+```bash
+dbt-tools deps model.my_project.orders --dbt-target ./target --depth 1 --json
+```
+
+Use shallow depth first for quick context, then widen only if needed.
+
+## Output shape patterns
+
+```bash
+dbt-tools deps model.my_project.orders --dbt-target ./target --format flat --json
+
+dbt-tools deps model.my_project.orders --dbt-target ./target --format tree --json
+
+dbt-tools deps model.my_project.orders --dbt-target ./target --direction upstream --build-order --json
+```
+
+If certain options are unavailable in your CLI version, inspect:
+
+```bash
+dbt-tools schema
+dbt-tools deps --help
+```
+
+## Output-bounding guidance
+
+When supported, use small field sets (`--fields`) or pagination-like options to keep agent context manageable.
+
+## Common failure responses
+
+- **Missing artifact target:** confirm `--dbt-target` or `DBT_TOOLS_DBT_TARGET`.
+- **Missing required artifact files:** deps needs manifest-backed artifacts; ask user to regenerate or point at the right target.
+- **Invalid resource id:** run discovery/search to recover a valid `unique_id`.
+- **Unsupported or changed command options:** stop assuming syntax; use `dbt-tools schema` / `dbt-tools deps --help`.

--- a/plugins/dbt-tools-cli/skills/discover-search/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/discover-search/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: discover-search
+description: Find dbt resources by name, type, tag, package, path, or fuzzy user wording and resolve candidate unique_ids for later investigation.
+compatibility: dbt-tools CLI on PATH; works with manifest-backed targets.
+---
+
+# discover-search
+
+## Trigger scenarios
+
+Activate this skill when the user asks to:
+
+- find a model/test/source by approximate wording,
+- list resources matching tags, package, type, or path,
+- identify likely `unique_id` values before running dependency or impact analysis.
+
+## Purpose
+
+Use `dbt-tools discover` and/or `dbt-tools search` to map user language into concrete dbt resources.
+
+The usual output of this skill is a short, ranked candidate set with one or more `unique_id` values.
+
+## Inputs the agent should identify
+
+- `--dbt-target` location (or a confirmed target environment variable).
+- User constraints: name fragments, resource type, tags, package, path, domain wording.
+- Whether the user wants one best match or multiple candidates.
+- Need for machine-readable parsing (`--json` preferred).
+
+## Recommended command pattern
+
+Start with JSON output and narrow quickly:
+
+```bash
+dbt-tools discover --dbt-target <target> --json
+```
+
+or
+
+```bash
+dbt-tools search <query> --dbt-target <target> --json
+```
+
+Then apply high-level output bounds (`--limit`, optional `--fields`) to keep context small.
+
+For compact recipes and branch guidance, see [references/commands.md](references/commands.md).
+
+## How to interpret results
+
+- Prioritize exact/strong matches to user constraints.
+- Extract `unique_id` for each top candidate.
+- If multiple plausible matches remain, present a short disambiguation list.
+- If no matches, suggest constraint relaxation (broader query, fewer filters, different target).
+
+## Failure handling
+
+- Missing artifacts/manifest: pause discovery and ask for a correct artifact target.
+- Zero matches: broaden search terms and remove overly strict filters.
+- Ambiguous results: ask the user to choose among top candidates or refine constraints.
+- Option mismatch or renamed commands: inspect `dbt-tools schema` and per-command `--help`.
+
+## Verification / completion criteria
+
+Consider this skill complete when the agent has:
+
+1. Run discovery/search with user-relevant constraints.
+2. Produced at least one candidate `unique_id` (or clearly explained zero results).
+3. Returned a concise shortlist ready for follow-up commands.
+4. Documented the next action (for example `deps`, `explain`, or `impact`) for the chosen resource.

--- a/plugins/dbt-tools-cli/skills/discover-search/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/discover-search/references/commands.md
@@ -1,0 +1,48 @@
+# discover/search command cheat sheet
+
+Use these lightweight patterns to turn user wording into `unique_id` candidates.
+
+## Start broad (JSON)
+
+```bash
+dbt-tools search "orders" --dbt-target ./target --json
+```
+
+or
+
+```bash
+dbt-tools discover --dbt-target ./target --json
+```
+
+Choose whichever command is available and better aligned to your installed CLI surface.
+
+## Narrow result size
+
+```bash
+dbt-tools search "orders" --dbt-target ./target --json --limit 20
+```
+
+If supported, add `--fields` to keep only identifiers and key labels.
+
+When options differ across versions, check:
+
+```bash
+dbt-tools schema
+dbt-tools search --help
+dbt-tools discover --help
+```
+
+## Typical workflow
+
+1. Query by the user’s wording.
+2. Apply type/tag/package/path filters if available.
+3. Return top `unique_id` candidates.
+4. Hand off selected id to `deps`, `explain`, or `impact`.
+
+## Common failure responses
+
+- **Missing artifact target:** set/confirm `--dbt-target` (or `DBT_TOOLS_DBT_TARGET`).
+- **Missing required artifact files:** manifest is required for discovery; ask user to regenerate artifacts.
+- **Ambiguous results:** provide a short candidate list and ask for selection.
+- **Zero discovery results:** broaden query or remove strict filters; verify target is correct.
+- **Unsupported or changed command options:** inspect `dbt-tools schema` or command-specific `--help`.

--- a/plugins/dbt-tools-cli/skills/explain-impact/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/explain-impact/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: explain-impact
+description: Explain a selected dbt resource and reason about downstream impact using dbt-tools explain/impact workflows.
+compatibility: dbt-tools CLI on PATH; command availability may vary by version.
+---
+
+# explain-impact
+
+## Trigger scenarios
+
+Activate this skill when the user asks:
+
+- what a specific resource does,
+- what would be affected by changing a resource,
+- how to communicate likely blast radius to stakeholders,
+- for a concise evidence-based explanation before making changes.
+
+## Purpose
+
+Use `dbt-tools explain` and `dbt-tools impact` (when available) to convert a selected `unique_id` into a practical explanation and impact summary.
+
+Because CLI surfaces evolve, treat command discovery as part of the workflow when option names are uncertain.
+
+## Inputs the agent should identify
+
+- Selected resource `unique_id`.
+- Target artifact location (`--dbt-target` or environment variable).
+- User intent: descriptive explanation, change impact, or both.
+- Preferred output mode (`--json` for parsing and structured reporting).
+
+## Recommended command pattern
+
+Start with command availability checks when uncertain:
+
+```bash
+dbt-tools schema
+```
+
+Then run the relevant command(s), preferring JSON:
+
+```bash
+dbt-tools explain <unique_id> --dbt-target <target> --json
+
+dbt-tools impact <unique_id> --dbt-target <target> --json
+```
+
+If syntax differs in the installed version, check `dbt-tools <command> --help` before retrying.
+
+For lightweight recipes and fallback branches, see [references/commands.md](references/commands.md).
+
+## How to interpret results
+
+- For `explain`: summarize resource role, context, and notable metadata.
+- For `impact`: summarize likely downstream affected nodes and practical blast-radius tiers.
+- Separate high-confidence CLI evidence from agent inference.
+- Keep outputs bounded and focused on the user’s decision.
+
+## Failure handling
+
+- Command missing or renamed: verify with `dbt-tools schema` and per-command help.
+- Invalid resource id: resolve a valid id with discovery/search, then rerun.
+- Missing artifacts: surface what is missing and request correct target artifacts.
+- Large result sets: use high-level field/limit controls where available and summarize top impact areas.
+
+## Verification / completion criteria
+
+Consider this skill complete when the agent has:
+
+1. Confirmed command availability (if needed) via `schema` or `--help`.
+2. Run `explain` and/or `impact` for the selected resource.
+3. Returned a concise explanation and impact summary grounded in CLI output.
+4. Provided clear next steps (for example deeper `deps` traversal, validation run, or rollout caution).

--- a/plugins/dbt-tools-cli/skills/explain-impact/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/explain-impact/references/commands.md
@@ -1,0 +1,41 @@
+# explain/impact command cheat sheet
+
+Use this page for stable investigation flow, not exhaustive CLI syntax.
+
+## Check availability first when uncertain
+
+```bash
+dbt-tools schema
+dbt-tools explain --help
+dbt-tools impact --help
+```
+
+If `impact` is not available in your installed CLI, continue with `explain` plus `deps` for impact reasoning.
+
+## Explain a selected resource
+
+```bash
+dbt-tools explain model.my_project.orders --dbt-target ./target --json
+```
+
+## Estimate or inspect impact
+
+```bash
+dbt-tools impact model.my_project.orders --dbt-target ./target --json
+```
+
+Prefer JSON for machine-readable stdout and structured stderr.
+
+## Keep output bounded
+
+When supported, use `--fields`, `--limit`, or similar controls to keep context small and focused on key nodes.
+
+For version-specific option names, rely on `schema`/`--help` instead of assumptions.
+
+## Common failure responses
+
+- **Missing artifact target:** confirm `--dbt-target` (or `DBT_TOOLS_DBT_TARGET`).
+- **Missing required artifact files:** request manifest/run artifacts before explanation/impact analysis.
+- **Invalid resource id:** use discovery/search to get a valid `unique_id`.
+- **Ambiguous or zero discovery results:** pause and disambiguate before running explain/impact.
+- **Unsupported or changed command options:** inspect `dbt-tools schema` or `dbt-tools <command> --help` and retry with supported syntax.

--- a/plugins/dbt-tools-cli/skills/status/SKILL.md
+++ b/plugins/dbt-tools-cli/skills/status/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: status
+description: Check dbt artifact readiness and freshness under a target path so an agent can decide whether analysis commands are likely to work.
+compatibility: dbt-tools CLI on PATH; local or remote --dbt-target supported.
+---
+
+# status
+
+## Trigger scenarios
+
+Activate this skill when the user asks whether dbt artifacts:
+
+- exist at a target directory or prefix,
+- are complete enough for analysis, or
+- look stale based on file timestamps.
+
+## Purpose
+
+Use `dbt-tools status` (or `freshness`) to quickly classify artifact availability and recency without assuming deeper command success.
+
+This skill is useful as a targeted check, but it is **not** a mandatory preflight before every other skill.
+
+## Inputs the agent should identify
+
+- Target location (`--dbt-target`), if provided by the user.
+- Whether machine-readable output is needed (`--json` preferred for parsing).
+- Whether the user cares about readiness, freshness, or both.
+
+## Recommended command pattern
+
+Prefer JSON for agent parsing:
+
+```bash
+dbt-tools status --dbt-target <target> --json
+```
+
+If `--dbt-target` is omitted intentionally, rely on `DBT_TOOLS_DBT_TARGET` if set.
+
+For lightweight command recipes and failure branches, see [references/commands.md](references/commands.md).
+
+## How to interpret results
+
+- Extract readiness classification and required-file presence first.
+- Report exactly which required files were found or missing.
+- If freshness fields are present, summarize age and whether it matches user expectations.
+- Use the result to decide whether to proceed, request artifact generation, or switch to a different target.
+
+## Failure handling
+
+- Missing target or missing required files: explain what is absent and suggest producing artifacts (for example by running dbt and pointing to the correct target).
+- Invalid path or inaccessible remote prefix: surface the CLI error, then retry only after correcting the target.
+- Option mismatch: check `dbt-tools schema` or `dbt-tools status --help` before guessing flags.
+
+## Verification / completion criteria
+
+Consider this skill complete when the agent has:
+
+1. Run `status` (preferably with `--json` when parsing is needed).
+2. Reported readiness and file presence clearly.
+3. Stated whether analysis can proceed for the user’s goal.
+4. Provided a concrete next step when artifacts are incomplete or stale.

--- a/plugins/dbt-tools-cli/skills/status/references/commands.md
+++ b/plugins/dbt-tools-cli/skills/status/references/commands.md
@@ -1,0 +1,42 @@
+# status command cheat sheet
+
+Use this page for stable, agent-friendly readiness checks.
+
+## Core recipe
+
+```bash
+dbt-tools status --dbt-target ./target --json
+```
+
+- Use `--json` when you need machine-readable stdout and structured stderr.
+- Reuse the same `--dbt-target` for follow-up commands.
+
+## Freshness-oriented check
+
+```bash
+dbt-tools freshness --dbt-target ./target --json
+```
+
+If `freshness` behavior is unclear in your installed version, inspect:
+
+```bash
+dbt-tools schema
+dbt-tools freshness --help
+```
+
+## Output-bounding guidance
+
+`status` is usually small already. If your CLI version supports field filtering, prefer a small subset (for example readiness + file metadata) to keep agent context compact.
+
+When uncertain about supported filters/options, use:
+
+```bash
+dbt-tools schema
+dbt-tools status --help
+```
+
+## Common failure responses
+
+- **Missing artifact target:** confirm or request `--dbt-target`, or ensure `DBT_TOOLS_DBT_TARGET` is set.
+- **Missing required artifact files:** report missing `manifest.json` and/or `run_results.json`; ask user to regenerate artifacts and retry.
+- **Unsupported or changed command options:** stop assuming flags; inspect `dbt-tools schema` or `dbt-tools status --help`.


### PR DESCRIPTION
### Motivation

- Provide portable, documentation-style Agent Skills so AI coding agents can reliably use the installed `dbt-tools` CLI for artifact investigation without adding runtime wrappers. 
- Surface stable, JSON-first, agent-friendly command patterns and failure-handling advice rather than duplicating the full CLI reference so skills remain robust across CLI surface changes.

### Description

- Added four independent skills under `plugins/dbt-tools-cli/skills/`: `status`, `discover-search`, `deps`, and `explain-impact`, each containing a `SKILL.md` with YAML frontmatter (`name`, `description`, `compatibility`) and a self-contained workflow (trigger scenarios, inputs, recommended command pattern, interpretation, failure handling, verification). 
- For each skill added a lightweight agent-oriented cheat sheet at `references/commands.md` with JSON-first examples, output-bounding guidance, and common failure responses.
- Updated `plugins/dbt-tools-cli/README.md` to list the new skills so agents can discover them from the plugin index. 
- All changes are documentation-only and confined to `plugins/dbt-tools-cli/` (no CLI implementation, code, or new dependencies were added).

### Testing

- Ran `./plugins/tests/verify-agent-plugins.sh structural` and it completed successfully. 
- Ran unit tests via `pnpm test` and they passed (`317 files, 2751 tests` reported). 
- Ran `pnpm lint:report` and it produced a clean lint report (score 100). 
- Built the workspace with `pnpm build` to satisfy a knip config-loading prerequisite and then re-ran `pnpm knip`, which succeeded with configuration hints. 
- Ran coverage via `pnpm coverage:report` and it completed and wrote `coverage-report.json`. 
- `pnpm exec trunk check ...` on the touched Markdown paths failed in this environment due to a network `ENETUNREACH` error when Trunk tried to fetch remote resources; this is an environment/network failure and not a repo-content error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8dc12688832cbdbb770a30d7dc12)