### PR TITLE
feat: auto-install Trunk git hooks for cloud coding agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,16 @@
   },
   "_comment": "Project defaults (committed). Personal overrides: .claude/settings.local.json (gitignored). Verify layers with /status in Claude Code. Sandbox: /sandbox in REPL; autoAllowBashIfSandboxed trades fewer prompts for less review of sandboxed commands.",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm exec trunk git-hooks sync"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,32 @@ If IT must enforce non-overridable rules (permissions, domains, MCP, marketplace
 
 ## Commands
 
+### Agent session startup (git hooks)
+
+Trunk's pre-commit (`trunk-fmt-pre-commit`) and pre-push (`trunk-check-pre-push`) actions
+auto-format code and run linters before each commit and push. These hooks must be installed
+once per workspace checkout — skipping this is the primary reason cloud agent sessions
+produce commits that fail the `trunk_check` CI job.
+
+Run once per fresh workspace (from the repo root):
+
+```sh
+pnpm exec trunk git-hooks sync
+```
+
+This is idempotent — safe to run on every session start. Per-agent coverage:
+
+| Agent                             | How hooks are installed                                                                                                                                                                         |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Claude Code**                   | Automatic — `SessionStart` hook in [`.claude/settings.json`](.claude/settings.json) runs `pnpm exec trunk git-hooks sync` at the start of every session                                         |
+| **Codex**                         | Automatic — the `prepare` lifecycle script in `package.json` runs `trunk git-hooks sync` when `pnpm install` is executed during sandbox setup (CI-guarded so it does not run in GitHub Actions) |
+| **Cursor**                        | Manual — run `pnpm exec trunk install` once in Cursor's integrated terminal at the start of your workspace session                                                                              |
+| **GitHub Copilot / other agents** | Manual — run `pnpm exec trunk install` in the terminal before making your first commit                                                                                                          |
+
+If Trunk's hooks are missing and you cannot run `trunk install`, use
+`pnpm format:without-trunk` before committing as a fallback to handle ESLint and Prettier
+formatting; then push and let CI run the full Trunk check.
+
 - **Codex CLI:** Project defaults live in [`.codex/config.toml`](.codex/config.toml). Codex loads that file only when the project is **trusted**; otherwise it uses your user config ([Config basics](https://developers.openai.com/codex/config-basic)).
 - **Dead code (Knip):** `pnpm knip` (optional fix: `pnpm knip:fix`, review diffs). Uses workspace entry points in [`knip.json`](knip.json).
 - **Trunk (lint/format orchestration):** The root dev dependency `@trunkio/launcher` matches [Trunk’s documented pnpm install](https://docs.trunk.io/code-quality/overview/cli/getting-started/install) (`pnpm add -D @trunkio/launcher`) and supplies `trunk` on `PATH` for `pnpm run` / `pnpm exec` after `pnpm install`. **`pnpm format`** and **`pnpm lint`** run Trunk first (`format:trunk`, `lint:trunk`); **`pnpm trunk`** passes through to the CLI (Trunk's documented pattern). If Trunk cannot run, use **`pnpm format:without-trunk`** / **`pnpm lint:without-trunk`**. Config and CLI version: [`.trunk/trunk.yaml`](.trunk/trunk.yaml). CI: [`.github/workflows/trunk_check.yml`](.github/workflows/trunk_check.yml) (`trunk-io/trunk-action`). Prerequisites detail: [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint:semgrep": "semgrep ci",
     "lint:trunk": "pnpm exec trunk check -y",
     "lint:trunk-all": "pnpm exec trunk check --all -y",
+    "prepare": "if [ -z \"${CI:-}\" ]; then pnpm exec trunk git-hooks sync; fi",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "pnpm --filter @dbt-tools/web test:e2e",


### PR DESCRIPTION
Cloud-based agents (Claude Code, Codex, Cursor, Copilot) always start from
a fresh checkout without Trunk's git hooks active, causing pre-commit/pre-push
checks to be skipped and producing commits that fail the trunk_check CI job.

- Add `prepare` lifecycle script to package.json: runs `trunk git-hooks sync`
  on `pnpm install`, CI-guarded so it never fires in GitHub Actions
- Add `SessionStart` hook to `.claude/settings.json`: runs `trunk git-hooks sync`
  at the start of every Claude Code session (covers persistent workspaces where
  node_modules already exists and prepare doesn't re-run)
- Add "Agent session startup" section to AGENTS.md: documents the mechanism
  and per-agent coverage table (Claude Code, Codex, Cursor, Copilot)

Trunk uses `git config core.hooksPath` to manage hooks in its cache dir,
so `trunk git-hooks sync` is the correct install command (not `trunk install`).

https://claude.ai/code/session_01JqZC7nJpG3EWYfeomr4s3s