### PR TITLE
chore: bump monorepo version to 0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbt-artifacts-parser",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "description": "A community-driven TypeScript library for parsing dbt artifacts with full type safety and automatic version detection.",
   "keywords": [],

--- a/packages/dbt-artifacts-parser/package.json
+++ b/packages/dbt-artifacts-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbt-artifacts-parser",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "TypeScript library for parsing dbt artifacts",
   "keywords": [],
   "license": "Apache-2.0",

--- a/packages/dbt-tools/cli/package.json
+++ b/packages/dbt-tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbt-tools/cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Structured CLI for dbt artifact analysis — JSON, schema introspection, field filtering; for operators, CI, and agents",
   "keywords": [
     "dbt",

--- a/packages/dbt-tools/core/package.json
+++ b/packages/dbt-tools/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbt-tools/core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Composable analysis engine for dbt artifacts (graphs, execution analysis) — substrate for @dbt-tools/cli and @dbt-tools/web",
   "keywords": [
     "dbt",

--- a/packages/dbt-tools/web/package.json
+++ b/packages/dbt-tools/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbt-tools/web",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Browser UI for deterministic dbt artifact investigation — dependencies, execution timelines, inventory (no LLM required)",
   "keywords": [
     "dbt",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps the **unified monorepo semver** from **0.5.4** to **0.5.5** on every workspace package that declares a top-level `version`:

- Root `package.json` (private workspace)
- `dbt-artifacts-parser`
- `@dbt-tools/core`, `@dbt-tools/cli`, `@dbt-tools/web`

Workspace dependencies remain `workspace:*`; no lockfile change required for this bump.

## Release note (npm)

Per [AGENTS.md](https://github.com/yu-iskw/dbt-artifacts-parser-ts/blob/main/AGENTS.md), **`dbt-artifacts-parser@0.5.5` should be published (or otherwise available on npm) before** publishing `@dbt-tools/*@0.5.5` if publish workflows rewrite workspace peers to registry versions.

## Verification

- `pnpm test`
- `pnpm lint:report`
- `pnpm knip` (after `pnpm --filter @dbt-tools/core build`)
- `pnpm coverage:report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8169ece-b005-4e84-af6e-12558e9317c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8169ece-b005-4e84-af6e-12558e9317c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

